### PR TITLE
Add EFI tooling and UEFI Secure Boot tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Note: this is a work in progress.
 
 On XCP-ng's test lab, the CI SSH private key allows to connect to any host installed for CI via PXE, and to any linux VM imported from pre-made images (OVA) and started.
 
+For Guest UEFI Secure Boot tests, the requirements are:
+* Test Runner
+    * `sbsign` or `pesign`
+    * If using `pesign`, `certutil` and `pk12util` must also be installed.
+      These should be included as package dependencies for your distro.
+    * `openssl`
+* VM
+    * `chattr`
+* XCP-ng Host (installed by default on XCP-ng 8.2+)
+    * `uefistored`
+    * `varstored-tools`
+
 ## Configuration
 The main configuration file is data.py. Copy data.py-dist to data.py and modify it if needed.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Note: this is a work in progress.
 * pytest >= 5.4 (python3 version)
 * xo-cli installed, in the PATH, and registered to an instance of XO that will be used during the tests
 
+### Quick install (python requirements)
+
+Install the python requirements using pip:
+
+```
+$ pip install -r requirements/base.txt
+
+```
+
+Additionally, for dev dependencies (things like the linter / style checker):
+
+```
+$ pip install -r requirements/dev.txt
+
+```
+
 ## Other requirements
 * XCP-ng hosts that you can ssh to using a SSH key, non-interactively
 * VM images suited to what the tests want. Some tests want a linux VM with SSH, available to import as an OVA over HTTP, for example.

--- a/lib/common.py
+++ b/lib/common.py
@@ -460,6 +460,16 @@ class BaseVM:
                 raise
         return value
 
+    def param_set(self, param_name, key, value):
+        args = {'uuid': self.uuid}
+
+        if key is not None:
+            param_name = '{}:{}'.format(param_name, key)
+
+        args[param_name] = value
+
+        return self.host.xe('vm-param-set', args)
+
     def vdi_uuids(self):
         output = self._disk_list()
         vdis = []

--- a/lib/common.py
+++ b/lib/common.py
@@ -783,6 +783,23 @@ class VM(BaseVM):
         finally:
             snapshot.destroy(verify=True)
 
+    def get_messages(self, name):
+        args = {
+            'obj-uuid': self.uuid,
+            'name': name,
+            'params': 'uuid',
+        }
+
+        lines = self.host.xe('message-list', args).strip().split('\n')
+
+        # Extracts uuids from lines of: "uuid ( RO) : <uuid>"
+        return [e.split(':')[1].strip() for e in lines if e]
+
+    def rm_messages(self, name):
+        msgs = self.get_messages(name)
+
+        for msg in msgs:
+            self.host.xe('message-destroy', {'uuid': msg})
 
 class Snapshot(BaseVM):
     def _disk_list(self):

