### PR TITLE
Add tests/system/test_irqbalance.py to check VIF irq balancing

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -1092,6 +1092,25 @@ class VIF:
         self.uuid = uuid
         self.vm = vm
 
+    def param_get(self, param_name, key=None, accept_unknown_key=False):
+        args = {'uuid': self.uuid, 'param-name': param_name}
+        if key is not None:
+            args['param-key'] = key
+        try:
+            value = self.vm.host.xe('vif-param-get', args)
+        except commands.SSHCommandFailed as e:
+            if key and accept_unknown_key and e.stdout == "Error: Key %s not found in map" % key:
+                value = None
+            else:
+                raise
+        return value
+
+    def device_id(self):
+        """ Build the identifier that will allow to grep for the VIF's interrupts. """
+        dom_id = self.vm.param_get('dom-id')
+        device = self.param_get('device')
+        return f"vif{dom_id}.{device}"
+
     def move(self, network_uuid):
         self.vm.host.xe('vif-move', {'uuid': self.uuid, 'network-uuid': network_uuid})
 

--- a/tests/system/test_irqbalance.py
+++ b/tests/system/test_irqbalance.py
@@ -1,0 +1,60 @@
+import logging
+import os
+import pytest
+import tempfile
+
+# Requirements:
+# - an XCP-ng host (--hosts) >= 8.2
+# - a VM (--vm)
+# - enough space to import 4 VMs on default SR
+# - the pool must have 1 shared SR
+# - each host must have a local SR
+
+@pytest.fixture(scope='module')
+def four_vms(imported_vm):
+    vm1 = imported_vm
+    vm2 = vm1.clone()
+    vm3 = vm1.clone()
+    vm4 = vm1.clone()
+    yield (vm1, vm2, vm3, vm4)
+    # teardown
+    logging.info("< Destroy VM4")
+    vm4.destroy()
+    logging.info("< Destroy VM3")
+    vm3.destroy()
+    logging.info("< Destroy VM2")
+    vm2.destroy()
+
+
+class TestIrqBalance:
+    def test_start_four_vms(self, four_vms):
+        for vm in four_vms:
+            vm.start()
+
+        for vm in four_vms:
+            vm.wait_for_vm_running_and_ssh_up()
+
+        logging.info("Create some network traffic for each VM")
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(os.urandom(2000000))
+            for vm in four_vms:
+                vm.scp(f.name, f.name)
+                vm.ssh(['rm', '-f', f.name])
+
+        logging.info("Check that the IRQs of the VMs VIFs are not all on the same CPU on dom0")
+        cpus = set()
+        for vm in four_vms:
+            # List the CPU(s) that handled IRQs for the VM's vifs
+            for vif in vm.vifs():
+                device_id = vif.device_id()
+                output = vm.host.ssh([rf'grep /proc/interrupts -e "xen-dyn\\s\+-event\\s\+{device_id}-"'])
+                assert len(output) > 0
+                for line in output.splitlines():
+                    fields = line.split()
+                    irqs_per_cpu = fields[1:fields.index('xen-dyn')]
+                    for i, val in enumerate(irqs_per_cpu):
+                        if int(val) > 0:
+                            logging.info(f"VIF {device_id}: {val} IRQs for CPU {i}")
+                            cpus.add(i)
+
+        assert len(cpus) > 1, "there must be more than one CPU that handles the IRQs"


### PR DESCRIPTION
Following a regression in a kernel hotfix, check that IRQs associated to
VIFs are not all affected to the same CPU, to avoid any future similar
regression.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>