### PR TITLE
Fix tests for PV guests

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -520,7 +520,7 @@ class VM(BaseVM):
         self.ip = None
         self.previous_host = None # previous host when migrated or being migrated
         self.is_windows = self.param_get('platform', 'device_id', accept_unknown_key=True) == '0002'
-        self.is_uefi = self.param_get('HVM-boot-params', 'firmware') == 'uefi'
+        self.is_uefi = self.param_get('HVM-boot-params', 'firmware', accept_unknown_key=True) == 'uefi'
 
     def power_state(self):
         return self.param_get('power-state')


### PR DESCRIPTION
Commit 14d27adf6be01880a33ce65494e4d3cf11940e58 assumed that the
HVM-boot-params:firmware key always exists, but it's not true for PV
guests. Don't fail when it doesn't exist.