### PR TITLE
Ignore stdout/stderr messages before "yum history list"

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -272,10 +272,19 @@ class Host:
             history_str = self.ssh(['yum', 'history', 'list', '--noplugins'])
 
         history = history_str.splitlines()
+        line_index = None
+        for i in range(len(history)):
+            if history[i].startswith('--------'):
+                line_index = i
+                break
+
+        if line_index is None:
+            raise Exception('Unable to get yum transactions')
+
         try:
-            return int(history[2].split()[0])
+            return int(history[line_index + 1].split()[0])
         except ValueError:
-            raise Exception('Unable to parse correctly last yum history tid. Output\n:' + history_str)
+            raise Exception('Unable to parse correctly last yum history tid. Output:\n' + history_str)
 
     def yum_install(self, packages, enablerepo=None):
         logging.info('Install packages: %s on host %s' % (' '.join(packages), self))


### PR DESCRIPTION
Yum stderr logs as "Warning: RPMDB modified outside of yum." are appended to the SSH output which completely breaks the history parsing. To solve this problem, we need to skip all log lines before transactions.