### PR TITLE
Do not test for raid file as a regular file

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -490,8 +490,9 @@ class Host:
         disks.sort()
         return disks
 
-    def file_exists(self, filepath):
-        return self.ssh_with_result(['test', '-f', filepath]).returncode == 0
+    def file_exists(self, filepath, regular_file=True):
+        option = '-f' if regular_file else '-e'
+        return self.ssh_with_result(['test', option, filepath]).returncode == 0
 
     def binary_exists(self, binary):
         return self.ssh_with_result(['which', binary]).returncode == 0

--- a/tests/xapi-plugins/test_raid.py
+++ b/tests/xapi-plugins/test_raid.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.fixture(scope='session')
 def host_with_raid(host):
     dummy_raid = False
-    if not host.file_exists('/dev/md127'):
+    if not host.file_exists('/dev/md127', regular_file=False):
         logging.info("> Host has no raids, creating one for tests")
         dummy_raid = True
         host.ssh(['dd', 'if=/dev/zero', 'of=raid-0', 'bs=1M', 'count=200'])


### PR DESCRIPTION
`/dev/md127` is NOT a regular file therefore:
`test -f` will always return `false`

Use `test -e` instead.

Add `regular_file=True` to `file_exists` to enable
the check of non regular file existence.

`test -e` only checks a file existence no matter what type it is.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>