### PR TITLE
vtpm: Fix installation of tpm2-tools package using apt-get

### DIFF
--- a/tests/vtpm/conftest.py
+++ b/tests/vtpm/conftest.py
@@ -50,13 +50,15 @@ def unix_vm_with_tpm2_tools(started_unix_vm_with_vtpm):
 
     pkg_mgr = vm.detect_package_manager()
     if pkg_mgr == PackageManagerEnum.APT_GET:
-        pkg_mgr = 'apt-get'
+        # Old versions of apt-get doesn't support the --update option with the
+        # install command so we have to first update then install
+        cmd = ['apt-get', 'update', '&&', 'apt-get']
     elif pkg_mgr == PackageManagerEnum.RPM:
-        pkg_mgr = 'yum'
+        cmd = ['yum']
     else:
         pytest.fail("Unsupported package manager for this test. Cannot install tpm2-tools")
 
-    logging.info("Installing tpm2-tools package using '%s'" % pkg_mgr)
-    vm.ssh([pkg_mgr, 'install', '-y', 'tpm2-tools'])
+    logging.info("Installing tpm2-tools package using '%s'" % cmd[0])
+    vm.ssh(cmd + ['install', '-y', 'tpm2-tools'])
 
     yield vm


### PR DESCRIPTION
apt-get needs to update its package index files before installing tpm2-tools as it might try to install outdated dependencies. This patch fixes this issue by first running 'apt-get update' before 'apt-get install'.