### PR TITLE
Add the -s parameter back, necessary for SSH output in debug logs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --maxfail=1
+addopts = -ra --maxfail=1 -s
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.


### PR DESCRIPTION
Contrarily to logs output through the logging module, SSH output is
captured by pytest, so --log-cli-level=debug doesn't display the output
anymore (it's displayed in cases or errors, but separate from other logs
so it's difficult to interpret).

Add the -s parameter back to disable output capture by pytest.

This does not solve everything: command output won't be repeated in the
captured logs in case of test failure, but this was already the case
before I removed the -s parameter.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>