### PR TITLE
Initialize xxx_device_config fixtures before installing extra RPMs

### DIFF
--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -30,7 +30,7 @@ class TestCephFSSRCreateDestroy:
             sr.destroy()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host, pool_with_ceph, cephfs_device_config):
+    def test_create_and_destroy_sr(self, host, cephfs_device_config, pool_with_ceph):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -29,7 +29,7 @@ class TestGlusterFSSRCreateDestroy:
             sr.destroy()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host, pool_with_glusterfs, gluster_volume_started, glusterfs_device_config):
+    def test_create_and_destroy_sr(self, host, glusterfs_device_config, pool_with_glusterfs, gluster_volume_started):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_glusterfs_fixture used in

--- a/tests/storage/moosefs/test_moosefs_sr.py
+++ b/tests/storage/moosefs/test_moosefs_sr.py
@@ -30,7 +30,7 @@ class TestMooseFSSRCreateDestroy:
             sr.destroy()
             assert False, "MooseFS SR creation should failed!"
 
-    def test_create_and_destroy_sr(self, pool_with_moosefs, moosefs_device_config):
+    def test_create_and_destroy_sr(self, moosefs_device_config, pool_with_moosefs):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         master = pool_with_moosefs.master
         sr = master.sr_create('moosefs', "MooseFS-SR-test2", moosefs_device_config, shared=True, verify=True)


### PR DESCRIPTION
We want the tests to fail immediately if the configuration is missing,
not after installing a lot of things to the host(s).

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>