### PR TITLE
Don't add options -s and -v to pytest calls by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra -sv
+addopts = -ra
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.


### PR DESCRIPTION
They used to be useful to display the output of the tests while they
were executing, but since we switched to using the logging module, they
became useless.

In addition to this, the added `-v` switch forced us to add an extra `-q`
when we want the quiet ouput of a command.
For example: `pytest --collect-only -qq` instead of `pytest --collect-only -q`

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>