### PR TITLE
Rename test SRs to make it obvious they're related to testing

### DIFF
--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -38,7 +38,7 @@ def cephfs_device_config(sr_device_config):
 @pytest.fixture(scope='session')
 def cephfs_sr(host, cephfs_device_config, pool_with_ceph):
     """ A CephFS SR on first host. """
-    sr = host.sr_create('cephfs', "CephFS-SR", cephfs_device_config, shared=True)
+    sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -23,7 +23,7 @@ class TestCephFSSRCreateDestroy:
             "mount.ceph must not be installed on the host at the beginning of the tests"
         sr = None
         try:
-            sr = host.sr_create('cephfs', "CephFS-SR", cephfs_device_config, shared=True)
+            sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:
@@ -32,7 +32,7 @@ class TestCephFSSRCreateDestroy:
 
     def test_create_and_destroy_sr(self, host, pool_with_ceph, cephfs_device_config):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('cephfs', "CephFS-SR", cephfs_device_config, shared=True, verify=True)
+        sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.fixture(scope='session')
 def ext_sr(host, sr_disk):
     """ An EXT SR on first host. """
-    sr = host.sr_create('ext', "EXT-local-SR", {'device': '/dev/' + sr_disk})
+    sr = host.sr_create('ext', "EXT-local-SR-test", {'device': '/dev/' + sr_disk})
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -13,11 +13,11 @@ class TestEXTSRCreateDestroy:
     """
 
     def test_create_sr_with_missing_device(self, host):
-        try_to_create_sr_with_missing_device('ext', 'EXT-local-SR', host)
+        try_to_create_sr_with_missing_device('ext', 'EXT-local-SR-test', host)
 
     def test_create_and_destroy_sr(self, host, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('ext', "EXT-local-SR", {'device': '/dev/' + sr_disk}, verify=True)
+        sr = host.sr_create('ext', "EXT-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -197,7 +197,7 @@ def glusterfs_device_config(host):
 def glusterfs_sr(host, pool_with_glusterfs, gluster_volume_started, glusterfs_device_config):
     """ A GlusterFS SR on first host. """
     # Create the SR
-    sr = host.sr_create('glusterfs', "GlusterFS-SR", glusterfs_device_config, shared=True)
+    sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True)
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -22,7 +22,7 @@ class TestGlusterFSSRCreateDestroy:
             "glusterd must not be installed on the host at the beginning of the tests"
         sr = None
         try:
-            sr = host.sr_create('glusterfs', "GlusterFS-SR", glusterfs_device_config, shared=True)
+            sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True)
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:
@@ -31,7 +31,7 @@ class TestGlusterFSSRCreateDestroy:
 
     def test_create_and_destroy_sr(self, host, pool_with_glusterfs, gluster_volume_started, glusterfs_device_config):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('glusterfs', "GlusterFS-SR", glusterfs_device_config, shared=True, verify=True)
+        sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_glusterfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -88,7 +88,7 @@ def create_linstor_sr(hosts_with_linstor):
     master.ssh(['linstor', 'node', 'create', '`uname -n`', master_ip, '--node-type', 'Combined'])
 
     try:
-        return master.sr_create('linstor', 'LINSTOR-SR', {
+        return master.sr_create('linstor', 'LINSTOR-SR-test', {
             'hosts': ','.join([host.hostname() for host in hosts_with_linstor]),
             'group-name': GROUP_NAME,
             'redundancy': len(hosts_with_linstor),

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -21,7 +21,7 @@ class TestLinstorSRCreateDestroy:
         assert not master.binary_exists('linstor'), \
             "linstor must not be installed on the host at the beginning of the tests"
         try:
-            sr = master.sr_create('linstor', 'LINSTOR-SR', {
+            sr = master.sr_create('linstor', 'LINSTOR-SR-test', {
                 'hosts': ','.join([host.hostname() for host in hosts]),
                 'group-name': GROUP_NAME,
                 'redundancy': len(hosts),

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.fixture(scope='session')
 def lvm_sr(host, sr_disk):
     """ An LVM SR on first host. """
-    sr = host.sr_create('lvm', "LVM-local-SR", {'device': '/dev/' + sr_disk})
+    sr = host.sr_create('lvm', "LVM-local-SR-test", {'device': '/dev/' + sr_disk})
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -13,11 +13,11 @@ class TestLVMSRCreateDestroy:
     """
 
     def test_create_sr_with_missing_device(self, host):
