### PR TITLE
Fix HSTS test

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -474,7 +474,7 @@ class Host:
             return "/var/lib/varstored"
 
     def enable_hsts_header(self):
-        self.ssh(['echo', '"add_hsts_response_header = true"', '>',
+        self.ssh(['echo', '"hsts_max_age = 63072000"', '>',
                   f'{XAPI_CONF_DIR}/00-XCP-ng-tests-enable-hsts-header.conf'])
         self.restart_toolstack(verify=True)
 

--- a/tests/misc/test_file_server.py
+++ b/tests/misc/test_file_server.py
@@ -19,7 +19,7 @@ def test_fileserver_redirect_https(host):
     assert lines[2].strip() == "location:https://" + host.hostname_or_ip + path
 
 class TestHSTS:
-    HSTS_HEADER = "Strict-Transport-Security:max-age=63072000"
+    HSTS_HEADER = "strict-transport-security:max-age=63072000"
 
     def __get_header(host):
         process = subprocess.Popen(


### PR DESCRIPTION
When merged upstream the parameter to activate HSTS has been modified to allow to specify the number of seconds during which the user agent as a known HSTS host. The header has been modified to be in lower case. This patch fixes these issues.