### PR TITLE
FreeBSD support in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ Many tests expect VMs with:
 
 Here are instructions that should help creating such VMs.
 
-### Linux
+### Linux and other unixes
 
 * Eject installation ISO
 * Setup network
 * Install openssh-server and enable it
+* Install bash in order to ensure a common shell is available in all test VMs
 * Install guest tools, then eject guest tools ISO
 * Add XCP-ng's CI public key in /root/.ssh/authorized_keys (mode 0600)
 * Test you can ssh to it

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -76,7 +76,9 @@ def _ssh(hostname_or_ip, cmd, check=True, simple_output=True, suppress_fingerpri
     command = " ".join(cmd)
     if background and target_os != "windows":
         # https://stackoverflow.com/questions/29142/getting-ssh-to-execute-a-command-in-the-background-on-target-machine
-        command = "nohup %s &>/dev/null &" % command
+        # ... and run the command through a bash shell so that output redirection both works on Linux and FreeBSD.
+        # Bash being available on VMs is a documented requirement.
+        command = "nohup bash -c \"%s &>/dev/null &\"" % command
 
     ssh_cmd = f"ssh root@{hostname_or_ip} {' '.join(options)} {shlex.quote(command)}"
 

--- a/tests/guest-tools/unix/test_guest_tools_unix.py
+++ b/tests/guest-tools/unix/test_guest_tools_unix.py
@@ -41,9 +41,8 @@ class TestGuestToolsUnix:
         if state.vm_distro == "alpine":
             pytest.skip('Alpine not supported by the guest tools installation script at the moment')
 
-        # Check that we are able to detect that xe-daemon is running
-        assert vm.ssh_with_result(['pgrep', '-x', 'xe-daemon']).returncode == 0, \
-            "xe-daemon must be running and detected by pgrep"
+        print("Check that we are able to detect that xe-daemon is running")
+        vm.ssh(['pgrep', '-f', 'xe-daemon'])
 
         # remove the installed tools
         logging.info("Detect package manager and uninstall the guest tools")
@@ -58,7 +57,7 @@ class TestGuestToolsUnix:
             pytest.skip("Package manager '%s' not supported in this test" % pkg_mgr)
 
         # check that xe-daemon is not running anymore
-        assert vm.ssh_with_result(['pgrep', '-x', 'xe-daemon']).returncode != 0, \
+        assert vm.ssh_with_result(['pgrep', '-f', 'xe-daemon']).returncode != 0, \
             "xe-daemon must not be running anymore"
 
         # mount ISO
@@ -84,7 +83,7 @@ class TestGuestToolsUnix:
         vm.unmount_guest_tools_iso()
 
         # check that xe-daemon is running
-        wait_for(lambda: vm.ssh_with_result(['pgrep', '-x', 'xe-daemon']).returncode == 0,
+        wait_for(lambda: vm.ssh_with_result(['pgrep', '-f', 'xe-daemon']).returncode == 0,
                  "Wait for xe-daemon running")
 
     def test_check_tools(self, running_vm, state):


### PR DESCRIPTION
This PR brings better support for FreeBSD VMs in our tests. The price to pay for this is I needed to add bash to the requirements for test VMs. Among our existing VMs, all VMs already have it, except Alpine VMs, but we can add it if this PR is accepted.

* Guest tools tests are skipped
* uefistored tests will probably not work. It's difficult to install FreeBSD in UEFI mode anyway, so I can't even test and think it's acceptable for now.