### PR TITLE
scripts/ansible: support VM updates with ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,68 @@ New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Pr
 * Check ssh to the VM works without asking for a password and opens bash as expected
 * Reboot, check it's still OK
 * Poweroff
+
+# Automating VM Setup with Ansible
+
+There is an Ansible runner that performs automatic updates on VMs using Ansible
+playbooks. The runner then exports the updated VMs as XVAs. The runner is found
+at `scripts/ansible/runner.py`.
+
+```bash
+usage: runner.py [-h] [--http HTTP] [--print-images] [--host HOST]
+                 [--export-directory EXPORT_DIRECTORY]
+                 playbook
+
+Run a playbook for updating test VMs
+
+positional arguments:
+  playbook              The Ansible playbook.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --http HTTP           The HTTP/PXE server containing the test VMs. Defaults
+                        to DEF_VM_URL in data.py, if not found then defaults
+                        to http://pxe/images/
+  --print-images        Show the available images on the PXE server and then
+                        exit.
+  --host HOST, -x HOST  The XCP-ng hostname or IP address. Defaults to host
+                        found in data.py
+  --export-directory EXPORT_DIRECTORY, -e EXPORT_DIRECTORY
+                        The directory on the XCP-ng host to export the updated
+                        image. Defaults to /root/ansible-updates/
+```
+
+## The Ansible Playbook
+
+The Ansible playbook must have a host name that matches the file name of an
+XVA located at the http server found using the `DEF_VM_URL` variable in
+data.py.
+
+Ansible host names do not support hyphens, so they are converted to underscores.
+
+For example, `alpine-uefi-minimal-3.12.0.xva` becomes `alpine_uefi_minimal_3.12.0.xva`.
+
+The runner then spins a VM using that XVA, applys the Ansible playbook, then
+exports the VM to a new XVA.
+
+As an example, given `DEF_VM_URL = "http://pxe/images/"` in `data.py` and
+the following playbook, the runner will look for an XVA file at
+`http://pxe/images/alpine-uefi-minimal-3.12.0.xva` and update it as described.
+
+Note that the "hosts" in Ansible refers to the VMs, not the XCP-ng host.
+The XCP-ng host used to run the VM is picked randomly from the HOSTS variable
+in data.py.
+
+```yaml
+---
+- hosts: alpine_uefi_minimal_3.12.0.xva
+  remote_user: root
+  gather_facts: no
+  tasks:
+    - name: Install Python for Ansible
+      raw: test -f /usr/bin/python3 || apk add --update --no-cache python3
+
+    - name: Install util-linux and efitools
+      community.general.apk:
+        name: util-linux efitools
+```

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,13 @@
 # All requirements + those only used in development
+ansible>=5.0.1
+ansible-core>=2.12.1
+beautifulsoup4>=4.10.0
+bs4>=0.0.1
+Jinja2>=3.0.3
+MarkupSafe>=2.0.1
 pycodestyle>=2.6.0
+pycparser>=2.21
+PyYAML>=6.0
+resolvelib>=0.5.4
+soupsieve>=2.3.1
 -r base.txt

--- a/scripts/ansible/playbooks/alpine_uefi_minimal_3_21_0.yaml
+++ b/scripts/ansible/playbooks/alpine_uefi_minimal_3_21_0.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: alpine_uefi_minimal_3.12.0.xva
+  remote_user: root
+  gather_facts: no
+  tasks:
+    - name: Install Python for Ansible
+      raw: test -f /usr/bin/python3 || apk add --update --no-cache python3
+
+    - name: Install util-linux and efitools
+      community.general.apk:
+        name: util-linux efitools

