### PR TITLE
Fix get_vtpm_uuid() function

### DIFF
--- a/lib/vm.py
+++ b/lib/vm.py
@@ -412,7 +412,7 @@ class VM(BaseVM):
         return binaries
 
     def get_vtpm_uuid(self):
-        return self.host.xe('vtpm-list', {'vm': self.uuid}, minimal=True)
+        return self.host.xe('vtpm-list', {'vm-uuid': self.uuid}, minimal=True)
 
     def create_vtpm(self):
         logging.info("Creating vTPM for vm %s" % self.uuid)


### PR DESCRIPTION
This patch fixes get_vtpm_uuid() as the vtpm-list command now uses 'vm-uuid' instead of 'vm' as parameter to specify the vm uuid.