### PR TITLE
Add --sr-deviceconfig parameter for remote SR config

### DIFF
--- a/data.py-dist
+++ b/data.py-dist
@@ -23,3 +23,8 @@ VM_IMAGES = {
     'mini-linux-x86_64-bios': 'alpine-minimal-3.12.0.xva',
     'mini-linux-x86_64-uefi': 'alpine-uefi-minimal-3.12.0.xva'
 }
+
+DEFAULT_CEPHFS_DEVICE_CONFIG = {
+#    'server': '10.0.0.2',
+#    'serverpath': '/vms'
+}


### PR DESCRIPTION
Also add related fixtures sr_deviceconfig and cephfs_deviceconfig. For
the latter, the deviceconfig will be read first from CLI if provided,
else from data.py's defaults