### PR TITLE
Run of XAPI's `quicktest`

### DIFF
--- a/tests/quicktest/test_quicktest.py
+++ b/tests/quicktest/test_quicktest.py
@@ -1,0 +1,12 @@
+import logging
+
+# Requirements:
+# From --host parameter:
+# - A XCP-ng host.
+#
+# /!\ Very long to execute
+
+def test_quicktest(host):
+    logging.info("Launching tests")
+    res = host.ssh(['/opt/xensource/debug/quicktest'])
+    logging.debug("Test result: %s" % res)


### PR DESCRIPTION
See: https://github.com/xapi-project/xen-api/tree/master/ocaml/quicktest

The test fails in case of:
- Quicktest failure
- Leaked XAPI object (missing or bad cleanup)

Otherwise success.

The result is printed for debug mode or thrown in case of error.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>