### PR TITLE
After reconnecting XO to a host, wait for the host object

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -260,6 +260,9 @@ class Host:
         xo_cli('server.disable', {'id': self.xo_srv_id})
         xo_cli('server.enable', {'id': self.xo_srv_id})
         wait_for(self.xo_server_connected, timeout_secs=10)
+        # wait for XO to know about the host. Apparently a connected server status
+        # is not enough to guarantee that the host object exists yet.
+        wait_for(lambda: xo_object_exists(self.uuid), "Wait for XO to know about HOST %s" % self.uuid)
 
     def import_vm(self, uri, sr_uuid=None):
         params = {}


### PR DESCRIPTION
Cross pool migration tests tend to fail because we might attempt the
migration before XO has time to add the Host object in its database, so
we wait for the object to be available.