### PR TITLE
Update tests for compatibility with Windows VMs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -207,7 +207,7 @@ def imported_vm(host, vm_ref):
 
 # TODO: make it a fixture factory?
 @pytest.fixture(scope="module")
-def running_linux_vm(imported_vm):
+def running_vm(imported_vm):
     vm = imported_vm
 
     # may be already running if we skipped the import to use an existing VM

--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -1,5 +1,5 @@
 import pytest
-from lib.common import wait_for
+from lib.common import wait_for, vm_image
 import time, subprocess
 
 # Requirements:
@@ -27,13 +27,13 @@ class TestCephFSSRCreateDestroy:
             sr.destroy()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host_with_ceph, cephfs_device_config, vm_ref):
+    def test_create_and_destroy_sr(self, host_with_ceph, cephfs_device_config):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         host = host_with_ceph
         sr = host.sr_create('cephfs', "CephFS-SR", cephfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm_url(vm_ref, sr_uuid=sr.uuid)
+        vm = host.import_vm_url(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
@@ -46,12 +46,11 @@ class TestCephFSSR:
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 
-    # FIXME: only suited to linux VMs
     def test_snapshot(self, vm_on_cephfs_sr):
         vm = vm_on_cephfs_sr
         vm.start()
         vm.wait_for_os_booted()
-        vm.test_snapshot_on_running_linux_vm()
+        vm.test_snapshot_on_running_vm()
         vm.shutdown(verify=True)
 
     # *** tests with reboots (longer tests).

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -1,5 +1,5 @@
 import pytest
-from lib.common import wait_for
+from lib.common import wait_for, vm_image
 
 # Requirements:
 # - one XCP-ng host with an additional unused disk for the SR
@@ -11,12 +11,12 @@ class TestEXTSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_and_destroy_sr(self, host, sr_disk, vm_ref):
+    def test_create_and_destroy_sr(self, host, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('ext', "EXT-local-SR", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm_url(vm_ref, sr_uuid=sr.uuid)
+        vm = host.import_vm_url(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
@@ -29,12 +29,11 @@ class TestEXTSR:
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 
-    # FIXME: only suited to linux VMs
     def test_snapshot(self, vm_on_ext_sr):
         vm = vm_on_ext_sr
         vm.start()
         vm.wait_for_os_booted()
-        vm.test_snapshot_on_running_linux_vm()
+        vm.test_snapshot_on_running_vm()
         vm.shutdown(verify=True)
 
     # *** tests with reboots (longer tests).

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -1,5 +1,5 @@
 from conftest import GROUP_NAME, create_linstor_sr, destroy_linstor_sr
-from lib.common import wait_for
+from lib.common import wait_for, vm_image
 from subprocess import CalledProcessError
 import pytest
 import time
@@ -33,13 +33,13 @@ class TestLinstorSRCreateDestroy:
         except CalledProcessError as e:
             print("SR creation failed, as expected: {}".format(e))
 
-    def test_create_and_destroy_sr(self, hosts_with_linstor, lvm_disks, vm_ref):
+    def test_create_and_destroy_sr(self, hosts_with_linstor, lvm_disks):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         master = hosts_with_linstor[0]
         sr = create_linstor_sr(hosts_with_linstor)
         # import a VM in order to detect vm import issues here rather than in the vm_on_linstor_sr fixture used in
         # the next tests, because errors in fixtures break teardown
-        vm = master.import_vm_url(vm_ref, sr.uuid)
+        vm = master.import_vm_url(vm_image('mini-linux-x86_64-bios'), sr.uuid)
         vm.destroy(verify=True)
         destroy_linstor_sr(hosts_with_linstor, sr)
 
@@ -55,7 +55,7 @@ class TestLinstorSR:
         vm = vm_on_linstor_sr
         vm.start()
         vm.wait_for_os_booted()
-        vm.test_snapshot_on_running_linux_vm()
+        vm.test_snapshot_on_running_vm()
         vm.shutdown(verify=True)
 
     # *** tests with reboots (longer tests).

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -1,5 +1,5 @@
 import pytest
-from lib.common import wait_for
+from lib.common import wait_for, vm_image
 import time, subprocess
 
 # Requirements:
@@ -26,13 +26,13 @@ class TestXFSSRCreateDestroy:
             sr.destroy()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host_with_xfsprogs, sr_disk, vm_ref):
+    def test_create_and_destroy_sr(self, host_with_xfsprogs, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         host = host_with_xfsprogs
         sr = host.sr_create('xfs', "XFS-local-SR", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
         # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm_url(vm_ref, sr_uuid=sr.uuid)
+        vm = host.import_vm_url(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
@@ -44,12 +44,11 @@ class TestXFSSR:
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 
-    # FIXME: only suited to linux VMs
     def test_snapshot(self, vm_on_xfs_sr):
         vm = vm_on_xfs_sr
         vm.start()
         vm.wait_for_os_booted()
-        vm.test_snapshot_on_running_linux_vm()
+        vm.test_snapshot_on_running_vm()
         vm.shutdown(verify=True)
 
     # *** tests with reboots (longer tests).

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -1,5 +1,5 @@
 import pytest
-from lib.common import wait_for
+from lib.common import wait_for, vm_image
 import time, subprocess
 
 # Requirements:
@@ -28,12 +28,12 @@ class TestZFSSRCreateDestroy:
             assert False, "SR creation should not have succeeded!"
 
     @pytest.mark.usefixtures("zpool_vol0")
-    def test_create_and_destroy_sr(self, host, vm_ref):
+    def test_create_and_destroy_sr(self, host):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('zfs', "ZFS-local-SR", {'location': 'vol0'}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm_url(vm_ref, sr_uuid=sr.uuid)
+        vm = host.import_vm_url(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
@@ -45,12 +45,11 @@ class TestZFSSR:
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 
-    # FIXME: only suited to linux VMs
     def test_snapshot(self, vm_on_zfs_sr):
         vm = vm_on_zfs_sr
         vm.start()
         vm.wait_for_os_booted()
-        vm.test_snapshot_on_running_linux_vm()
+        vm.test_snapshot_on_running_vm()
         vm.shutdown(verify=True)
 
     # *** tests with reboots (longer tests).


### PR DESCRIPTION
- Require SSH + bash + user named "root" on the windows VM
- Use an alternate method for starting background processes on the VM
- Rename fixtures and functions that used to be specific to linux
- Wait for the management agent to be up before attempting other
  operations
- Always use the mini linux VM for SR creation tests.