### PR TITLE
Test HTTP Strict Transport Security header

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -150,6 +150,12 @@ def host_less_than_8_3(host):
     if not host.xcp_version < version.parse(version_str):
         pytest.skip(f"This test requires an XCP-ng < {version_str} host")
 
+@pytest.fixture(scope='session')
+def host_with_hsts(host):
+    host.enable_hsts_header()
+    yield host
+    host.disable_hsts_header()
+
 @pytest.fixture(scope='function')
 def xfail_on_xcpng_8_3(host, request):
     """ Test that is relevant but expected to fail in current state of XCP-ng 8.3. """

--- a/lib/host.py
+++ b/lib/host.py
@@ -470,3 +470,12 @@ class Host:
             return "/var/lib/uefistored"
         else:
             return "/var/lib/varstored"
+
+    def enable_hsts_header(self):
+        self.ssh(['echo', '"add_hsts_response_header = true"', '>',
+                  f'{XAPI_CONF_DIR}/00-XCP-ng-tests-enable-hsts-header.conf'])
+        self.restart_toolstack(verify=True)
+
+    def disable_hsts_header(self):
+        self.ssh(['rm', '-f', f'{XAPI_CONF_DIR}/00-XCP-ng-tests-enable-hsts-header.conf'])
+        self.restart_toolstack(verify=True)

--- a/tests/misc/test_file_server.py
+++ b/tests/misc/test_file_server.py
@@ -17,3 +17,30 @@ def test_fileserver_redirect_https(host):
     lines = stdout.decode().splitlines()
     assert lines[0].strip() == "HTTP/1.1 301 Moved Permanently"
     assert lines[2].strip() == "location:https://" + host.hostname_or_ip + path
+
+class TestHSTS:
+    HSTS_HEADER = "Strict-Transport-Security:max-age=63072000"
+
+    def __get_header(host):
+        process = subprocess.Popen(
+            ["curl", "-XGET", "-k", "-I", "https://" + host.hostname_or_ip],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        stdout, _ = process.communicate()
+        return stdout.decode().splitlines()
+
+    def test_fileserver_hsts_default(self, host):
+        # By default HSTS header should not be set
+        for line in TestHSTS.__get_header(host):
+            assert line != TestHSTS.HSTS_HEADER
+
+    def test_fileserver_hsts(self, host_with_hsts):
+        hsts_header_found = False
+
+        for line in TestHSTS.__get_header(host_with_hsts):
+            if line == TestHSTS.HSTS_HEADER:
+                hsts_header_found = True
+                break
+
+        assert hsts_header_found


### PR DESCRIPTION
By default the HSTS header is not added by XAPI server. This test checks that it is the case and it also tests that once the HSTS is enabled it is added by the server. It is enabled by setting add_hsts_response_header to true in XAPI conf.