### PR TITLE
Improve EFI module and VM EFI method ergonomics

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -917,7 +917,7 @@ class VM(BaseVM):
         """Sets the data and attrs for an EFI variable and GUID."""
         assert len(attrs) == 4
 
-        efivarfs = '/sys/firmware/efi/efivars/%s-%s' % (var, guid)
+        efivarfs = '/sys/firmware/efi/efivars/%s-%s' % (var, guid.as_str())
 
         if self.file_exists(efivarfs):
             self.ssh(['chattr', '-i', efivarfs])
@@ -930,7 +930,7 @@ class VM(BaseVM):
 
     def get_efi_var(self, var, guid):
         """Returns a 2-tuple of (attrs, data) for an EFI variable."""
-        efivarfs = '/sys/firmware/efi/efivars/%s-%s' % (var, guid)
+        efivarfs = '/sys/firmware/efi/efivars/%s-%s' % (var, guid.as_str())
 
         if not self.file_exists(efivarfs):
             return b''
@@ -993,7 +993,7 @@ class VM(BaseVM):
             dest = self.host.ssh(['mktemp'])
             self.host.scp(auth.auth, dest)
             self.host.ssh([
-                'varstore-set', self.uuid, efi.EFI_GUID_STRS[auth.name], auth.name,
+                'varstore-set', self.uuid, auth.guid.as_str(), auth.name,
                 str(efi.EFI_AT_ATTRS), dest
             ])
             self.host.ssh(['rm', '-f', dest])

--- a/lib/common.py
+++ b/lib/common.py
@@ -933,12 +933,12 @@ class VM(BaseVM):
         efivarfs = '/sys/firmware/efi/efivars/%s-%s' % (var, guid)
 
         if not self.file_exists(efivarfs):
-            return 0, b''
+            return b''
 
         data = self.ssh(['cat', efivarfs], simple_output=False, decode=False).stdout
 
         # The efivarfs file starts with the attributes, which are 4 bytes long
-        return data[:4], data[4:]
+        return data[4:]
 
     def file_exists(self, filepath):
         """Returns True if the file exists, otherwise returns False."""

--- a/tests/uefistored/test_secure_boot.py
+++ b/tests/uefistored/test_secure_boot.py
@@ -4,7 +4,7 @@ import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for
-from lib.efi import EFIAuth, EFI_AT_ATTRS_BYTES, EFI_GUID_STRS, esl_from_auth_file
+from lib.efi import EFIAuth, EFI_AT_ATTRS_BYTES, get_secure_boot_guid, esl_from_auth_file
 
 VM_SECURE_BOOT_FAILED = 'VM_SECURE_BOOT_FAILED'
 
@@ -347,7 +347,7 @@ class TestUEFIKeyExchange:
             ok = True
             saved_exception = None
             try:
-                vm.set_efi_var(auth.name, EFI_GUID_STRS[auth.name],
+                vm.set_efi_var(auth.name, auth.guid,
                                EFI_AT_ATTRS_BYTES, auth.auth_data)
             except SSHCommandFailed:
                 ok = False
@@ -462,7 +462,7 @@ class TestPoolToVMCertInheritance:
         vm.host.pool.clear_uefi_certs()
 
     def is_vm_cert_present(self, vm, key):
-        res = vm.host.ssh(['varstore-get', vm.uuid, EFI_GUID_STRS[key], key],
+        res = vm.host.ssh(['varstore-get', vm.uuid, get_secure_boot_guid(key).as_str(), key],
                           check=False, simple_output=False, decode=False)
         return res.returncode == 0
 
@@ -470,7 +470,7 @@ class TestPoolToVMCertInheritance:
         return hashlib.md5(esl_from_auth_file(auth)).hexdigest()
 
     def check_vm_cert_md5sum(self, vm, key, reference_file):
-        res = vm.host.ssh(['varstore-get', vm.uuid, EFI_GUID_STRS[key], key],
+        res = vm.host.ssh(['varstore-get', vm.uuid, get_secure_boot_guid(key).as_str(), key],
                           check=False, simple_output=False, decode=False)
         assert res.returncode == 0, f"Cert {key} must be present"
         reference_md5 = self.get_md5sum_from_auth(reference_file)


### PR DESCRIPTION
Some parts of the EFI code are quite cumbersome, so this PR attempts to try and help that.

It depends on #57.

The main refactoring is in refactoring the GUID and is described in more detail in the commit message for `lib/efi: refactor GUID strings and bytes into GUID class`.

The second refactoring is simply eliminating the return of the attributes in `vm.get_efi_var()` since they are never used and are unlikely to be used in the future.