### PR TITLE
Detect NVMe disks, not just SATA disks

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -295,8 +295,8 @@ class Host:
         return self.xe('network-list', {'bridge': self.inventory['MANAGEMENT_INTERFACE']}, minimal=True)
 
     def disks(self):
-        """ List of SCSI disks, e.g ['sda', 'sdb']. """
-        disks = self.ssh(['lsblk', '-nd', '-I', '8', '--output', 'NAME']).splitlines()
+        """ List of SCSI disks, e.g ['sda', 'sdb', 'nvme0n1']. """
+        disks = self.ssh(['lsblk', '-nd', '-I', '8,259', '--output', 'NAME']).splitlines()
         disks.sort()
         return disks
 


### PR DESCRIPTION
NVMe devices are currently ignored due to the "-I 8" option we pass to lsblk.

The major number for NVMe devices is 259, add it to the filter.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>