### PR TITLE
Add new `gencert` parameter

### DIFF
--- a/tests/xapi/tls_verification/test_tls_verification.py
+++ b/tests/xapi/tls_verification/test_tls_verification.py
@@ -69,7 +69,7 @@ class TestTLSVerification:
         hostA2 = hostA2_with_saved_cert
         logging.info(f"Replace the certificate on host {hostA2}")
         hostA2.ssh(['rm', XAPI_POOL_PEM_FILEPATH])
-        hostA2.ssh(['/opt/xensource/libexec/gencert', XAPI_POOL_PEM_FILEPATH, 'xapi:pool'])
+        hostA2.ssh(['/opt/xensource/libexec/gencert', XAPI_POOL_PEM_FILEPATH, '-1', 'xapi:pool'])
         hostA2.ssh(['systemctl', 'reload-or-restart stunnel@xapi'])
         # Restart toolstack on client host to clear any existing TLS connection
         hostA1.restart_toolstack(True)


### PR DESCRIPTION
- A new param has been added: `cert_gid`
See: https://github.com/xapi-project/xen-api/commit/c59ac1668f30090e9ae3b744b008c4dc36ba29cc