### PR TITLE
Add --json to xo-cli calls when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Note: this is a perpertual work in progress. If you encounter any obstacles or b
 ## Main requirements
 * python >= 3.5
 * pytest >= 5.4 (python3 version)
-* xo-cli installed, in the PATH, and registered to an instance of XO that will be used during the tests
+* xo-cli >= 0.17.0 installed, in the PATH, and registered to an instance of XO that will be used during the tests
 
 ### Quick install (python requirements)
 

--- a/lib/host.py
+++ b/lib/host.py
@@ -136,7 +136,7 @@ class Host:
         return inventory
 
     def xo_get_server_id(self, store=True):
-        servers = json.loads(xo_cli('server.getAll'))
+        servers = xo_cli('server.getAll', use_json=True)
         for server in servers:
             if server['host'] == self.hostname_or_ip:
                 if store:
@@ -148,7 +148,7 @@ class Host:
         if self.xo_srv_id is not None:
             xo_cli('server.remove', {'id': self.xo_srv_id})
         else:
-            servers = json.loads(xo_cli('server.getAll'))
+            servers = xo_cli('server.getAll', use_json=True)
             for server in servers:
                 if server['host'] == self.hostname_or_ip:
                     xo_cli('server.remove', {'id': server['id']})
@@ -172,7 +172,7 @@ class Host:
         self.xo_srv_id = xo_srv_id
 
     def xo_server_status(self):
-        servers = json.loads(xo_cli('server.getAll'))
+        servers = xo_cli('server.getAll', use_json=True)
         for server in servers:
             if server['host'] == self.hostname_or_ip:
                 return server['status']

--- a/lib/xo.py
+++ b/lib/xo.py
@@ -1,17 +1,23 @@
 import json
 import subprocess
 
-def xo_cli(action, args={}, check=True, simple_output=True):
+def xo_cli(action, args={}, check=True, simple_output=True, use_json=False):
+    run_array = ['xo-cli', action]
+    if use_json:
+        run_array += ['--json']
+    run_array += ["%s=%s" % (key, value) for key, value in args.items()]
     res = subprocess.run(
-        ['xo-cli', action] + ["%s=%s" % (key, value) for key, value in args.items()],
+        run_array,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         check=check
     )
     if simple_output:
-        return res.stdout.decode().strip()
-    else:
-        return res
+        output = res.stdout.decode().strip()
+        if use_json:
+            return json.loads(output)
+        return output
+    return res
 
 def xo_object_exists(uuid):
     lst = json.loads(xo_cli('--list-objects', {'uuid': uuid}))


### PR DESCRIPTION
Originally xo-cli output was in json, then it moved to more human
readable output by default. In v0.17.0 --json option allows users to
choose between the more readable and the json output. Versions in
between are not compatible with xcp-ng-tests at all, therefore, we
now need at least v0.17.0.
