### PR TITLE
Make sure `PK.auth` is never missing

### DIFF
--- a/lib/pool.py
+++ b/lib/pool.py
@@ -1,5 +1,7 @@
 import logging
 
+from packaging import version
+
 import lib.commands as commands
 
 from lib.common import safe_split, wait_for, wait_for_not
@@ -105,9 +107,10 @@ class Pool:
     def clear_uefi_certs(self):
         logging.info('Clearing pool UEFI certificates in XAPI and on hosts disks')
         self.master.ssh(['secureboot-certs', 'clear'])
-        # remove files on each host
-        for host in self.hosts:
-            host.ssh(['rm', '-f', '/var/lib/uefistored/*'])
+        # remove files on each host on XCP-ng < 8.3
+        if self.master.xcp_version < version.parse("8.3"):
+            for host in self.hosts:
+                host.ssh(['rm', '-f', '/var/lib/uefistored/*'])
 
     def install_custom_uefi_certs(self, auths):
         host = self.master

--- a/tests/uefistored/test_cert_inheritance.py
+++ b/tests/uefistored/test_cert_inheritance.py
@@ -331,7 +331,7 @@ class TestPoolToDiskCertPropagationToAllHosts:
         vm, snapshot = uefi_vm_and_snapshot
         for h in host.pool.hosts:
             logging.info(f"Check host {h} has no certificate on disk except PK.")
-            # Make sure PK has been fetched from fallback dir so none SB UEFI VMs can still be booted
+            # Make sure PK has been fetched from fallback dir so UEFI VMs without certs can still be booted
             assert h.file_exists(f'{CERT_DIR}/PK.auth')
             for key in ['KEK', 'db', 'dbx']:
                 assert not h.file_exists(f'{CERT_DIR}/{key}.auth')


### PR DESCRIPTION
Test that if XAPI clear UEFI certificates `PK.auth` is fetched from a fallback dir

See: https://github.com/xapi-project/xen-api/pull/4696

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>