### PR TITLE
Robustify Host.is_package_installed()

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -314,13 +314,7 @@ class Host:
         return self.ssh(['repoquery', '--show-duplicates', package]).splitlines()
 
     def is_package_installed(self, package):
-        try:
-            self.ssh(['yum', 'list', 'installed', package])
-            return True
-        except commands.SSHCommandFailed as e:
-            if e.stdout.endswith('Error: No matching Packages to list'):
-                return False
-            raise e
+        return self.ssh_with_result(['rpm', '-q', package]).returncode == 0
 
     def yum_save_state(self):
         logging.info(f"Save yum state for host {self}")


### PR DESCRIPTION
The current implementation is dependent on the exact output of the yum list installed command, which can depend on the system language of the user who runs the tests, and might change in the future.

Instead, use the simpler `rpm -q package` command, which returns nonzero if the package doesn't exist on the system.