### PR TITLE
Add a new test to check that extras pkgs can be installed

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -275,7 +275,7 @@ class Host:
     def yum_install(self, packages, enablerepo=None):
         logging.info('Install packages: %s on host %s' % (' '.join(packages), self))
         enablerepo_cmd = ['--enablerepo=%s' % enablerepo] if enablerepo is not None else []
-        return self.ssh(['yum', 'install', '-y'] + enablerepo_cmd + packages)
+        return self.ssh(['yum', 'install', '--setopt=skip_missing_names_on_install=False', '-y'] + enablerepo_cmd + packages)
 
     def yum_remove(self, packages):
         logging.info('Remove packages: %s from host %s' % (' '.join(packages), self))

--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -1,0 +1,12 @@
+import logging
+import pytest
+import urllib.request
+
+@pytest.fixture(scope="session")
+def extra_pkgs(host):
+    version = host.xcp_version
+    url = f"https://reports.xcp-ng.org/{version}/extra_installable.txt"
+
+    logging.info(f"Getting extra packages from {url}")
+    response = urllib.request.urlopen(url)
+    return response.read().decode('utf-8').splitlines()

--- a/tests/packages/extra/test_extra_group_pkgs.py
+++ b/tests/packages/extra/test_extra_group_pkgs.py
@@ -1,0 +1,11 @@
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
+from pkgfixtures import host_with_saved_yum_state
+
+def test_extra_group_packages_url_resolved(host, extra_pkgs):
+    for p in extra_pkgs:
+        host.ssh(['yumdownloader', '--resolve', '--urls', p])
+        
+def test_extra_group_packages_can_be_installed(host_with_saved_yum_state, extra_pkgs):
+    # Just try to install all packages together. Installing them one by one
+    # takes too much time due to the generation of the initrd.
+    host_with_saved_yum_state.yum_install(extra_pkgs)


### PR DESCRIPTION
This test gets a list of packages from
https://reports.xcp-ng.org/<xcp-ng-version>/extra_installable.txt and check that all packages can be installed. It saves the yum state before installing the package and restore it after.