### PR TITLE
Fix copy-pasted comments in tests/storage/storage.py

### DIFF
--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -22,7 +22,7 @@ def cold_migration_then_come_back(vm, prov_host, prov_sr, dest_host, dest_sr):
     vm.start()
     vm.wait_for_os_booted()
     vm.shutdown(verify=True)
-    # Migrate it back to the first host on XFS SR
+    # Migrate it back to the provenance SR
     vm.migrate(prov_host, prov_sr)
     wait_for(lambda: vm.all_vdis_on_host(prov_host), "Wait for all VDIs back on provenance host")
     # Start VM to make sure it works
@@ -38,7 +38,7 @@ def live_storage_migration_then_come_back(vm, prov_host, prov_sr, dest_host, des
     vm.migrate(dest_host, dest_sr)
     wait_for(lambda: vm.all_vdis_on_host(dest_host), "Wait for all VDIs on destination host")
     wait_for(lambda: vm.is_running_on_host(dest_host), "Wait for VM to be running on destination host")
-    # Migrate it back to the first host on XFS SR
+    # Migrate it back to the provenance SR
     vm.migrate(prov_host, prov_sr)
     wait_for(lambda: vm.all_vdis_on_host(prov_host), "Wait for all VDIs back on provenance host")
     wait_for(lambda: vm.is_running_on_host(prov_host), "Wait for VM to be running on provenance host")


### PR DESCRIPTION
Functions that were extracted from the XFS storage tests should not
mention XFS anymore. Fix that.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>