### PR TITLE
add ZFS test and ZFS tests on multihost

### DIFF
--- a/test_zfs_sr.py
+++ b/test_zfs_sr.py
@@ -98,11 +98,11 @@ class TestZFSSR:
     # Impact on other tests: none if succeeds
     def test_zfs_unmounted(self, host):
         sr = TestZFSSR.sr
-        pool_imported = True
+        zpool_imported = True
         try:
             # Simulate broken mountpoint
             host.ssh(['zpool', 'export', 'vol0'])
-            pool_imported = False
+            zpool_imported = False
             try:
                 sr.scan()
                 assert False, "SR scan should have failed"
@@ -114,11 +114,11 @@ class TestZFSSR:
             print("Assert PBD not attached")
             assert not sr.all_pbds_attached()
             host.ssh(['zpool', 'import', 'vol0'])
-            pool_imported = True
+            zpool_imported = True
             sr.plug_pbds(verify=True)
             sr.scan()
         finally:
-            if not pool_imported:
+            if not zpool_imported:
                 host.ssh(['zpool', 'import', 'vol0'])
 
     # *** End of tests with reboots

--- a/test_zfs_sr.py
+++ b/test_zfs_sr.py
@@ -86,7 +86,6 @@ class TestZFSSR:
             assert not sr.all_pbds_attached()
             host.yum_install(['zfs'])
             host.ssh(['modprobe', 'zfs'])
-            # TODO: Remove import once done by the driver
             host.ssh(['zpool', 'import', 'vol0'])
             zfs_installed = True
             sr.plug_pbds(verify=True)
@@ -114,7 +113,6 @@ class TestZFSSR:
             time.sleep(10)
             print("Assert PBD not attached")
             assert not sr.all_pbds_attached()
-            # TODO: Remove import once done by the driver
             host.ssh(['zpool', 'import', 'vol0'])
             pool_imported = True
             sr.plug_pbds(verify=True)

--- a/test_zfs_sr_multihost.py
+++ b/test_zfs_sr_multihost.py
@@ -16,7 +16,7 @@ def zfs_sr(host, sr_disk):
     """ a ZFS SR on first host """
     assert not host.file_exists('/usr/sbin/zpool'), \
         "zfs must not be installed on the host at the beginning of the tests"
-    host.yum_install(['zfs'])
+    host.yum_install(['zfs'], save_state=True)
     host.ssh(['modprobe', 'zfs'])
     host.ssh(['zpool', 'create', 'vol0', '/dev/' + sr_disk])
     sr = host.sr_create('zfs', "ZFS-local-SR", {'location': 'vol0'})
@@ -24,7 +24,7 @@ def zfs_sr(host, sr_disk):
     # teardown
     sr.destroy()
     host.ssh(['zpool', 'destroy', 'vol0'])
-    host.yum_remove(['zfs'])
+    host.yum_restore_saved_state()
 
 @pytest.fixture(scope='module')
 def vm_on_zfs_sr(host, zfs_sr, vm_ref):

--- a/test_zfs_sr_multihost.py
+++ b/test_zfs_sr_multihost.py
@@ -1,0 +1,49 @@
+import pytest
+from lib.common import cold_migration_then_come_back, live_storage_migration_then_come_back
+
+# Requirements:
+# From --hosts parameter:
+# - host(A1): first XCP-ng host >= 8.2 with an additional unused disk for the SR.
+# - hostA2: Second member of the pool. Can have any local SR.
+# - hostB1: Master of a second pool. Any local SR.
+# From --vm parameter
+# - A VM to import to the ZFS SR
+# And:
+# - access to XCP-ng RPM repository from hostA1
+
+@pytest.fixture(scope='module')
+def zfs_sr(host, sr_disk):
+    """ a ZFS SR on first host """
+    assert not host.file_exists('/usr/sbin/zpool'), \
+        "zfs must not be installed on the host at the beginning of the tests"
+    host.yum_install(['zfs'])
+    host.ssh(['modprobe', 'zfs'])
+    host.ssh(['zpool', 'create', 'vol0', '/dev/' + sr_disk])
+    sr = host.sr_create('zfs', "ZFS-local-SR", {'location': 'vol0'})
+    yield sr
+    # teardown
+    sr.destroy()
+    host.ssh(['zpool', 'destroy', 'vol0'])
+    host.yum_remove(['zfs'])
+
+@pytest.fixture(scope='module')
+def vm_on_zfs_sr(host, zfs_sr, vm_ref):
+    print(">> ", end='')
+    vm = host.import_vm_url(vm_ref, sr_uuid=zfs_sr.uuid)
+    yield vm
+    # teardown
+    print("<< Destroy VM")
+    vm.destroy(verify=True)
+
+class TestZFSSRMultiHost:
+    def test_cold_intrapool_migration(self, host, hostA2, vm_on_zfs_sr, zfs_sr, local_sr_on_hostA2):
+        cold_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostA2, local_sr_on_hostA2)
+
+    def test_live_intrapool_migration(self, host, hostA2, vm_on_zfs_sr, zfs_sr, local_sr_on_hostA2):
+        live_storage_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostA2, local_sr_on_hostA2)
+
+    def test_cold_crosspool_migration(self, host, hostB1, vm_on_zfs_sr, zfs_sr, local_sr_on_hostB1):
+        cold_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostB1, local_sr_on_hostB1)
+
+    def test_live_crosspool_migration(self, host, hostB1, vm_on_zfs_sr, zfs_sr, local_sr_on_hostB1):
+        live_storage_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostB1, local_sr_on_hostB1)


### PR DESCRIPTION
Add one ZFS test: SR activation and scan fails if the ZFS mountpoint is not mounted (start from a working setup then "break" the mount). The scan must not appear like it succeeded and the SR was empty.

Add ZFS migration test on several hosts.