### PR TITLE
Modify command pesign to add force option

### DIFF
--- a/lib/efi.py
+++ b/lib/efi.py
@@ -284,7 +284,7 @@ def pesign(key, cert, name, image):
 
         # Sign the image
         commands.local_cmd([
-            'pesign', '-n', certdir, '-c', common_name, '-s', '-i', image,
+            'pesign', '-f', '-n', certdir, '-c', common_name, '-s', '-i', image,
             '-o', signed
         ])
 


### PR DESCRIPTION
We modify the pesign command to add the force (-f) option.
Without it, pesign refuse to overwrite any output files
which already exist.

Signed-off-by: Gael Duperrey <gduperrey@vates.fr>