### PR TITLE
Remove xcp-ng-staging from set_proxies test

### DIFF
--- a/tests/xapi-plugins/plugin_updater/test_updater.py
+++ b/tests/xapi-plugins/plugin_updater/test_updater.py
@@ -31,8 +31,7 @@ class TestProxies:
         set_proxies = '{' \
             '"xcp-ng-base": "_none_", ' \
             '"xcp-ng-updates": "_none_", ' \
-            '"xcp-ng-testing": "_none_", ' \
-            '"xcp-ng-staging": "_none_"' \
+            '"xcp-ng-testing": "_none_" ' \
             '}'
         host.call_plugin('updater.py', 'set_proxies', {"proxies": set_proxies})
 


### PR DESCRIPTION
It's not present in yum's configuration by default and thus makes the
test fail.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>