### PR TITLE
Robustify guest tools ISO mount in tests

### DIFF
--- a/tests/guest-tools/unix/test_guest_tools_unix.py
+++ b/tests/guest-tools/unix/test_guest_tools_unix.py
@@ -65,8 +65,8 @@ class TestGuestToolsUnix:
         logging.info("Mount guest tools ISO")
         vm.mount_guest_tools_iso()
         tmp_mnt = vm.ssh(['mktemp', '-d'])
-        time.sleep(1) # wait a small amount of time just to ensure the device is available
-        vm.ssh(['mount', '/dev/cdrom', tmp_mnt])
+        time.sleep(2) # wait a small amount of time just to ensure the device is available
+        vm.ssh(['mount', '-t', 'iso9660', '/dev/cdrom', tmp_mnt])
 
         # get tools version number for future checks
         prefix = 'xe-guest-utilities_'


### PR DESCRIPTION
Explicitly specify -t iso9660 as it seems mount randomly fails in the
context of our tests when we don't set it.

Also raise the sleep time to 2s to give more time to the device to
appear on slower hosts.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>