### PR TITLE
Change URLs for the GPG-key and repo file for Moosefs

### DIFF
--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -7,8 +7,8 @@ from pkgfixtures import pool_with_saved_yum_state
 def install_moosefs(host):
     assert not host.file_exists('/usr/sbin/mount.moosefs'), \
         "MooseFS client should not be installed on the host before all tests"
-    host.ssh(['curl https://ppa.moosefs.com/RPM-GPG-KEY-MooseFS > /etc/pki/rpm-gpg/RPM-GPG-KEY-MooseFS'])
-    host.ssh(['curl http://ppa.moosefs.com/MooseFS-3-el7.repo > /etc/yum.repos.d/MooseFS.repo'])
+    host.ssh(['curl https://repository.moosefs.com/RPM-GPG-KEY-MooseFS > /etc/pki/rpm-gpg/RPM-GPG-KEY-MooseFS'])
+    host.ssh(['curl http://repository.moosefs.com/MooseFS-3-el7.repo > /etc/yum.repos.d/MooseFS.repo'])
     host.yum_install(['fuse', 'moosefs-client'])
 
 def uninstall_moosefs_repo(host):


### PR DESCRIPTION
The URLs for the GPG key and the repo file have changed on the Moosefs side. We update thooses urls to adapt.