### PR TITLE
Remove broken set_proxies test and improve get_proxies test

### DIFF
--- a/tests/xapi-plugins/plugin_updater/test_updater.py
+++ b/tests/xapi-plugins/plugin_updater/test_updater.py
@@ -21,22 +21,6 @@ class TestUpdate:
 
 class TestProxies:
     def test_get_proxies(self, host):
-        host.call_plugin('updater.py', 'get_proxies')
-
-    # TODO: test more set with URLs etc and trigger errors
-
-    def test_set_proxies(self, host):
-        proxies = host.call_plugin('updater.py', 'get_proxies')
-
-        set_proxies = '{' \
-            '"xcp-ng-base": "_none_", ' \
-            '"xcp-ng-updates": "_none_", ' \
-            '"xcp-ng-testing": "_none_" ' \
-            '}'
-        host.call_plugin('updater.py', 'set_proxies', {"proxies": set_proxies})
-
-        res = host.call_plugin('updater.py', 'get_proxies')
-        assert json.loads(res) == json.loads(set_proxies)
-
-        host.call_plugin('updater.py', 'set_proxies', {"proxies": proxies})
-        assert json.loads(res) == json.loads(proxies)
+        proxies = json.loads(host.call_plugin('updater.py', 'get_proxies'))
+        for repo in 'xcp-ng-base', 'xcp-ng-testing', 'xcp-ng-updates':
+            assert repo in proxies


### PR DESCRIPTION
The set_proxies test doesn't really test much currently as it only
attempts to remove repo proxies when hosts already don't have any proxies
set. The way it is implemented makes the test fail as soon as the list
of repositories in xcp-ng.repo is different from what is installed by
default, and attempting to improve the test reveals that set_proxies
doesn't have any practical use at the moment (setting a proxy will only
work if the repo URL is formatted in a special way that is specific to
apt-cacher-ng.

Let's remove the test altogether and add one back when/if the feature
becomes used by XO.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>