### PR TITLE
Really remove the added packages at teardown

### DIFF
--- a/test_xfs_sr.py
+++ b/test_xfs_sr.py
@@ -8,10 +8,10 @@ import time
 
 @pytest.fixture(scope='module')
 def host_with_xfsprogs(host):
-    host.yum_install(['xfsprogs'])
+    host.yum_install(['xfsprogs'], save_state=True)
     yield host
     # teardown
-    host.yum_remove(['xfsprogs'])
+    host.yum_restore_saved_state()
 
 @pytest.mark.incremental
 class TestXFSSR:

--- a/test_xfs_sr_multihost.py
+++ b/test_xfs_sr_multihost.py
@@ -16,12 +16,12 @@ def xfs_sr(host, sr_disk):
     """ a XFS SR on first host """
     assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
         "xfsprogs must not be installed on the host at the beginning of the tests"
-    host.yum_install(['xfsprogs'])
+    host.yum_install(['xfsprogs'], save_state=True)
     sr = host.sr_create('xfs', "XFS-local-SR", {'device': '/dev/' + sr_disk})
     yield sr
     # teardown
     sr.destroy()
-    host.yum_remove(['xfsprogs'])
+    host.yum_restore_saved_state()
 
 @pytest.fixture(scope='module')
 def vm_on_xfs_sr(host, xfs_sr, vm_ref):

--- a/test_zfs_sr.py
+++ b/test_zfs_sr.py
@@ -8,14 +8,14 @@ import time
 
 @pytest.fixture(scope='module')
 def host_with_zfs(host, sr_disk):
-    host.yum_install(['zfs'])
+    host.yum_install(['zfs'], save_state=True)
     disk = sr_disk
     host.ssh(['modprobe', 'zfs'])
     host.ssh(['zpool', 'create', 'vol0', '/dev/' + disk])
     yield host
     # teardown
     host.ssh(['zpool', 'destroy', 'vol0'])
-    host.yum_remove(['zfs'])
+    host.yum_restore_saved_state()
 
 @pytest.mark.incremental
 class TestZFSSR:


### PR DESCRIPTION
When installing additional packages to a host for testing, we only
removed the explicitly installed packages at teardown, but not their
dependencies.

Instead, compare the lists of packages before and after the installation
of the additional packages, and remove anything that was added.