### PR TITLE
Add DB append tests

### DIFF
--- a/tests/uefistored/conftest.py
+++ b/tests/uefistored/conftest.py
@@ -39,3 +39,11 @@ def uefi_vm_and_snapshot(imported_vm):
 def uefi_vm(uefi_vm_and_snapshot):
     vm, _ = uefi_vm_and_snapshot
     yield vm
+
+@pytest.fixture(scope='module')
+def linux_uefi_vm(uefi_vm):
+    vm = uefi_vm
+    if vm.is_windows:
+        pytest.skip("linux_uefi_vm can only be used on Linux VMs")
+
+    yield vm

--- a/tests/uefistored/test_auth_var.py
+++ b/tests/uefistored/test_auth_var.py
@@ -44,21 +44,25 @@ def test_auth_variable(imported_vm):
         pytest.skip('not valid test for Windows VMs')
 
     vm.start()
-    vm.wait_for_vm_running_and_ssh_up()
 
-    cert = Certificate()
+    try:
+        vm.wait_for_vm_running_and_ssh_up()
 
-    # Set the variable
-    set_and_assert_var(vm, cert, b'I am old news', should_pass=True)
+        cert = Certificate()
 
-    # Set the variable with new data, signed by the same cert
-    set_and_assert_var(vm, cert, b'I am new news', should_pass=True)
+        # Set the variable
+        set_and_assert_var(vm, cert, b'I am old news', should_pass=True)
 
-    # Remove var
-    set_and_assert_var(vm, cert, b'', should_pass=True)
+        # Set the variable with new data, signed by the same cert
+        set_and_assert_var(vm, cert, b'I am new news', should_pass=True)
 
-    # Set the variable with new data, signed by the same cert
-    set_and_assert_var(vm, cert, b'new data', should_pass=True)
+        # Remove var
+        set_and_assert_var(vm, cert, b'', should_pass=True)
 
-    # Set the variable with new data, signed by a different cert
-    set_and_assert_var(vm, Certificate(), b'this should fail', should_pass=False)
+        # Set the variable with new data, signed by the same cert
+        set_and_assert_var(vm, cert, b'new data', should_pass=True)
+
+        # Set the variable with new data, signed by a different cert
+        set_and_assert_var(vm, Certificate(), b'this should fail', should_pass=False)
+    finally:
+        vm.shutdown(verify=True)


### PR DESCRIPTION
This PR adds support for testing the append of the UEFI DB variable. This was the cause of the KB update bug in Windows.

The test has only been tested on Alpine and it requires `efi-updatevar`. It will fail without `efi-updatevar`.