### PR TITLE
Remove unnecessary pytest.mark.default_vm

### DIFF
--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -14,8 +14,6 @@ from tests.storage.nfs.conftest import vm_on_nfs_sr, nfs_sr, nfs_device_config
 # From --second-network parameter
 # - second_network: A 2nd network of the pool, NOT the management interface, with PIF plugged on all hosts
 
-pytestmark = pytest.mark.default_vm('mini-linux-x86_64-bios')
-
 def _host_evacuate_test(source_host, dest_host, network_uuid, vm, expect_error=False, error=""):
     source_name = source_host.xe('host-param-get', {'uuid': source_host.uuid, 'param-name': 'name-label'})
     vm.start(on=source_name)

--- a/tests/misc/test_basic_without_ssh.py
+++ b/tests/misc/test_basic_without_ssh.py
@@ -25,8 +25,6 @@ def existing_shared_sr(host):
     assert sr is not None, "A shared SR on the pool is required"
     return sr
 
-pytestmark = pytest.mark.default_vm('mini-linux-x86_64-bios')
-
 @pytest.mark.incremental
 class TestBasicNoSSH:
     def test_start(self, imported_vm):

--- a/tests/misc/test_cross_pool_migration.py
+++ b/tests/misc/test_cross_pool_migration.py
@@ -3,8 +3,6 @@ import pytest
 
 from lib.common import wait_for, wait_for_not
 
-pytestmark = pytest.mark.default_vm('mini-linux-x86_64-bios')
-
 def test_cross_pool_migration(host, hostB1, imported_vm):
     assert host.pool.uuid != hostB1.pool.uuid
 

--- a/tests/misc/test_export.py
+++ b/tests/misc/test_export.py
@@ -2,8 +2,6 @@ import logging
 import pytest
 
 
-pytestmark = pytest.mark.default_vm('mini-linux-x86_64-bios')
-
 # What can be improved: control over where the exported files get written
 # and over the destination SR for VM import.
 

--- a/tests/misc/test_vm_basic_operations.py
+++ b/tests/misc/test_vm_basic_operations.py
@@ -3,8 +3,6 @@ import pytest
 
 from lib.common import wait_for_not
 
-pytestmark = pytest.mark.default_vm('mini-linux-x86_64-bios')
-
 def test_pause(running_vm):
     vm = running_vm
     vm.pause(verify=True)


### PR DESCRIPTION
It's not necessary to define a default VM for those tests, as the
global default VM for all tests is exactly the same.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>