### PR TITLE
Allow to stream a SSH result

### DIFF
--- a/tests/quicktest/test_quicktest.py
+++ b/tests/quicktest/test_quicktest.py
@@ -8,5 +8,4 @@ import logging
 
 def test_quicktest(host):
     logging.info("Launching tests")
-    res = host.ssh(['/opt/xensource/debug/quicktest'])
-    logging.debug("Test result: %s" % res)
+    host.ssh(['/opt/xensource/debug/quicktest'])


### PR DESCRIPTION
More user friendly when a SSH command dumps a lot of text during a long time.

resolves https://github.com/xcp-ng/xcp-ng-tests/issues/60

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>