-        try_to_create_sr_with_missing_device('lvm', 'LVM-local-SR', host)
+        try_to_create_sr_with_missing_device('lvm', 'LVM-local-SR-test', host)
 
     def test_create_and_destroy_sr(self, host, sr_disk):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('lvm', "LVM-local-SR", {'device': '/dev/' + sr_disk}, verify=True)
+        sr = host.sr_create('lvm', "LVM-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -21,7 +21,7 @@ def lvmoiscsi_device_config(sr_device_config):
 @pytest.fixture(scope='session')
 def lvmoiscsi_sr(host, lvmoiscsi_device_config):
     """ A lvmoiscsi SR on first host. """
-    sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR", lvmoiscsi_device_config, shared=True)
+    sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test", lvmoiscsi_device_config, shared=True)
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -14,7 +14,7 @@ class TestLVMOISCSISRCreateDestroy:
 
     def test_create_and_destroy_sr(self, host, lvmoiscsi_device_config):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR", lvmoiscsi_device_config, shared=True, verify=True)
+        sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test", lvmoiscsi_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -21,7 +21,7 @@ def nfs_device_config(sr_device_config):
 @pytest.fixture(scope='session')
 def nfs_sr(host, nfs_device_config):
     """ A NFS SR on first host. """
-    sr = host.sr_create('nfs', "NFS-SR", nfs_device_config, shared=True)
+    sr = host.sr_create('nfs', "NFS-SR-test", nfs_device_config, shared=True)
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -7,7 +7,7 @@ from lib.common import wait_for, vm_image
 class TestNFSSRCreateDestroy:
     def test_create_and_destroy_sr(self, host, sr_disk, nfs_device_config):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('nfs', "NFS-SR", nfs_device_config, shared=True, verify=True)
+        sr = host.sr_create('nfs', "NFS-SR-test", nfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_nfs fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -14,7 +14,7 @@ def host_with_xfsprogs(host):
 @pytest.fixture(scope='session')
 def xfs_sr(sr_disk, host_with_xfsprogs):
     """ A XFS SR on first host. """
-    sr = host_with_xfsprogs.sr_create('xfs', "XFS-local-SR", {'device': '/dev/' + sr_disk})
+    sr = host_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk})
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -22,7 +22,7 @@ class TestXFSSRCreateDestroy:
             "xfsprogs must not be installed on the host at the beginning of the tests"
         sr = None
         try:
-            sr = host.sr_create('xfs', "XFS-local-SR", {'device': '/dev/' + sr_disk})
+            sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk})
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:
@@ -32,7 +32,7 @@ class TestXFSSRCreateDestroy:
     def test_create_and_destroy_sr(self, sr_disk, host_with_xfsprogs):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         host = host_with_xfsprogs
-        sr = host.sr_create('xfs', "XFS-local-SR", {'device': '/dev/' + sr_disk}, verify=True)
+        sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -25,7 +25,7 @@ def zpool_vol0(sr_disk_wiped, host_with_zfs):
 @pytest.fixture(scope='session')
 def zfs_sr(host, zpool_vol0):
     """ A ZFS SR on first host. """
-    sr = host.sr_create('zfs', "ZFS-local-SR", {'location': VOLUME_PATH})
+    sr = host.sr_create('zfs', "ZFS-local-SR-test", {'location': VOLUME_PATH})
     yield sr
     # teardown
     sr.destroy()

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -24,7 +24,7 @@ class TestZFSSRCreateDestroy:
             "zfs must not be installed on the host at the beginning of the tests"
         sr = None
         try:
-            sr = host.sr_create('zfs', "ZFS-local-SR", {'location': VOLUME_PATH})
+            sr = host.sr_create('zfs', "ZFS-local-SR-test", {'location': VOLUME_PATH})
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:
@@ -34,7 +34,7 @@ class TestZFSSRCreateDestroy:
     @pytest.mark.usefixtures("zpool_vol0")
     def test_create_and_destroy_sr(self, host):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('zfs', "ZFS-local-SR", {'location': VOLUME_PATH}, verify=True)
+        sr = host.sr_create('zfs', "ZFS-local-SR-test", {'location': VOLUME_PATH}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
         # the next tests, because errors in fixtures break teardown
         vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)


### PR DESCRIPTION
I've seen cases when a test adds a SR with the same name as an already
existing SR that is not related to the tests. For some reason I then had
to manually remove the added SR after a test failure, and it was
confusing to have two SRs with the same name.

Add a -test suffix to the SR names created in our storage tests.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>