### PR TITLE
Improve host-evacuate tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -319,10 +319,10 @@ def second_network(request, host):
         pytest.fail("This test requires the --second-network parameter!")
     network_uuid = request.param
     pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': network_uuid}, minimal=True)
-    if pif_uuid == "":
+    if pif_uuid:
         pytest.fail("The provided --second-network UUID doesn't exist or doesn't have a PIF on master host")
     ip = host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'IP'})
-    if ip == "":
+    if ip:
         pytest.fail("The provided --second-network has a PIF but no IP")
     if network_uuid == host.management_network():
         pytest.fail("--second-network must NOT be the management network")

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -36,7 +36,7 @@ class VM(BaseVM):
 
     # By xe design on must be an host name-label
     def start(self, on=None):
-        msg_starts_on = f" (on host {on})" if on is not None else None
+        msg_starts_on = f" (on host {on})" if on else None
         logging.info("Start VM" + msg_starts_on)
         args = {'uuid': self.uuid}
         if on is not None:

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -36,7 +36,8 @@ class VM(BaseVM):
 
     # By xe design on must be an host name-label
     def start(self, on=None):
-        logging.info("Start VM")
+        msg_starts_on = f" (on host {on})" if on is not None else None
+        logging.info("Start VM" + msg_starts_on)
         args = {'uuid': self.uuid}
         if on is not None:
             args['on'] = on

--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -28,7 +28,10 @@ def _host_evacuate_test(source_host, dest_host, network_uuid, vm, expect_error=F
         args['network-uuid'] = network_uuid
 
     try:
-        logging.info(f"Evacuate host {source_host}")
+        if not expect_error:
+            logging.info(f"Evacuate host {source_host}")
+        else:
+            logging.info(f"Attempt evacuating host {source_host}. This should fail.")
         source_host.xe('host-evacuate', args)
         wait_for(lambda: vm.all_vdis_on_host(dest_host), "Wait for all VDIs on destination host")
         wait_for(lambda: vm.is_running_on_host(dest_host), "Wait for VM to be running on destination host")
@@ -37,6 +40,7 @@ def _host_evacuate_test(source_host, dest_host, network_uuid, vm, expect_error=F
     except SSHCommandFailed as e:
         if not (expect_error and e.stdout.find(error) > -1):
             raise
+        logging.info(f"Evacuate failed with the expected error: {error}.")
     finally:
         vm.shutdown(verify=True)
 
@@ -69,21 +73,25 @@ class TestHostEvacuate:
         ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
         reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
         args = _save_ip_configuration_mode(host, pif_uuid)
+        logging.info(f"Reconfigure PIF {pif_uuid}: remove its IP")
         host.xe(reconfigure_method, {'uuid': pif_uuid, 'mode': 'none'})
         try:
             no_ip_error = 'The specified interface cannot be used because it has no IP address'
             _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, no_ip_error)
         finally:
+            logging.info(f"Restore the configuration of PIF {pif_uuid}")
             host.xe(reconfigure_method, args)
 
     def test_host_evacuate_with_network_not_attached(self, host, hostA2, second_network, vm_on_nfs_sr):
         pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
+        logging.info(f"Unplug PIF {pif_uuid}")
         host.xe('pif-unplug', {'uuid': pif_uuid})
         try:
             not_attached_error = \
                 'The operation you requested cannot be performed because the specified PIF is currently unplugged'
             _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_attached_error)
         finally:
+            logging.info(f"Re-plug PIF {pif_uuid}")
             host.xe('pif-plug', {'uuid': pif_uuid})
 
     def test_host_evacuate_with_network_not_present(self, host, hostA2, second_network, vm_on_nfs_sr):
@@ -91,6 +99,7 @@ class TestHostEvacuate:
         ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
         reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
         args = _save_ip_configuration_mode(host, pif_uuid)
+        logging.info(f"Forget PIF {pif_uuid}")
         host.xe('pif-forget', {'uuid': pif_uuid})
         try:
             not_present_error = 'This host has no PIF on the given network'
@@ -99,5 +108,6 @@ class TestHostEvacuate:
             host.xe('pif-scan', {'host-uuid': host.uuid})
             pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
             args['uuid'] = pif_uuid
+            logging.info(f"Re-add and plug PIF {pif_uuid}")
             host.xe(reconfigure_method, args)
             host.xe('pif-plug', {'uuid': pif_uuid})

--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -1,3 +1,6 @@
+import logging
+import pytest
+
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for
 # The pool needs a shared SR to use `host.evacuate`. All three fixtures below are needed.
@@ -5,13 +8,16 @@ from tests.storage.nfs.conftest import vm_on_nfs_sr, nfs_sr, nfs_device_config
 
 # Requirements:
 # From --hosts parameter:
-# - host(A1): first XCP-ng host >= 8.2 (+ updates) with an additional unused disk for the SR.
-# - hostA2: Second member of the pool. Can have any local SR. No need to specify it on CLI.
+# - host(A1): first XCP-ng host >= 8.2 (+ XAPI patch allowing to select migration network for evacuate)
+# - hostA2: Second member of the pool.
 # From --vm parameter
 # - A VM to import
-# From --second-network parameter
-# - second_network: A 2nd physical network of the pool, NOT the management interface,
-# with PIF plugged and configured with an IP on all hosts
+# From data.py or --sr-device-config parameter: configuration to create a new NFS SR.
+# From --second-network parameter (for most tests)
+# - second_network: A 2nd physical network of the pool with PIF plugged and configured with an IP on all hosts
+#   Must NOT be the management interface.
+#   Must NOT be the network used to access the NFS SR.
+#   This network will be disconnected at some point during the tests
 
 def _host_evacuate_test(source_host, dest_host, network_uuid, vm, expect_error=False, error=""):
     source_name = source_host.xe('host-param-get', {'uuid': source_host.uuid, 'param-name': 'name-label'})