--- a/scripts/ansible/runner.py
+++ b/scripts/ansible/runner.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+
+import argparse
+import atexit
+import logging
+import os
+import sys
+import tempfile
+import __main__
+from signal import SIGABRT, SIGINT, SIGQUIT, SIGTERM, signal
+from subprocess import run
+from typing import List
+
+import requests
+import yaml
+from bs4 import BeautifulSoup
+
+try:
+    from yaml import CDumper as Dumper
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Dumper, Loader
+
+cur = os.path.split(__main__.__file__)[0]
+root = os.path.abspath(os.path.join(cur, "..", ".."))
+sys.path.append(root)
+
+import data  # noqa
+from lib.commands import ssh  # noqa
+from lib.common import VM, Host  # noqa
+
+user = getattr(data, "HOST_DEFAULT_USER", "root")
+
+
+def get_url_paths(url, ext="", params={}):
+    """Return all paths of files found at http server at url that match extension ext."""
+    response = requests.get(url, params=params)
+    if response.ok:
+        response_text = response.text
+    else:
+        return response.raise_for_status()
+    soup = BeautifulSoup(response_text, "html.parser")
+    return [url + node.get("href") for node in soup.find_all("a") if node.get("href").endswith(ext)]
+
+
+class Image:
+    def __init__(self, url):
+        self.url = url
+        self.image_name = os.path.basename(self.url)
+        self.ansible_hostname = self.image_name.replace("-", "_")
+        self.export_path = os.path.join(args.export_directory, self.image_name)
+        self.vm = None
+
+    @staticmethod
+    def from_http_server(server_url):
+        if server_url[-1] != "/":
+            server_url += "/"
+
+        return [Image(url) for url in get_url_paths(server_url, ".xva")]
+
+    def __str__(self):
+        return self.url
+
+
+def get_ansible_hosts(playbook: str) -> List[str]:
+    ansible_hosts = []
+    with open(playbook, "r") as f:
+        for play in yaml.load(f, Loader=Loader):
+            ansible_hosts.append(play["hosts"])
+
+    if not ansible_hosts:
+        logger.error("No playbook hosts found")
+        sys.exit(1)
+
+    logger.info(f"Playbook Hosts Found: {ansible_hosts}")
+
+    return ansible_hosts
+
+
+def print_images(images: List[Image]):
+    print("\nAvailable Images:")
+    for image in images:
+        print(image)
+
+
+vms: List[VM] = []
+
+
+def cleanup(*args, **kwargs):
+    if not vms:
+        return
+
+    logger.debug(f"Running cleanup")
+    while vms:
+        vm = vms.pop()
+        logger.debug(f"Destroying {vm}")
+        vm.destroy()
+
+
+def modified(host: Host, image: Image) -> bool:
+    """
+    Return True if the playbook is modified. Otherwise, return False.
+
+    A playbook is considered modified if its modified timestamp is newer than
+    the modified timestamp of the image at the export path.
+
+    This avoids updating XVAs that are already up-to-date.
+    """
+    playbook_modified = int(os.stat(args.playbook).st_mtime)
+
+    if not host.file_exists(image.export_path):
+        return True
+
+    image_modified = int(host.ssh(["stat", "--format", "%Y", image.export_path]))
+    if image_modified > playbook_modified:
+        logger.info((
+            f"Skipping {image.image_name}, the file found at "
+            f"{image.export_path} is newer than the playbook"
+        ))
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run a playbook for updating test VMs")
+    parser.add_argument(
+        "--http",
+        type=str,
+        required=False,
+        default=getattr(data, "DEF_VM_URL", "http://pxe/images/"),
+        help=(
+            "The HTTP/PXE server containing the test VMs. Defaults to DEF_VM_URL "
+            "in data.py, if not found then defaults to http://pxe/images/"
+        ),
+    )
+    parser.add_argument(
+        "--forced",
+        action="store_true",
+        help="Force update all VMs. Don't skip any due to modified timestamps."
+    )
+    parser.add_argument(
+        "--loglevel",
+        choices=["DEBUG", "ERROR", "WARNING", "INFO"],
+        default="INFO",
+        help="Force update all VMs. Don't skip any due to modified timestamps."
+    )
+    parser.add_argument(
+        "--print-images",
+        action="store_true",
+        required=False,
+        help="Show the available images on the PXE server and then exit.",
+    )
+
+    # Args host/playbook are not required if the user only wants to print the images
+    if "--print-images" not in sys.argv:
+        parser.add_argument(
+            "--host",
+            "-x",
+            type=str,
+            help="The XCP-ng hostname or IP address. Defaults to host found in data.py",
+        )
+        parser.add_argument(
+            "--export-directory",
+            "-e",
+            type=str,
+            required=False,
+            default=os.path.join("/", "root", "ansible-updates/"),
+            help=(
+                "The directory on the XCP-ng host to export the updated image. "
+                "Defaults to /root/ansible-updates/"
+            ),
+        )
+        parser.add_argument("playbook", type=str, help="The Ansible playbook.")
+
+    args = parser.parse_args()
+
+    logger = logging.getLogger("ansible:runner")
+    logger.setLevel(level=getattr(logging, args.loglevel))
+
+    if not logger.hasHandlers():
+        ch = logging.StreamHandler()
+        ch.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
+        logger.addHandler(ch)
+
+    atexit.register(cleanup)
+    for sig in [SIGINT, SIGQUIT, SIGABRT, SIGTERM]:
+        signal(sig, cleanup)
+
+    if args.print_images:
+        print_images(images)
+        sys.exit(0)
+
+    ansible_hosts = get_ansible_hosts(args.playbook)
+
+    # Initialize the hosts and gather the urls for the VM images to update
+    host = args.host if args.host else list(data.HOSTS.keys())[0]
+    host = Host(host)
+    host.initialize()
+
+    # Create an inventory (i.e., hosts file) for Ansible. The host name is the image name.
+    lines = []
+
+    images = []
+    for image in Image.from_http_server(args.http):
+        if image.ansible_hostname not in ansible_hosts:
+            continue
+
+        if args.forced or modified(host, image):
+            images.append(image)
+
+    for image in images:
+        vm = image.vm = host.import_vm(image.url)
+        vm.start()
+        vm.wait_for_os_booted()
+        vms.append(vm)
+
+        lines.append(f"[{image.ansible_hostname}]")
+        lines.append(
+            f"{vm.ip} ansible_user=root ansible_python_interpreter=auto_silent"
+        )
+        lines.append("\n")
+
+    if not vms:
+        logger.info("No hostnames needing update found in playbook")
+        sys.exit(0)
+
+    _, inventory = tempfile.mkstemp()
+    with open(inventory, "w") as f:
+        logger.info("Generated Inventory:")
+        for line in lines:
+            logger.info(line)
+            f.write(line + "\n")
+
+    # Update the VMs
+    run(["ansible-playbook", "-i", inventory, args.playbook])
+
+    # Export the updated VMs
+    exports = []
+    for image in images:
+        try:
+            vm = image.vm
+            if vm is None:
+                logger.warning(f"VM for {image.image_name} not found, not exporting")
+                continue
+            vm.shutdown(verify=True)
+            path = image.export_path
+            vm.host.ssh(["mkdir", "-p", os.path.split(path)[0]])
+            vm.host.ssh(["rm", "-f", path])
+            vm.export(path)
+            exports.append(f"{user}@{vm.host.hostname_or_ip}:" + path)
+        except Exception as e:
+            logger.error(e)
+
+    if exports:
+        logger.info("\nExports:")
+        logger.info("\n\t".join(exports))


### PR DESCRIPTION
This PR adds support for updating test VMs using Ansible.

Currently, this script does the following:

1. Parses an Ansible playbook for host names
2. Searches for XVAs located at DEF_VM_URL (usually http://pxe/images)
3. Matches the XVAs to the playbook host names
4. For each match:
   1. Create the VM by importing the XVA
    2. Apply the Ansible playbook to the VM
    3. Shutdown the VM
    4. Export the VM to `--export-directory'` argument OR the default `/root/ansible-updates/`
  

Future work:

1. Allow exporting the VM remotely, such as back to `http://pxe/images`
2. Use the Ansible XenServer plugin to create the VMs instead of using the script to create the inventory. Currently, the XenServer plugin doesn't support creating a VM by importing an XVA, but instead only by creating one from a template.