### PR TITLE
Avoid host crashes when running XTF's XSA 304 POC

### DIFF
--- a/tests/xtf/conftest.py
+++ b/tests/xtf/conftest.py
@@ -12,6 +12,19 @@ def host_with_hvm_fep(host):
     yield host
 
 @pytest.fixture(scope="package")
+def host_with_dynamically_disabled_ept_sp(host):
+    """
+    Disable EPT superpages before running XTF.
+
+    The XSA-304 POC will crash hosts with vulnerable hardware if EPT SP are enabled.
+    """
+    logging.info("Switching EPT superpages to secure")
+    host.ssh(['xl', 'set-parameters', 'ept=no-exec-sp'])
+    yield host
+    logging.info("Switching back EPT superpages to fast")
+    host.ssh(['xl', 'set-parameters', 'ept=exec-sp'])
+
+@pytest.fixture(scope="package")
 def host_with_git_and_gcc(host_with_saved_yum_state):
     host = host_with_saved_yum_state
     host.yum_install(['git', 'gcc'])

--- a/tests/xtf/test_xtf.py
+++ b/tests/xtf/test_xtf.py
@@ -8,7 +8,7 @@ from lib.commands import SSHCommandFailed
 # - host: XCP-ng host >= 8.2, with Xen booted with the hvm_fep command line parameter
 #         See https://xenbits.xen.org/docs/xtf/
 
-@pytest.mark.usefixtures("host_with_hvm_fep")
+@pytest.mark.usefixtures("host_with_hvm_fep", "host_with_dynamically_disabled_ept_sp")
 class TestXtf:
     _common_skips = [
         'test-hvm32-umip',


### PR DESCRIPTION
We want other tests to run even if a host hardware is vulnerable to XSA-304, so we change Xen's `ept` parameter "live" before running XTF.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

UNTESTED: CC @gduperrey.