### PR TITLE
Use scp to fix TestProxies tests

### DIFF
--- a/tests/xapi-plugins/test_updater.py
+++ b/tests/xapi-plugins/test_updater.py
@@ -31,12 +31,13 @@ class TestProxies:
         set_proxies = '{ \
             "xcp-ng-base": "_none_", \
             "xcp-ng-updates": "_none_", \
-            "xcp-ng-testing": "_none_" \
+            "xcp-ng-testing": "_none_", \
+            "xcp-ng-staging": "_none_" \
         }'
-        host.call_plugin('updater.py', 'set_proxies', {"proxies": set_proxies})
+        host.call_plugin('updater.py', 'set_proxies', {"proxies": set_proxies}, use_scp=True)
 
         res = host.call_plugin('updater.py', 'get_proxies')
         assert json.loads(res) == json.loads(set_proxies)
 
-        host.call_plugin('updater.py', 'set_proxies', {"proxies": proxies})
+        host.call_plugin('updater.py', 'set_proxies', {"proxies": proxies}, use_scp=True)
         assert json.loads(res) == json.loads(proxies)


### PR DESCRIPTION
We can't use a json string argument on a host using host.xe
because we must already escape the simple/double quotes
of the ssh and xe commands. JSON introduces a new level of quotes...
Otherwise we have a bad shell interpretation of the quotes on the server.

Solution: we use scp to copy a script that contains the xe command on the host.

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>