### PR TITLE
Test `VIF`'s allowed IP

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -23,6 +23,7 @@ JOBS = {
         "paths": [
             "tests/misc",
             "tests/migration",
+            "tests/network",
             "tests/snapshot",
             "tests/xapi",
             "tests/xapi-plugins",

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -2,7 +2,7 @@ import logging
 
 import lib.commands as commands
 
-from lib.common import _param_get
+from lib.common import _param_get, _param_remove, _param_set
 from lib.sr import SR
 
 class BaseVM:
@@ -15,29 +15,13 @@ class BaseVM:
         self.host = host
 
     def param_get(self, param_name, key=None, accept_unknown_key=False):
-        return _param_get(self.host, self.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+        return _param_get(self.host, BaseVM.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
     def param_set(self, param_name, key, value):
-        args = {'uuid': self.uuid}
+        _param_set(self.host, BaseVM.xe_prefix, self.uuid, param_name, value, key)
 
-        if key is not None:
-            param_name = '{}:{}'.format(param_name, key)
-
-        args[param_name] = value
-
-        return self.host.xe('vm-param-set', args)
-
-    def param_remove(self, param_name, key=None, accept_unknown_key=False):
-        args = {'uuid': self.uuid, 'param-name': param_name}
-        if key is not None:
-            args['param-key'] = key
-        try:
-            self.host.xe('vm-param-remove', args)
-        except commands.SSHCommandFailed as e:
-            if key and accept_unknown_key and e.stdout == "Error: Key %s not found in map" % key:
-                pass
-            else:
-                raise
+    def param_remove(self, param_name, key, accept_unknown_key=False):
+        _param_remove(self.host, BaseVM.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
     def name(self):
         return self.param_get('name-label')

--- a/lib/common.py
+++ b/lib/common.py
@@ -153,3 +153,35 @@ def _param_get(host, xe_prefix, uuid, param_name, key=None, accept_unknown_key=F
         else:
             raise
     return value
+
+def _param_set(host, xe_prefix, uuid, param_name, value, key=None):
+    """ Common implementation for param_set. """
+    args = {'uuid': uuid}
+
+    if key is not None:
+        param_name = '{}:{}'.format(param_name, key)
+
+    args[param_name] = value
+
+    host.xe(f'{xe_prefix}-param-set', args)
+
+def _param_add(host, xe_prefix, uuid, param_name, value, key=None):
+    """ Common implementation for param_add. """
+    param_key = f'{key}={value}' if key is not None else value
+    args = {'uuid': uuid, 'param-name': param_name, 'param-key': param_key}
+
+    host.xe(f'{xe_prefix}-param-add', args)
+
+def _param_remove(host, xe_prefix, uuid, param_name, key, accept_unknown_key=False):
+    """ Common implementation for param_remove. """
+    args = {'uuid': uuid, 'param-name': param_name, 'param-key': key}
+    try:
+        host.xe(f'{xe_prefix}-param-remove', args)
+    except commands.SSHCommandFailed as e:
+        if not accept_unknown_key or e.stdout != "Error: Key %s not found in map" % key:
+            raise
+
+def _param_clear(host, xe_prefix, uuid, param_name):
+    """ Common implementation for param_clear. """
+    args = {'uuid': uuid, 'param-name': param_name}
+    host.xe(f'{xe_prefix}-param-clear', args)

--- a/lib/host.py
+++ b/lib/host.py
@@ -88,7 +88,7 @@ class Host:
         return result
 
     def param_get(self, param_name, key=None, accept_unknown_key=False):
-        return _param_get(self, self.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+        return _param_get(self, Host.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
     def create_file(self, filename, text):
         with tempfile.NamedTemporaryFile('w') as file:

--- a/lib/vif.py
+++ b/lib/vif.py
@@ -1,6 +1,6 @@
 import lib.commands as commands
 
-from lib.common import _param_get
+from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set
 
 class VIF:
     xe_prefix = "vif"
@@ -11,6 +11,18 @@ class VIF:
 
     def param_get(self, param_name, key=None, accept_unknown_key=False):
         return _param_get(self.vm.host, VIF.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+
+    def param_set(self, param_name, value, key=None):
+        _param_set(self.vm.host, VIF.xe_prefix, self.uuid, param_name, value, key)
+
+    def param_add(self, param_name, value, key=None):
+        _param_add(self.vm.host, VIF.xe_prefix, self.uuid, param_name, value, key)
+
+    def param_clear(self, param_name):
+        _param_clear(self.vm.host, VIF.xe_prefix, self.uuid, param_name)
+
+    def param_remove(self, param_name, key, accept_unknown_key=False):
+        _param_remove(self.vm.host, VIF.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
     def device_id(self):
         """ Build the identifier that will allow to grep for the VIF's interrupts. """

--- a/lib/vif.py
+++ b/lib/vif.py
@@ -10,7 +10,7 @@ class VIF:
         self.vm = vm
 
     def param_get(self, param_name, key=None, accept_unknown_key=False):
-        return _param_get(self.vm.host, self.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+        return _param_get(self.vm.host, VIF.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
     def device_id(self):
         """ Build the identifier that will allow to grep for the VIF's interrupts. """

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.fixture(scope='package')
+def host_no_sdn_controller(host):
+    """ An XCP-ng with no SDN controller. """
+    if host.xe('sdn-controller-list', minimal=True):
+        pytest.skip(f"This test requires an XCP-ng with no SDN controller")

--- a/tests/network/test_vif_allowed_ip.py
+++ b/tests/network/test_vif_allowed_ip.py
@@ -1,0 +1,88 @@
+import ipaddress
+import os
+import pytest
+
+# Requirements:
+# - one XCP-ng host (--host) >= 8.2 (>= 8.3 for the CIDR tests) with no SDN controller configured
+# - a VM (--vm)
+
+def ip_responsive(ip):
+    return not os.system(f"ping -c 3 -W 10 {ip} > /dev/null 2>&1")
+
+@pytest.mark.small_vm
+@pytest.mark.usefixtures("host_no_sdn_controller")
+class TestAllowedIP:
+    def test_unallowed_ip(self, running_vm):
+        vm = running_vm
+        vif = vm.vifs()[0]
+        ip = vm.ip
+        ip_address = ipaddress.ip_address(ip)
+        ip_family = ip_address.version
+        dummy_ip = str(ip_address + 1)
+        assert ip_responsive(ip)
+
+        vif.param_add(f"ipv{ip_family}-allowed", dummy_ip)
+        vif.param_set("locking-mode", "locked")
+        assert not ip_responsive(ip)
+
+        vif.param_clear(f"ipv{ip_family}-allowed")
+        vif.param_set("locking-mode", "unlocked")
+
+    def test_allowed_ip(self, running_vm):
+        vm = running_vm
+        vif = vm.vifs()[0]
+        ip = vm.ip
+        ip_address = ipaddress.ip_address(ip)
+        ip_family = ip_address.version
+
+        vif.param_clear(f"ipv{ip_family}-allowed")
+        vif.param_set("locking-mode", "locked")
+        assert not ip_responsive(ip)
+
+        vif.param_add(f"ipv{ip_family}-allowed", ip)
+        assert ip_responsive(ip)
+
+        vif.param_remove(f"ipv{ip_family}-allowed", ip)
+        assert not ip_responsive(ip)
+
+        vif.param_set("locking-mode", "unlocked")
+
+@pytest.mark.small_vm
+@pytest.mark.usefixtures("host_at_least_8_3", "host_no_sdn_controller")
+class TestAllowedCIDR:
+    def test_unallowed_cidr(self, running_vm):
+        vm = running_vm
+        vif = vm.vifs()[0]
+        ip = vm.ip
+        ip_address = ipaddress.ip_address(ip)
+        ip_family = ip_address.version
+        lo = "127.0.0.1" if ip_family == 4 else "::1"
+        dummy_cidr = f'{lo}/24'
+        assert ip_responsive(ip)
+
+        vif.param_add(f"ipv{ip_family}-allowed", dummy_cidr)
+        vif.param_set("locking-mode", "locked")
+        assert not ip_responsive(ip)
+
+        vif.param_clear(f"ipv{ip_family}-allowed")
+        vif.param_set("locking-mode", "unlocked")
+
+    def test_allowed_cidr(self, running_vm):
+        vm = running_vm
+        vif = vm.vifs()[0]
+        ip = vm.ip
+        ip_address = ipaddress.ip_address(ip)
+        ip_family = ip_address.version
+        cidr = f'{ip}/24'
+
+        vif.param_clear(f"ipv{ip_family}-allowed")
+        vif.param_set("locking-mode", "locked")
+        assert not ip_responsive(ip)
+
+        vif.param_add(f"ipv{ip_family}-allowed", cidr)
+        assert ip_responsive(ip)
+
+        vif.param_remove(f"ipv{ip_family}-allowed", cidr)
+        assert not ip_responsive(ip)
+
+        vif.param_set("locking-mode", "unlocked")


### PR DESCRIPTION
- Skip tests on XCP-ng hosts with a SDN controller configured
- Test allowed IP range with CIDR for XCP-ng >= 8.3