### PR TITLE
In SR tests, start the VM on the host that rebooted

### DIFF
--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -69,7 +69,7 @@ class TestCephFSSR:
         host.reboot(verify=True)
         wait_for(sr.all_pbds_attached, "Wait for PDB attached")
         # start the VM as a way to check that the underlying SR is operational
-        vm.start()
+        vm.start(on=host.uuid)
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -87,7 +87,7 @@ class TestGlusterFSSR:
         host.reboot(verify=True)
         wait_for(sr.all_pbds_attached, "Wait for PDB attached")
         # start the VM as a way to check that the underlying SR is operational
-        vm.start()
+        vm.start(on=host.uuid)
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -74,7 +74,7 @@ class TestLinstorSR:
         host.reboot(verify=True)
         wait_for(sr.all_pbds_attached, "Wait for PDB attached")
         # start the VM as a way to check that the underlying SR is operational
-        vm.start()
+        vm.start(on=host.uuid)
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -51,7 +51,7 @@ class TestLVMOISCSISR:
         host.reboot(verify=True)
         wait_for(sr.all_pbds_attached, "Wait for PDB attached")
         # start the VM as a way to check that the underlying SR is operational
-        vm.start()
+        vm.start(on=host.uuid)
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -43,7 +43,7 @@ class TestNFSSR:
         host.reboot(verify=True)
         wait_for(sr.all_pbds_attached, "Wait for PDB attached")
         # start the VM as a way to check that the underlying SR is operational
-        vm.start()
+        vm.start(on=host.uuid)
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 


### PR DESCRIPTION
We want to assess that the SR works on the very host that we rebooted.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>