### PR TITLE
Adapt tests for IPv6 hosts

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -4,6 +4,7 @@ import subprocess
 
 import lib.config as config
 
+from lib.netutil import wrap_ip
 
 class BaseCommandFailed(Exception):
     __slots__ = 'returncode', 'stdout', 'cmd'
@@ -157,10 +158,11 @@ def scp(hostname_or_ip, src, dest, check=True, suppress_fingerprint_warnings=Tru
         # Based on https://unix.stackexchange.com/a/365976/257493
         opts = '-o "StrictHostKeyChecking no" -o "LogLevel ERROR" -o "UserKnownHostsFile /dev/null"'
 
+    ip = wrap_ip(hostname_or_ip)
     if local_dest:
-        src = 'root@{}:{}'.format(hostname_or_ip, src)
+        src = 'root@{}:{}'.format(ip, src)
     else:
-        dest = 'root@{}:{}'.format(hostname_or_ip, dest)
+        dest = 'root@{}:{}'.format(ip, dest)
 
     command = "scp {} {} {}".format(opts, src, dest)
     res = subprocess.run(

--- a/lib/host.py
+++ b/lib/host.py
@@ -10,6 +10,7 @@ import lib.commands as commands
 
 from lib.common import _param_get, safe_split, to_xapi_bool, wait_for, wait_for_not
 from lib.common import prefix_object_name
+from lib.netutil import wrap_ip
 from lib.sr import SR
 from lib.vm import VM
 from lib.xo import xo_cli, xo_object_exists
@@ -147,7 +148,7 @@ class Host:
     def xo_get_server_id(self, store=True):
         servers = xo_cli('server.getAll', use_json=True)
         for server in servers:
-            if server['host'] == self.hostname_or_ip:
+            if server['host'] == wrap_ip(self.hostname_or_ip):
                 if store:
                     self.xo_srv_id = server['id']
                 return server['id']
@@ -159,7 +160,7 @@ class Host:
         else:
             servers = xo_cli('server.getAll', use_json=True)
             for server in servers:
-                if server['host'] == self.hostname_or_ip:
+                if server['host'] == wrap_ip(self.hostname_or_ip):
                     xo_cli('server.remove', {'id': server['id']})
 
     def xo_server_add(self, username, password, label=None, unregister_first=True):
@@ -171,7 +172,7 @@ class Host:
         xo_srv_id = xo_cli(
             'server.add',
             {
-                'host': self.hostname_or_ip,
+                'host': wrap_ip(self.hostname_or_ip),
                 'username': username,
                 'password': password,
                 'allowUnauthorized': 'true',
@@ -183,7 +184,7 @@ class Host:
     def xo_server_status(self):
         servers = xo_cli('server.getAll', use_json=True)
         for server in servers:
-            if server['host'] == self.hostname_or_ip:
+            if server['host'] == wrap_ip(self.hostname_or_ip):
                 return server['status']
         return None
 

--- a/lib/netutil.py
+++ b/lib/netutil.py
@@ -1,0 +1,12 @@
+import socket
+
+def is_ipv6(ip):
+    try:
+        socket.inet_pton(socket.AF_INET6, ip)
+        return True
+    except Exception:
+        return False
+
+def wrap_ip(ip):
+    """ Wrap an IP between brackets if and only if it's an IPv6. """
+    return f"[{ip}]" if is_ipv6(ip) else ip

--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -111,5 +111,8 @@ class TestHostEvacuateWithNetwork:
             pif_uuid = host.xe('pif-list', {'host-uuid': hostA2.uuid, 'network-uuid': second_network}, minimal=True)
             args['uuid'] = pif_uuid
             logging.info(f"Re-add and plug PIF {pif_uuid}")
+            if ipv6:
+                # Default is IPv4
+                host.xe('pif-set-primary-address-type', {'uuid': pif_uuid, 'primary_address_type': 'ipv6'})
             host.xe(reconfigure_method, args)
             host.xe('pif-plug', {'uuid': pif_uuid})

--- a/tests/misc/test_file_server.py
+++ b/tests/misc/test_file_server.py
@@ -2,6 +2,8 @@ import pytest
 import re
 import subprocess
 
+from lib.netutil import wrap_ip
+
 # These tests are meant to test an host fileserver behavior.
 #
 # Requirements:
@@ -14,15 +16,16 @@ def _header_equal(header, name, value):
 
 def test_fileserver_redirect_https(host):
     path = "/path/to/dir/file.txt"
+    ip = wrap_ip(host.hostname_or_ip)
     process = subprocess.Popen(
-        ["curl", "-i", "http://" + host.hostname_or_ip + path],
+        ["curl", "-i", "http://" + ip + path],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
     stdout, _ = process.communicate()
     lines = stdout.decode().splitlines()
     assert lines[0].strip() == "HTTP/1.1 301 Moved Permanently"
-    assert _header_equal(lines[2], "location", "https://" + host.hostname_or_ip + path)
+    assert _header_equal(lines[2], "location", "https://" + ip + path)
 
 @pytest.mark.usefixtures("host_at_least_8_3")
 class TestHSTS:
@@ -31,7 +34,7 @@ class TestHSTS:
 
     def __get_header(host):
         process = subprocess.Popen(
-            ["curl", "-XGET", "-k", "-I", "https://" + host.hostname_or_ip],
+            ["curl", "-XGET", "-k", "-I", "https://" + wrap_ip(host.hostname_or_ip)],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )

--- a/tests/storage/moosefs/test_moosefs_sr.py
+++ b/tests/storage/moosefs/test_moosefs_sr.py
@@ -31,6 +31,8 @@ class TestMooseFSSRCreateDestroy:
             sr.destroy()
             assert False, "MooseFS SR creation should failed!"
 
+    # MooseFS doesn't support IPv6
+    @pytest.mark.usefixtures("host_no_ipv6")
     def test_create_and_destroy_sr(self, moosefs_device_config, pool_with_moosefs_enabled):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         master = pool_with_moosefs_enabled.master
@@ -41,7 +43,8 @@ class TestMooseFSSRCreateDestroy:
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
-@pytest.mark.usefixtures("moosefs_sr")
+# MooseFS doesn't support IPv6
+@pytest.mark.usefixtures("moosefs_sr", "host_no_ipv6")
 class TestMooseFSSR:
     @pytest.mark.quicktest
     def test_quicktest(self, moosefs_sr):

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_moosefs_sr, moosefs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_moosefs_sr, host, moosefs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_moosefs_sr, moosefs_sr):
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, moosefs_sr, hostA2, moosefs_sr)

--- a/tests/xen/test_xtf.py
+++ b/tests/xen/test_xtf.py
@@ -8,7 +8,8 @@ from lib.commands import SSHCommandFailed
 # - host: XCP-ng host >= 8.2, with Xen booted with the hvm_fep command line parameter
 #         See https://xenbits.xen.org/docs/xtf/
 
-@pytest.mark.usefixtures("host_with_hvm_fep", "host_with_dynamically_disabled_ept_sp")
+# XTF git repo is not available in IPv6
+@pytest.mark.usefixtures("host_with_hvm_fep", "host_with_dynamically_disabled_ept_sp", "host_no_ipv6")
 class TestXtf:
     _common_skips = [
         # UMIP requires hardware support, that is a recent enough CPU


### PR DESCRIPTION
- add brackets around IP in URI when necessary
- ignore tests not suporting IPv6