@@ -22,6 +28,7 @@ def _host_evacuate_test(source_host, dest_host, network_uuid, vm, expect_error=F
         args['network-uuid'] = network_uuid
 
     try:
+        logging.info(f"Evacuate host {source_host}")
         source_host.xe('host-evacuate', args)
         wait_for(lambda: vm.all_vdis_on_host(dest_host), "Wait for all VDIs on destination host")
         wait_for(lambda: vm.is_running_on_host(dest_host), "Wait for VM to be running on destination host")
@@ -48,46 +55,49 @@ def _save_ip_configuration_mode(host, pif_uuid):
 
     return args
 
-def test_host_evacuate(host, hostA2, vm_on_nfs_sr):
-    _host_evacuate_test(host, hostA2, None, vm_on_nfs_sr)
+@pytest.mark.incremental
+class TestHostEvacuate:
+    # first in list so that it fails early in case the --second-network parameter is missing or wrong
+    def test_host_evacuate_with_network(self, host, hostA2, second_network, vm_on_nfs_sr):
+        _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr)
 
-def test_host_evacuate_with_network(host, hostA2, second_network, vm_on_nfs_sr):
-    _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr)
+    def test_host_evacuate(self, host, hostA2, vm_on_nfs_sr):
+        _host_evacuate_test(host, hostA2, None, vm_on_nfs_sr)
 
-def test_host_evacuate_with_network_no_ip(host, hostA2, second_network, vm_on_nfs_sr):
-    pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
-    ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
-    reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
-    args = _save_ip_configuration_mode(host, pif_uuid)
-    host.xe(reconfigure_method, {'uuid': pif_uuid, 'mode': 'none'})
-    try:
-        no_ip_error = 'The specified interface cannot be used because it has no IP address'
-        _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, no_ip_error)
-    finally:
-        host.xe(reconfigure_method, args)
-
-def test_host_evacuate_with_network_not_attached(host, hostA2, second_network, vm_on_nfs_sr):
-    pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
-    host.xe('pif-unplug', {'uuid': pif_uuid})
-    try:
-        not_attached_error = \
-            'The operation you requested cannot be performed because the specified PIF is currently unplugged'
-        _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_attached_error)
-    finally:
-        host.xe('pif-plug', {'uuid': pif_uuid})
-
-def test_host_evacuate_with_network_not_present(host, hostA2, second_network, vm_on_nfs_sr):
-    pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
-    ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
-    reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
-    args = _save_ip_configuration_mode(host, pif_uuid)
-    host.xe('pif-forget', {'uuid': pif_uuid})
-    try:
-        not_present_error = 'This host has no PIF on the given network'
-        _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_present_error)
-    finally:
-        host.xe('pif-scan', {'host-uuid': host.uuid})
+    def test_host_evacuate_with_network_no_ip(self, host, hostA2, second_network, vm_on_nfs_sr):
         pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
-        args['uuid'] = pif_uuid
-        host.xe(reconfigure_method, args)
-        host.xe('pif-plug', {'uuid': pif_uuid})
+        ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
+        reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
+        args = _save_ip_configuration_mode(host, pif_uuid)
+        host.xe(reconfigure_method, {'uuid': pif_uuid, 'mode': 'none'})
+        try:
+            no_ip_error = 'The specified interface cannot be used because it has no IP address'
+            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, no_ip_error)
+        finally:
+            host.xe(reconfigure_method, args)
+
+    def test_host_evacuate_with_network_not_attached(self, host, hostA2, second_network, vm_on_nfs_sr):
+        pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
+        host.xe('pif-unplug', {'uuid': pif_uuid})
+        try:
+            not_attached_error = \
+                'The operation you requested cannot be performed because the specified PIF is currently unplugged'
+            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_attached_error)
+        finally:
+            host.xe('pif-plug', {'uuid': pif_uuid})
+
+    def test_host_evacuate_with_network_not_present(self, host, hostA2, second_network, vm_on_nfs_sr):
+        pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
+        ipv6 = (host.xe('pif-param-get', {'uuid': pif_uuid, 'param-name': 'primary-address-type'}) == "IPv6")
+        reconfigure_method = 'pif-reconfigure-ipv6' if ipv6 else 'pif-reconfigure-ip'
+        args = _save_ip_configuration_mode(host, pif_uuid)
+        host.xe('pif-forget', {'uuid': pif_uuid})
+        try:
+            not_present_error = 'This host has no PIF on the given network'
+            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_present_error)
+        finally:
+            host.xe('pif-scan', {'host-uuid': host.uuid})
+            pif_uuid = host.xe('pif-list', {'host-uuid': host.uuid, 'network-uuid': second_network}, minimal=True)
+            args['uuid'] = pif_uuid
+            host.xe(reconfigure_method, args)
+            host.xe('pif-plug', {'uuid': pif_uuid})


### PR DESCRIPTION
* Improve the second_network fixture so that the tests that require it
  fail nicely when it doesn't meet the expected criteria: is present,
  the uuid points at an existing network which has a PIF and an IP address
  on master host, and is not the management network.
* Improve the requirements comment section. In particular, stress out
  the fact that the NFS SR must not depend on the "second network".
* Mark the tests incremental and put a test that requires the
  second_network fixture, so that test execution fails fast when the
  parameter is missing. It's still possible to directly call the only test
  that doesn't require this fixture.
* Add logs.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>