### PR TITLE
Rename VM list "multi/windows" into "multi/uefi_windows"

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -155,7 +155,7 @@ JOBS = {
         ],
         "nb_pools": 1,
         "params": {
-            "--vm[]": "multi/windows",
+            "--vm[]": "multi/uefi_windows",
         },
         "paths": ["tests/uefistored"],
         "markers": "multi_vms and windows_vm",

--- a/vm_data.py-dist
+++ b/vm_data.py-dist
@@ -21,7 +21,7 @@ VMS = {
         "tools_unix": [],
         # UEFI unix/linux Vms
         "uefi_unix": [],
-        # Windows VMs
-        "windows": [],
+        # UEFI Windows VMs
+        "uefi_windows": [],
     }
 }


### PR DESCRIPTION
The VMs in this list must be UEFI Windows VMs as we test Secure Boot on
them. As there may also be Windows VMs in other lists, let's use an
unambiguous name.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>