--- a/lib/efi.py
+++ b/lib/efi.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import atexit
+import copy
+import logging
+import os
+import shlex
+import shutil
+import struct
+import subprocess
+import uuid
+from datetime import datetime, timedelta
+from subprocess import check_call
+from tempfile import TemporaryDirectory
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.serialization import Encoding, pkcs7
+
+EFI_HEADER_MAGIC = 'MZ'
+
+EFI_GLOBAL_VARIABLE_GUID_STR = '8be4df61-93ca-11d2-aa0d-00e098032b8c'
+EFI_IMAGE_SECURITY_DATABASE_GUID_STR = 'd719b2cb-3d3a-4596-a3bc-dad00e67656f'
+
+# Variable attributes for time based authentication attrs
+EFI_AT_ATTRS = 0x27
+
+time_seed = datetime.now()
+time_offset = 1
+
+p7_out = ''
+
+WIN_CERT_TYPE_EFI_GUID = 0x0EF1
+
+u8 = 'B'
+u16 = 'H'
+u32 = 'I'
+EFI_GUID = '16s'
+
+
+def efi_pack(*args):
+    """
+    Return bytes of an EFI struct (little endian).
+
+    EFI structs are all packed as little endian.
+    """
+    return struct.pack('<' + args[0], *args[1:])
+
+
+def pack_guid(data1, data2, data3, data4):
+    return b''.join(
+        [
+            struct.pack(u32, data1),
+            struct.pack(u16, data2),
+            struct.pack(u16, data3),
+            bytes(data4),
+        ]
+    )
+
+
+EFI_AT_ATTRS_BYTES = efi_pack(u32, EFI_AT_ATTRS)
+
+EFI_CERT_PKCS7_GUID = pack_guid(
+    0x4AAFD29D,
+    0x68DF,
+    0x49EE,
+    [0x8A, 0xA9, 0x34, 0x7D, 0x37, 0x56, 0x65, 0xA7],
+)
+
+EFI_GLOBAL_VARIABLE_GUID = pack_guid(
+    0x8BE4DF61, 0x93CA, 0x11D2, [0xAA, 0x0D, 0x00, 0xE0, 0x98, 0x03, 0x2B, 0x8C]
+)
+
+EFI_IMAGE_SECURITY_DATABASE_GUID = pack_guid(
+    0xD719B2CB, 0x3D3A, 0x4596, [0xA3, 0xBC, 0xDA, 0xD0, 0xE, 0x67, 0x65, 0x6F]
+)
+
+VATES_GUID = pack_guid(
+    0xFDD69FA4, 0x3E66, 0x11EB, [0x8C, 0x1B, 0x98, 0x3B, 0x8F, 0xB6, 0xDA, 0xCD]
+)
+
+EFI_CERT_X509_GUID = pack_guid(
+    0xA5C059A1, 0x94E4, 0x4AA7, [0x87, 0xB5, 0xAB, 0x15, 0x5C, 0x2B, 0xF0, 0x72]
+)
+
+WIN_CERTIFICATE = ''.join([u32, u16, u16])
+WIN_CERTIFICATE_UEFI_GUID = ''.join([WIN_CERTIFICATE, EFI_GUID])
+WIN_CERTIFICATE_UEFI_GUID_offset = struct.calcsize(WIN_CERTIFICATE_UEFI_GUID)
+
+EFI_TIME = ''.join(
+    [
+        u16,  # Year
+        u8,  # Month
+        u8,  # Day
+        u8,  # Hour
+        u8,  # Minute
+        u8,  # Second
+        u8,  # Pad1
+        u32,  # Nanosecond
+        u16,  # TimeZone
+        u8,  # Daylight
+        u8,  # Pad2
+    ]
+)
+
+EFI_VARIABLE_AUTHENTICATION_2 = ''.join([EFI_TIME, WIN_CERTIFICATE_UEFI_GUID])
+EFI_SIGNATURE_DATA = EFI_GUID
+EFI_SIGNATURE_DATA_size = struct.calcsize(EFI_SIGNATURE_DATA)
+EFI_SIGNATURE_LIST = ''.join([EFI_GUID, u32, u32, u32])
+EFI_SIGNATURE_LIST_size = struct.calcsize(EFI_SIGNATURE_LIST)
+EFI_SIGNATURE_DATA_offset = 16
+
+EFI_GUIDS = {
+    'PK': EFI_GLOBAL_VARIABLE_GUID,
+    'KEK': EFI_GLOBAL_VARIABLE_GUID,
+    'db': EFI_IMAGE_SECURITY_DATABASE_GUID,
+    'dbx': EFI_IMAGE_SECURITY_DATABASE_GUID,
+}
+
+EFI_GUID_STRS = {
+    'PK': EFI_GLOBAL_VARIABLE_GUID_STR,
+    'KEK': EFI_GLOBAL_VARIABLE_GUID_STR,
+    'db': EFI_IMAGE_SECURITY_DATABASE_GUID_STR,
+    'dbx': EFI_IMAGE_SECURITY_DATABASE_GUID_STR,
+}
+
+
+def cert_to_efi_sig_list(cert):
+    """Return an ESL from a PEM cert."""
+    with open(cert, 'rb') as f:
+        pem = f.read()
+        cert = x509.load_pem_x509_certificate(pem)
+        der = cert.public_bytes(Encoding.DER)
+
+    signature_type = EFI_CERT_X509_GUID
+    signature_list_size = len(der) + EFI_SIGNATURE_LIST_size + EFI_SIGNATURE_DATA_size
+    signature_header_size = 0
+    signature_size = signature_list_size - EFI_SIGNATURE_LIST_size
+    signature_owner = VATES_GUID
+
+    return (
+        efi_pack(
+            EFI_SIGNATURE_LIST,
+            bytes(signature_type),
+            signature_list_size,
+            signature_header_size,
+            signature_size,
+        ) + efi_pack(EFI_SIGNATURE_DATA, bytes(signature_owner)) + der
+    )
+
+
+def certs_to_sig_db(certs):
+    """Returns a signature database from a list cert file paths."""
+    if isinstance(certs, str):
+        certs = [certs]
+
+    db = b''
+
+    for i, cert in enumerate(certs):
+        tmp = cert_to_efi_sig_list(cert)
+        logging.debug('Size of Cert %d: %d' % (i, len(tmp)))
+        db += tmp
+
+    return db
+
+
+def sign_efi_sig_db(sig_db, var, key, cert, time=None, guid=None):
+    """Return a pkcs7 SignedData from a UEFI signature database."""
+    global p7_out
+
+    if guid is None:
+        if var == 'PK' or var == 'KEK':
+            guid = EFI_GLOBAL_VARIABLE_GUID
+        elif var == 'db' or var == 'dbx' or var == 'dbt':
+            guid = EFI_IMAGE_SECURITY_DATABASE_GUID
+        else:
+            raise RuntimeError('GUID could not be determined')
+
+    if time is None:
+        time = datetime.now()
+
+    timestamp = efi_pack(
+        EFI_TIME,
+        time.year,
+        time.month,
+        time.day,
+        time.hour,
+        time.minute,
+        time.second,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+
+    logging.info(
+        'Timestamp is %d-%d-%d %02d:%02d:%02d'
+        % (time.year, time.month, time.day, time.hour, time.minute, time.second)
+    )
+
+    var_utf16 = var.encode('utf-16-le')
+    attributes = EFI_AT_ATTRS_BYTES
+
+    # From UEFI spec (2.6):
+    #    digest = hash (VariableName, VendorGuid, Attributes, TimeStamp,
+    #                   DataNew_variable_content)
+    payload = var_utf16 + bytes(guid) + attributes + timestamp + sig_db
+
+    logging.debug('Signature DB Size: %d' % len(sig_db))
+    logging.info('Authentication Payload size %d' % len(payload))
+
+    p7 = sign(payload, key, cert)
+
+    if p7_out:
+        with open(p7_out, 'wb') as f:
+            f.write(p7)
+
+    return create_auth2_header(p7, timestamp) + p7 + sig_db
+
+
+def sign(payload, key_file, cert_file):
+    """Returns a signed PKCS7 of payload signed by key and cert."""
+    with open(key_file, 'rb') as f:
+        priv_key = serialization.load_pem_private_key(f.read(), password=None)
+
+    with open(cert_file, 'rb') as f:
+        cert = x509.load_pem_x509_certificate(f.read())
+
+    options = [
+        pkcs7.PKCS7Options.DetachedSignature,
+        pkcs7.PKCS7Options.Binary,
+        pkcs7.PKCS7Options.NoAttributes,
+    ]
+
+    return (
+        pkcs7.PKCS7SignatureBuilder()
+        .set_data(payload)
+        .add_signer(cert, priv_key, hashes.SHA256())
+        .sign(serialization.Encoding.DER, options)
+    )
+
+
+def create_auth2_header(sig_db, timestamp):
+    """Return an EFI_AUTHENTICATE_VARIABLE_2 from a signature database."""
+    length = len(sig_db) + WIN_CERTIFICATE_UEFI_GUID_offset
+    revision = 0x200
+    win_cert = efi_pack(WIN_CERTIFICATE, length, revision, WIN_CERT_TYPE_EFI_GUID)
+    auth_info = win_cert + EFI_CERT_PKCS7_GUID
+
+    return timestamp + auth_info
+
+
+def timestamp():
+    global time_offset
+    time_offset += 1
+    return time_seed + timedelta(seconds=time_offset)
+
+
+def get_signed_name(image: str):
+    fpath, ext = os.path.splitext(image)
+    return fpath + '-signed' + ext
+
+
+def pesign(key, cert, name, image):
+    """Sign a binary using pesign."""
+    with TemporaryDirectory(prefix='certdir_') as certdir:
+        # Setup pesign cert dir. commands taken from:
+        #     https://en.opensuse.org/openSUSE:UEFI_Image_File_Sign_Tools
+        common_name = name + ' Owner'
+        check_call(['certutil', '-N', '-d', certdir, '--empty-password'])
+        check_call([
+            'certutil', '-A', '-n', common_name, '-d', certdir, '-t',
+            'CT,CT,CT', '-i', cert
+        ])
+
+        pk12 = os.path.join(certdir, '%s.p12' % name)
+
+        # Create a pk12 out of the cert and key
+        password = 'root'
+        check_call([
+            'openssl', 'pkcs12', '-export', '-out', pk12,
+            '-in', cert, '-inkey', key,
+            '-passin', 'pass:' + password, '-passout', 'pass:' + password,
+        ])
+
+        # Enroll the pk12 to the cert database for pesign to use
+        check_call(['pk12util', '-d', certdir, '-i', pk12, '-W', password])
+        signed = get_signed_name(image)
+
+        # Sign the image
+        check_call([
+            'pesign', '-n', certdir, '-c', common_name, '-s', '-i', image,
+            '-o', signed
+        ])
+
+        return signed
+
+
+class EFIAuth:
+    def __init__(self, name, is_null=False):
+        self.name = name
+        self.is_null = is_null
+        self.guid = EFI_GUIDS[self.name]
+        self.key = ''
+        self.cert = Certificate()
+        self.tempdir = TemporaryDirectory(prefix=name + '_')
+        atexit.register(self.tempdir.cleanup)
+        self.efi_signature_list = self._get_efi_signature_list()
+        self.auth_data = None
+        self.auth = os.path.join(self.tempdir.name, '%s.auth' % self.name)
+
+    def is_signed(self):
+        return os.path.exists(self.auth)
+
+    def sign_auth(self, other: 'EFIAuth'):
+        """
+        Sign another EFIAuth object.
+
+        The other EFIAuth's member `auth` will be set to
+        the path of the .auth file.
+        """
+        other.auth_data = self.cert.sign_data(
+            other.name, other.efi_signature_list, other.guid
+        )
+
+        with open(other.auth, 'wb') as f:
+            f.write(other.auth_data)
+
+    def sign_image(self, image: str) -> str:
+        """
+        Sign an EFI image.
+
+        The arg `image` is the path to an EFI image (such as grubx64.efi).
+
+        The EFI image can be any PE/COFF binary.  The UEFI spec calls them images,
+        but 'binary' probably better fits community terminology.
+
+        Returns path to signed image.
+        """
+        if shutil.which('sbsign'):
+            signed = get_signed_name(image)
+            check_call([
+                'sbsign', '--key', self.cert.key, '--cert', self.cert.pub,
+                image, '--output', signed
+            ])
+        else:
+            signed = pesign(self.cert.key, self.cert.pub, self.name, image)
+
+        return signed
+
+    @classmethod
+    def copy(cls, other, name=None):
+        """
+        Make a copy of an existing EFIAuth object.
+
+        Specify a name to copy the certs, but to change the filenames
+        to retain a new name.
+
+        Note: the backing .auth files will not be regenerated with the new
+        name, so attempting to set a copied variable at runtime, not in custom
+        mode, will fail due a mismatch in the hash (containing the old name)
+        and the new data (containing the new name).  This doesn't affect
+        tests right now because the certs are set from the dom0, which bypasses
+        guest runtime checks.
+
+        TODO: copy other's cert and ask the signer to call sign_auth() on
+              the new obj.  This will recalculate the digest and the new
+              signature will be correct, and will pass guest runtime checks.
+
+        This is ONLY useful for creating a new handle.
+        """
+        if name is None:
+            name = other.name
+
+        obj = cls(name=name, is_null=other.is_null)
+        obj.cert = other.cert.copy()
+        obj.efi_signature_list = other.efi_signature_list
+
+        if other.is_signed():
+            obj.auth_data = copy.copy(other.auth_data)
+            shutil.copyfile(other.auth, obj.auth)
+
+        return obj
+
+    def _get_efi_signature_list(self) -> str:
+        if self.is_null:
+            return b''
+
+        return certs_to_sig_db(self.cert.pub)
+
+
+class Certificate:
+    def __init__(self, common_name='XCP-ng Test Common Name', init_keys=True):
+        self.common_name = common_name
+        self.name = common_name.replace(' ', '_').lower()
+        self.tempdir = TemporaryDirectory(prefix='cert_' + self.name)
+        atexit.register(self.tempdir.cleanup)
+        self.key = os.path.join(self.tempdir.name, '%s.key' % self.name)
+        self.pub = os.path.join(self.tempdir.name, 'tmp.crt')
+
+        if init_keys:
+            check_call([
+                'openssl', 'req', '-new', '-x509', '-newkey', 'rsa:2048',
+                '-subj', '/CN=%s/' % self.common_name, '-nodes', '-keyout',
+                self.key, '-sha256', '-days', '3650', '-out', self.pub
+            ])
+
+    def sign_data(self, var, data, guid):
+        return sign_efi_sig_db(
+            data, var, self.key, self.pub, time=timestamp(), guid=guid
+        )
+
+    def _get_cert_path(self):
+        return os.path.join(
+            self.tempdir.name, '_'.join(self.common_name.split()) + '.crt'
+        )
+
+    def copy(self):
+        obj = Certificate(common_name=self.common_name, init_keys=False)
+        shutil.copyfile(self.key, obj.key)
+        shutil.copyfile(self.pub, obj.pub)
+        return obj
+
+
+if __name__ == '__main__':
+    import argparse
+    import sys
+
+    epilog = '''
+Examples:
+
+    # Create a PK.auth (self-signed)
+    {prog} -k PK.key -c PK.cert PK PK.auth PK.cert
+
+    # Create a KEK.auth
+    {prog} -k PK.key -c PK.cert KEK KEK.auth KEK.cert
+
+    # Create a db.auth
+    {prog} -k KEK.key -c KEK.cert db db.auth db.cert
+'''.format(
+        prog=sys.argv[0]
+    )
+
+    parser = argparse.ArgumentParser(
+        description='Create signed UEFI secure boot variables',
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('-k', '--key', type=str, help='The signers key')
+    parser.add_argument('-c', '--cert', type=str, help='The signers cert (PEM)')
+    parser.add_argument('--log', type=str, choices=['DEBUG', 'INFO'])
+    parser.add_argument(
+        '--p7',
+        type=str,
+        help='Output the intermediary p7 data object (useful for debug)',
+    )
+    parser.add_argument(
+        'var',
+        type=str,
+        choices=['PK', 'KEK', 'db', 'dbx'],
+        help='The variable name for the cert',
+    )
+    parser.add_argument('outputfile', type=str, help='The name of the output file')
+    parser.add_argument('certs', nargs='+', help='The new certs for the variable')
+    args = parser.parse_args()
+
+    if args.log:
+        logging.basicConfig(
+            format='%(levelname)s:%(message)s', level=getattr(logging, args.log.upper())
+        )
+
+    if args.p7:
+        p7_out = args.p7
+
+    db = certs_to_sig_db(args.certs)
+    auth = sign_efi_sig_db(db, args.var, args.key, args.cert)
+
+    with open(args.outputfile, 'wb') as f:
+        f.write(auth)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,14 @@
+attrs>=20.3.0
+cffi>=1.14.4
+cryptography>=3.3.1
+importlib-metadata>=2.1.1
+more-itertools>=8.6.0
+packaging>=20.7
+pathlib2>=2.3.5
+pluggy>=0.13.1
+py>=1.9.0
+pyparsing>=2.4.7
+pytest>=5.4.0
+six>=1.15.0
+wcwidth>=0.2.5
+zipp>=1.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,3 @@
+# All requirements + those only used in development
+pycodestyle>=2.6.0
+-r base.txt

--- a/tests/uefistored/conftest.py
+++ b/tests/uefistored/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+@pytest.fixture(scope='module')
+def imported_sb_vm(imported_vm):
+    vm = imported_vm
+
+    if not vm.is_uefi:
+        pytest.skip('imported_sb_vm can only be used on UEFI VMs')
+
+    tmp_pk = vm.host.ssh(['mktemp'])
+    tmp_kek = vm.host.ssh(['mktemp'])
+    tmp_db = vm.host.ssh(['mktemp'])
+    tmp_dbx = vm.host.ssh(['mktemp'])
+
+    vm.host.ssh(['mv', '/usr/share/uefistored/PK.auth', tmp_pk], check=False)
+    vm.host.ssh(['mv', '/var/lib/uefistored/db.auth', tmp_db], check=False)
+    vm.host.ssh(['mv', '/var/lib/uefistored/KEK.auth', tmp_kek], check=False)
+    vm.host.ssh(['mv', '/var/lib/uefistored/dbx.auth', tmp_dbx], check=False)
+
+    # Any VM that has been booted at least once comes with some
+    # UEFI variable state, so simply clear the state of
+    # secure boot specific variables before each test.
+    vm.host.ssh(['varstore-sb-state', vm.uuid, 'setup'])
+
+    yield vm
+
+    # Restore PK, KEK, db on host
+    vm.host.ssh(['mv', tmp_pk, '/usr/share/uefistored/PK.auth'], check=False)
+    vm.host.ssh(['mv', tmp_kek, '/var/lib/uefistored/KEK.auth'], check=False)
+    vm.host.ssh(['mv', tmp_db, '/var/lib/uefistored/db.auth'], check=False)
+    vm.host.ssh(['mv', tmp_dbx, '/var/lib/uefistored/dbx.auth'], check=False)

--- a/tests/uefistored/test_auth_var.py
+++ b/tests/uefistored/test_auth_var.py
@@ -1,0 +1,57 @@
+import pytest
+
+from subprocess import CalledProcessError
+from lib.efi import (
+    Certificate,
+    EFI_GLOBAL_VARIABLE_GUID,
+    EFI_GLOBAL_VARIABLE_GUID_STR,
+    EFI_AT_ATTRS_BYTES,
+)
+
+
+def set_and_assert_var(vm, cert, new, should_pass):
+    var = 'myvariable'
+
+    _, old = vm.get_efi_var(var, EFI_GLOBAL_VARIABLE_GUID_STR)
+
+    signed = cert.sign_data(var, new, EFI_GLOBAL_VARIABLE_GUID)
+
+    ok = True
+    try:
+        vm.set_efi_var(var, EFI_GLOBAL_VARIABLE_GUID_STR, EFI_AT_ATTRS_BYTES, signed)
+    except CalledProcessError:
+        ok = False
+
+    _, ret = vm.get_efi_var(var, EFI_GLOBAL_VARIABLE_GUID_STR)
+
+    if should_pass:
+        assert ret == new
+    else:
+        assert ret == old
+        assert not ok, 'This var should not have successfully set'
+
+
+def test_auth_variable(imported_vm):
+    vm = imported_vm
+    if vm.is_windows:
+        pytest.skip('not valid test for Windows VMs')
+
+    vm.start()
+    vm.wait_for_vm_running_and_ssh_up()
+
+    cert = Certificate()
+
+    # Set the variable
+    set_and_assert_var(vm, cert, b'I am old news', should_pass=True)
+
+    # Set the variable with new data, signed by the same cert
+    set_and_assert_var(vm, cert, b'I am new news', should_pass=True)
+
+    # Remove var
+    set_and_assert_var(vm, cert, b'', should_pass=True)
+
+    # Set the variable with new data, signed by the same cert
+    set_and_assert_var(vm, cert, b'new data', should_pass=True)
+
+    # Set the variable with new data, signed by the same cert
+    set_and_assert_var(vm, Certificate(), b'this should fail', should_pass=False)

--- a/tests/uefistored/test_secure_boot.py
+++ b/tests/uefistored/test_secure_boot.py
@@ -1,0 +1,296 @@
+import os
+import pytest
+import subprocess
+from lib.common import wait_for
+from lib.efi import EFIAuth, EFI_AT_ATTRS, EFI_AT_ATTRS_BYTES, EFI_GUID_STRS
+
+VM_SECURE_BOOT_FAILED = 'VM_SECURE_BOOT_FAILED'
+
+
+def check_sb_failed(vm):
+    vm.start()
+    wait_for(
+        lambda: vm.get_messages(VM_SECURE_BOOT_FAILED),
+        'Wait for message %s' % VM_SECURE_BOOT_FAILED,
+    )
+
+    # If there is a VM_SECURE_BOOT_FAILED message and yet the OS still
+    # successfully booted, this is a uefistored bug
+    assert not vm.is_ssh_up(), 'The OS booted when it should have failed'
+
+
+def check_sb_succeeded(vm):
+    vm.start()
+    vm.wait_for_vm_running_and_ssh_up()
+    assert not vm.get_messages(VM_SECURE_BOOT_FAILED)
+
+
+def sign_efi_bins(vm, db):
+    '''Boots the VM if it is halted, signs the bootloader, and halts the
+    VM again (if halted was its original state).
+    '''
+    shutdown = not vm.is_running()
+    if shutdown:
+        vm.start()
+        vm.wait_for_vm_running_and_ssh_up()
+
+    print('> Sign bootloader')
+    vm.sign_efi_bins(db)
+
+    if shutdown:
+        vm.shutdown(verify=True)
+
+
+def install_auths(vm, auths, use_xapi=False):
+    for auth in auths:
+        print('> Setting {}'.format(auth.name))
+
+        if auth.name == 'PK':
+            dest = '/usr/share/uefistored/%s.auth' % auth.name
+        else:
+            dest = '/var/lib/uefistored/%s.auth' % auth.name
+
+        vm.host.scp(auth.auth, dest)
+
+        if use_xapi:
+            vm.host.ssh([
+                'varstore-set', vm.uuid, EFI_GUID_STRS[auth.name], auth.name,
+                str(EFI_AT_ATTRS), dest,
+            ])
+
+
+def generate_keys(self_signed=False):
+    PK = EFIAuth('PK')
+    KEK = EFIAuth('KEK')
+    db = EFIAuth('db')
+
+    if self_signed:
+        PK.sign_auth(PK)
+        KEK.sign_auth(KEK)
+        db.sign_auth(db)
+    else:
+        PK.sign_auth(PK)
+        PK.sign_auth(KEK)
+        KEK.sign_auth(db)
+
+    # For our tests the dbx blacklists anything signed by the db
+    dbx = EFIAuth.copy(db, name='dbx')
+
+    return PK, KEK, db, dbx
+
+
+class TestGuestLinuxUEFISecureBoot:
+    @pytest.fixture(autouse=True)
+    def setup_and_cleanup(self, imported_sb_vm):
+        vm = imported_sb_vm
+        if vm.is_windows:
+            pytest.skip('only valid for Linux VMs')
+
+        self.PK, self.KEK, self.db, self.dbx = generate_keys()
+        vm.param_set('platform', 'secureboot', 'false')
+        snapshot = vm.snapshot()
+        yield
+
+        try:
+            snapshot.revert()
+        except subprocess.CalledProcessError:
+            raise
+        finally:
+            # Messages may be populated from previous tests and may
+            # interfere with future tests, so remove them
+            print('> remove guest SB messages')
+            vm.rm_messages(VM_SECURE_BOOT_FAILED)
+
+    def test_boot_succeeds_when_PK_set_and_sb_disabled(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK])
+        vm.param_set('platform', 'secureboot', 'false')
+        check_sb_succeeded(vm)
+
+    def test_boot_succeeds_when_PK_set_and_sb_disabled_xapi(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK], use_xapi=True)
+        vm.param_set('platform', 'secureboot', 'false')
+        check_sb_succeeded(vm)
+
+    def test_boot_fails_when_db_set_and_images_unsigned(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db])
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_failed(vm)
+
+    def test_boot_fails_when_db_set_and_images_unsigned_xapi(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db], use_xapi=True)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_failed(vm)
+
+    def test_boot_success_when_launching_db_signed_images(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db])
+        sign_efi_bins(vm, self.db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_succeeded(vm)
+
+    def test_boot_success_when_launching_db_signed_images_xapi(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db], use_xapi=True)
+        sign_efi_bins(vm, self.db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_succeeded(vm)
+
+    def test_boot_fails_when_launching_dbx_signed_images(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db, self.dbx])
+        sign_efi_bins(vm, self.db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_failed(vm)
+
+    def test_boot_fails_when_launching_dbx_signed_images_xapi(self, imported_sb_vm):
+        vm = imported_sb_vm
+        install_auths(vm, [self.PK, self.KEK, self.db, self.dbx], use_xapi=True)
+        sign_efi_bins(vm, self.db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_failed(vm)
+
+    def test_boot_success_when_initial_keys_not_signed_by_parent(self, imported_sb_vm):
+        vm = imported_sb_vm
+        PK, KEK, db, _ = generate_keys(self_signed=True)
+        install_auths(vm, [PK, KEK, db])
+        sign_efi_bins(vm, db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_succeeded(vm)
+
+    def test_boot_success_when_initial_keys_not_signed_by_parent_xapi(self, imported_sb_vm):
+        vm = imported_sb_vm
+        PK, KEK, db, _ = generate_keys(self_signed=True)
+        install_auths(vm, [PK, KEK, db], use_xapi=True)
+        sign_efi_bins(vm, db)
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_succeeded(vm)
+
+
+class TestGuestWindowsUEFISecureBoot:
+    @pytest.fixture(autouse=True)
+    def setup_and_cleanup(self, imported_sb_vm):
+        vm = imported_sb_vm
+        if not vm.is_windows:
+            pytest.skip('only valid for Windows VMs')
+
+        self.PK, self.KEK, self.db, self.dbx = generate_keys()
+        vm.param_set('platform', 'secureboot', 'false')
+        snapshot = vm.snapshot()
+        yield
+
+        try:
+            snapshot.revert()
+        except subprocess.CalledProcessError:
+            raise
+        finally:
+            # Messages may be populated from previous tests and may
+            # interfere with future tests, so remove them
+            print('> remove guest SB messages')
+            vm.rm_messages(VM_SECURE_BOOT_FAILED)
+
+    def test_windows_fails(self, imported_sb_vm):
+        vm = imported_sb_vm
+        PK, KEK, db, _ = generate_keys(self_signed=True)
+        install_auths(vm, [PK, KEK, db])
+        vm.param_set('platform', 'secureboot', 'true')
+        check_sb_failed(vm)
+
+    def test_windows_succeeds(self, imported_sb_vm):
+        vm = imported_sb_vm
+        PK, _, _, _ = generate_keys(self_signed=True)
+        install_auths(vm, [PK])
+        vm.param_set('platform', 'secureboot', 'true')
+        vm.host.ssh(['secureboot-certs'])
+        check_sb_succeeded(vm)
+
+        # Cleanup secureboot-certs certs
+        vm.host.ssh(['rm', '/var/lib/uefistored/db.auth'])
+        vm.host.ssh(['rm', '/var/lib/uefistored/KEK.auth'])
+
+
+class TestUEFIKeyExchange:
+    def test_key_exchanges(self, imported_sb_vm):
+        vm = imported_sb_vm
+        if vm.is_windows:
+            pytest.skip('only valid for Linux VMs')
+
+        PK = EFIAuth('PK')
+        null_PK = EFIAuth('PK', is_null=True)
+        new_PK = EFIAuth('PK')
+        bad_PK = EFIAuth('PK')
+
+        KEK = EFIAuth('KEK')
+        null_KEK = EFIAuth('KEK', is_null=True)
+
+        db_from_KEK = EFIAuth('db')
+        db_from_PK = EFIAuth('db')
+        null_db_from_KEK = EFIAuth('db', is_null=True)
+        null_db_from_PK = EFIAuth('db', is_null=True)
+
+        PK.sign_auth(PK)
+        PK.sign_auth(null_PK)
+        PK.sign_auth(KEK)
+        PK.sign_auth(null_KEK)
+        PK.sign_auth(new_PK)
+        PK.sign_auth(db_from_PK)
+        PK.sign_auth(null_db_from_PK)
+        PK.sign_auth(db_from_KEK)
+        PK.sign_auth(null_db_from_KEK)
+        KEK.sign_auth(db_from_KEK)
+        KEK.sign_auth(null_db_from_KEK)
+        bad_PK.sign_auth(bad_PK)
+
+        if vm.is_running():
+            vm.shutdown(force=True, verify=True)
+
+        # Clear all SB keys
+        vm.host.ssh(['varstore-sb-state', vm.uuid, 'setup'])
+
+        # Start with only PK, we will test adding the rest of the keys
+        vm.host.ssh(['rm', '/usr/share/uefistored/*'], check=False)
+        vm.host.scp(PK.auth, '/usr/share/uefistored/PK.auth')
+        vm.param_set('platform', 'secureboot', 'false')
+
+        if not vm.is_running():
+            vm.start()
+            vm.wait_for_vm_running_and_ssh_up()
+
+        tests = [
+            # Clear the PK
+            (null_PK, True),
+            # Set the PK
+            (PK, True),
+            # Set a PK with the wrong sig, should fail and PK should be unchanged
+            (bad_PK, False),
+            # Set, clear, and reset the KEK
+            (KEK, True),
+            (null_KEK, True),
+            (KEK, True),
+            # Set and clear the db signed by the KEK
+            (db_from_KEK, True),
+            (null_db_from_KEK, True),
+            # Set and clear the db signed by the PK
+            (db_from_PK, True),
+            (null_db_from_PK, True),
+            # Set a new PK
+            (new_PK, True),
+            # Set old PK, should fail due to expired timestamp
+            (PK, False),
+        ]
+
+        for i, (auth, should_succeed) in enumerate(tests):
+            print('> Testing {} ({})'.format(auth.name, i))
+
+            ok = True
+            try:
+                vm.set_efi_var(auth.name, EFI_GUID_STRS[auth.name],
+                               EFI_AT_ATTRS_BYTES, auth.auth_data)
+            except subprocess.CalledProcessError:
+                ok = False
+
+            if (should_succeed and not ok) or (ok and not should_succeed):
+                raise AssertionError('Failed to set {} {}'.format(i, auth.name))


### PR DESCRIPTION
Changes to core test framework:

- Add an option to make the destination of `scp()` local instead of only remote.
- Add `get_messages()` and `rm_messages()` to `BaseVM`
- Add `vm_key` attr to BaseVM so that tests can use the key to access configuration data if necessary (as was for UEFI tests)
- Remove inheritance to Snapshot from BaseVM

Adds UEFI Secure Boot tests.  The current release of `uefistored` (2.6) may fail these tests.  My dev branch, which will be merged early next week, passes them all.

Future: Use OpenSSL bindings instead of running an `openssl` subprocess.