### PR TITLE
Add secureboot-certs --version check

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -122,6 +122,10 @@ class Pool:
 
     def save_uefi_certs(self):
         logging.info('Saving pool UEFI certificates')
+
+        if int(self.master.ssh(["secureboot-certs", "--version"]).split(".")[0]) < 1:
+            raise RuntimeError("The host must have secureboot-certs version >= 1.0.0")
+
         saved_certs = {
             'PK': self.master.ssh(['mktemp']),
             'KEK': self.master.ssh(['mktemp']),


### PR DESCRIPTION
This commit adds a check to the secureboot-certs version to ensure that
it is the correct version.

If secureboot-certs is an older version, the tests will fail in
mysterious ways (the certs will seemingly disappear without explanation,
due to the temp certs being named /tmp/tmp.XYZ instead of PK.auth,
KEK.auth, etc...).

Although this probably is unlikely to happen in the future, this short
fix seemed worth the potential hours lost in case tests get ran on a
host with an old uefistored package installed.

Note: only works with this commit applied in uefistored:

https://github.com/xcp-ng/uefistored/pull/32/commits/6ebe1c1085812512d4490255642ce67430a9174b