### PR TITLE
Add tests to check error when device is missing on LVM/EXT SRs

### DIFF
--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from lib.common import wait_for, vm_image
 
 # Requirements:
@@ -10,6 +11,17 @@ class TestEXTSRCreateDestroy:
     because they precisely need to test SR creation and destruction,
     and VM import.
     """
+
+    def test_create_sr_with_device_missing(self, host):
+        try:
+            sr = host.sr_create('ext', 'EXT-local-SR', {}, verify=True)
+        except subprocess.CalledProcessError as e:
+            assert e.stdout == (
+                b'Error code: SR_BACKEND_FAILURE_90\nError parameters: , '
+                b'The request is missing the device parameter, \n'
+            ), 'Bad error, current: {}'.format(e.stdout)
+            return
+        assert False, 'SR creation should not have succeeded!'
 
     def test_create_and_destroy_sr(self, host, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from lib.common import wait_for, vm_image
 
 # Requirements:
@@ -10,6 +11,17 @@ class TestLVMSRCreateDestroy:
     because they precisely need to test SR creation and destruction,
     and VM import.
     """
+
+    def test_create_sr_with_device_missing(self, host):
+        try:
+            sr = host.sr_create('ext', 'LVM-local-SR', {}, verify=True)
+        except subprocess.CalledProcessError as e:
+            assert e.stdout == (
+                b'Error code: SR_BACKEND_FAILURE_90\nError parameters: , '
+                b'The request is missing the device parameter, \n'
+            ), 'Bad error, current: {}'.format(e.stdout)
+            return
+        assert False, 'SR creation should not have succeeded!'
 
     def test_create_and_destroy_sr(self, host, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible


### PR DESCRIPTION
Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>