### PR TITLE
Fix string escaping for SSH commands and xe commands

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 import subprocess
 
 import lib.config as config
@@ -77,7 +78,7 @@ def ssh(hostname_or_ip, cmd, check=True, simple_output=True, suppress_fingerprin
         # https://stackoverflow.com/questions/29142/getting-ssh-to-execute-a-command-in-the-background-on-target-machine
         command = "nohup %s &>/dev/null &" % command
 
-    ssh_cmd = "ssh root@%s %s '%s'" % (hostname_or_ip, ' '.join(options), command)
+    ssh_cmd = f"ssh root@{hostname_or_ip} {' '.join(options)} {shlex.quote(command)}"
 
     windows_background = background and target_os == "windows"
     # Fetch banner and remove it to avoid stdout/stderr pollution.

--- a/lib/host.py
+++ b/lib/host.py
@@ -57,7 +57,7 @@ class Host:
             result = self.execute_script(' '.join(command), 'sh', simple_output)
         else:
             result = self.ssh(
-                [shlex.quote(' '.join(command))],
+                command,
                 check=check,
                 simple_output=simple_output
             )


### PR DESCRIPTION
* Use shlex.quote to escape the command given to SSH, instead of adding
  quotes around the command.
* Don't escape the whole xe command anymore. Escaping the values of
  parameters is enough when combined with escaping the whole SSH
  command.
* The rationale is we need just two levels of escaping:
  * Protecting against local shell interpretation (that's why we escape
    the whole command given to SSH)
  * Protecting against the distant shell (that's why we escape the
    values given to xe).

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>