### PR TITLE
Stop at first failure by default.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra
+addopts = -ra --maxfail=1
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.


### PR DESCRIPTION
The setup of tests is often complex and it's rarely good to let the test
suite continue its execution after a failure (especially if it's a
teardown failure).

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>