### PR TITLE
Add xo-cli version check and --json to xo-cli calls

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import re
 import pytest
 import tempfile
 
@@ -85,32 +83,7 @@ def pytest_addoption(parser):
              "Set it to 'auto' to let the fixtures auto-detect available disks."
     )
 
-def check_xo_cli_version():
-    try:
-        output = subprocess.check_output(['xo-cli', '--help'])
-    except FileNotFoundError:
-        pytest.exit("Could not find xo-cli in path")
-    lines = output.splitlines()
-    for line in lines:
-        line = line.decode('utf-8')
-        if not line.startswith("xo-cli "):
-            continue
-        match = re.match(rf"{re.escape('xo-cli')}\s+v(\d+)\.(\d+)\.(\d+)", line)
-
-        if match is None:
-            continue
-
-        major, minor, patch = map(int, match.groups())
-        if major <= 0 and minor < 17:
-            pytest.exit(f"Expected xo-cli >= v0.17.0, found v{major}.{minor}.{patch}".format(), 1)
-        else:
-            return
-
-    pytest.exit("Could not find xo-cli version", 1)
-
-
 def pytest_configure(config):
-    check_xo_cli_version()
     global_config.ignore_ssh_banner = config.getoption('--ignore-ssh-banner')
     global_config.ssh_output_max_lines = int(config.getoption('--ssh-output-max-lines'))
 

--- a/lib/xo.py
+++ b/lib/xo.py
@@ -3,7 +3,7 @@ import subprocess
 
 def xo_cli(action, args={}, check=True, simple_output=True):
     res = subprocess.run(
-        ['xo-cli', action] + ["%s=%s" % (key, value) for key, value in args.items()],
+        ['xo-cli', action, '--json'] + ["%s=%s" % (key, value) for key, value in args.items()],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         check=check


### PR DESCRIPTION
- checks xo-cli is available
- ensure version is > v0.17.0 as --json was added with this version
- adds the --json parameter to xo-cli calls

Originally xo-cli output was in json, then it moved to more human
readable output by default. In v0.17.0 --json option allows users to
choose between the more readable and the json output. Versions in
between are not compatible with xcp-ng-tests at all, therefore, we
enfore at least v0.17.0.
