### PR TITLE
Trigger GC run and wait for it to complete before destroying a SR

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -58,3 +58,7 @@ def parse_xe_dict(xe_dict):
         key, value = pair.split(':')
         res[key.strip()] = value.strip()
     return res
+
+def safe_split(text, sep=','):
+    """ A split function that returns an empty list if the input string is empty. """
+    return text.split(sep) if len(text) > 0 else []

--- a/lib/sr.py
+++ b/lib/sr.py
@@ -2,18 +2,20 @@ import logging
 
 import lib.commands as commands
 
-from lib.common import wait_for, wait_for_not
+from lib.common import safe_split, wait_for, wait_for_not
 
 class SR:
     def __init__(self, uuid, pool):
         self.uuid = uuid
         self.pool = pool
+        self._is_shared = None # cached value for is_shared()
+        self._main_host = None # cached value for main_host()
 
     def pbd_uuids(self):
         return self.pool.master.xe('pbd-list', {'sr-uuid': self.uuid}, minimal=True).split(',')
 
     def unplug_pbds(self, force=False):
-        logging.info("Unplug PBDs")
+        logging.info(f"Unplug PBDs for SR {self.uuid}")
         for pbd_uuid in self.pbd_uuids():
             try:
                 self.pool.master.xe('pbd-unplug', {'uuid': pbd_uuid})
@@ -38,12 +40,48 @@ class SR:
         if verify:
             wait_for(self.all_pbds_attached, "Wait for PDBs attached")
 
+    def vdi_uuids(self, managed=False):
+        return safe_split(self.pool.master.xe('vdi-list', {'sr-uuid': self.uuid, 'managed': managed}, minimal=True))
+
     def destroy(self, verify=False, force=False):
-        self.unplug_pbds(force)
-        logging.info("Destroy SR " + self.uuid)
-        self.pool.master.xe('sr-destroy', {'uuid': self.uuid})
-        if verify:
-            wait_for_not(self.exists, "Wait for SR destroyed")
+        # Rescan SR to improve the chances of the forced GC run triggered by sr-destroy
+        # remove all VDIs in one pass and such have sr-destroy working on first try.
+        self.scan()
+        max_tries = 5
+        for i in range(1, max_tries + 1): # [1, 2, ..., max_tries]
+            self.unplug_pbds(force)
+            logging.info(f"Destroy SR {self.uuid} (attempt {i})")
+            try:
+                # Note: sr-destroy triggers ONE forced GC run
+                # This may not be enough in some cases
+                # (when VDIs to GC are not all leafs and would require several runs)
+                self.pool.master.xe('sr-destroy', {'uuid': self.uuid})
+            except commands.SSHCommandFailed as e:
+                if "the SR is not empty" not in e.stdout:
+                    raise
+                else:
+                    logging.info(f"SR destroy failed with message: {e.stdout}")
+                    try:
+                        self.plug_pbds()
+                        # rescan for an up to date list of VDIs
+                        self.scan()
+                    except commands.SSHCommandFailed:
+                        raise Exception("SR destroy failed and then pbd-plug failed too. Can't continue further.")
+                    output = self.vdi_uuids(managed=True)
+                    if len(output) > 0:
+                        raise Exception("SR destroy failed due to SR not empty, "
+                                        "and there are indeed managed VDIs left on the SR.")
+                    else:
+                        logging.info("SR destroy failed due to SR not empty but there aren't any managed VDIs left.")
+                        if i < max_tries:
+                            logging.info(f"Retrying sr-destroy in case it failed due to incomplete GC.")
+                            continue
+                        else:
+                            raise Exception(f"Could not destroy the SR even after {i} attempts.")
+            if verify:
+                wait_for_not(self.exists, "Wait for SR destroyed")
+            # Everything apparently went fine. Get out of the retry loop.
+            break
 
     def forget(self, force=False):
         self.unplug_pbds(force)
@@ -63,8 +101,19 @@ class SR:
     def attached_to_host(self, host):
         return host.uuid in self.hosts_uuids()
 
+    def main_host(self):
+        """ Returns the host in case of a local SR, the master host in case of a shared SR. """
+        if self._main_host is None:
+            if self.is_shared():
+                self._main_host = self.pool.master
+            else:
+                self._main_host = self.pool.get_host_by_uuid(self.hosts_uuids()[0])
+        return self._main_host
+
     def content_type(self):
         return self.pool.master.xe('sr-param-get', {'uuid': self.uuid, 'param-name': 'content-type'})
 
     def is_shared(self):
-        return self.pool.master.xe('sr-param-get', {'uuid': self.uuid, 'param-name': 'shared'})
+        if self._is_shared is None:
+            self._is_shared = self.pool.master.xe('sr-param-get', {'uuid': self.uuid, 'param-name': 'shared'})
+        return self._is_shared


### PR DESCRIPTION
(this supersedes PR #79)

We encountered situations where the VDIs were not garbage collected
correctly when sr destroy is called, despite the fact that the driver's
delete method did trigger a forced GC run.

Based on upstream advice, we run sr scan to trigger a GC run and then
wait for the GC run to complete, before attempting the SR deletion.

See https://github.com/xapi-project/sm/issues/583

**Update: I changed the way to do again, because this made the teardown too long when the GC takes a long time to wake up**

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>