### PR TITLE
Change test fsp for another repo and better teardown

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -97,13 +97,15 @@ class Host:
             file.flush()
             self.scp(file.name, filename)
 
-    def add_xcpng_repo(self, name):
+    def add_xcpng_repo(self, name, base_repo='xcp-ng'):
+        assert base_repo in ['xcp-ng', 'vates']
+        base_repo_url = 'http://mirrors.xcp-ng.org/' if base_repo == 'xcp-ng' else 'https://repo.vates.tech/xcp-ng/'
         major = self.xcp_version.major
         version = self.xcp_version_short
         self.create_file(f"/etc/yum.repos.d/xcp-ng-{name}.repo", (
             f"[xcp-ng-{name}]\n"
             f"name=XCP-ng {name} Repository\n"
-            f"baseurl=http://mirrors.xcp-ng.org/{major}/{version}/{name}/x86_64/ http://updates.xcp-ng.org/{major}/{version}/{name}/x86_64/\n" # noqa
+            f"baseurl={base_repo_url}/{major}/{version}/{name}/x86_64/\n"
             "enabled=1\n"
             "gpgcheck=1\n"
             "repo_gpgcheck=1\n"

--- a/tests/storage/fsp/conftest.py
+++ b/tests/storage/fsp/conftest.py
@@ -7,7 +7,7 @@ FSP_PACKAGES = ['xcp-ng-xapi-storage']
 DIRECTORIES_PATH = 'directories'
 
 def install_fsp(host):
-    host.add_xcpng_repo(FSP_REPO_NAME)
+    host.add_xcpng_repo(FSP_REPO_NAME, 'vates')
     host.yum_save_state()
     host.yum_install(FSP_PACKAGES)
 

--- a/tests/storage/fsp/conftest.py
+++ b/tests/storage/fsp/conftest.py
@@ -6,20 +6,20 @@ FSP_PACKAGES = ['xcp-ng-xapi-storage']
 
 DIRECTORIES_PATH = 'directories'
 
-def install_fsp(host):
+@pytest.fixture(scope='package')
+def host_with_runx_repo(host_with_saved_yum_state):
+    host = host_with_saved_yum_state
     host.add_xcpng_repo(FSP_REPO_NAME, 'vates')
-    host.yum_save_state()
-    host.yum_install(FSP_PACKAGES)
-
-def uninstall_fsp(host):
-    host.yum_restore_saved_state()
+    yield host
+    # teardown
     host.remove_xcpng_repo(FSP_REPO_NAME)
 
 @pytest.fixture(scope='package')
-def host_with_fsp(host):
-    install_fsp(host)
+def host_with_fsp(host_with_runx_repo):
+    host = host_with_runx_repo
+    host.yum_install(FSP_PACKAGES)
     yield host
-    uninstall_fsp(host)
+    # teardown: nothing to do, done by host_with_saved_yum_state.
 
 @pytest.fixture(scope='package')
 def fsp_config(host_with_fsp):


### PR DESCRIPTION
We changed the test for fsp to use repo on repo.vates.tech and to have a better teardown when the test failed. We con't want that the repo file stayed on the test server.