### PR TITLE
Only connect XO for migration tests

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -349,7 +349,7 @@ class Host:
         self.saved_packages_list = None
         self.saved_rollback_id = None
 
-    def reboot(self, verify=False, reconnect_xo=True):
+    def reboot(self, verify=False):
         logging.info("Reboot host %s" % self)
         try:
             self.ssh(['reboot'])
@@ -357,11 +357,9 @@ class Host:
             # ssh connection may get killed by the reboot and terminate with an error code
             if "closed by remote host" not in e.stdout:
                 raise
-        if verify or reconnect_xo:
+        if verify:
             wait_for_not(self.is_enabled, "Wait for host down")
             wait_for(self.is_enabled, "Wait for host up", timeout_secs=1800)
-        if reconnect_xo and self.is_master():
-            self.xo_server_reconnect()
 
     def management_network(self):
         return self.xe('network-list', {'bridge': self.inventory['MANAGEMENT_INTERFACE']}, minimal=True)

--- a/tests/guest-tools/unix/test_guest_tools_unix.py
+++ b/tests/guest-tools/unix/test_guest_tools_unix.py
@@ -116,6 +116,7 @@ class TestGuestToolsUnix:
         vm.start()
         vm.wait_for_vm_running_and_ssh_up()
 
+    @pytest.mark.usefixtures('hosts_with_xo')
     def test_storage_migration(self, running_vm, host, hostA2, local_sr_on_hostA2, state):
         vm = running_vm
         # migrate to default SR on hostA2

--- a/tests/misc/test_basic_without_ssh.py
+++ b/tests/misc/test_basic_without_ssh.py
@@ -75,7 +75,7 @@ class TestBasicNoSSH:
     # Live migration tests
     # We want to test storage migration (memory+disks) and live migration without storage migration (memory only).
     # The order will depend on the initial location of the VM: a local SR or a shared SR.
-    @pytest.mark.usefixtures("hostA2")
+    @pytest.mark.usefixtures("hostA2", 'hosts_with_xo')
     def test_live_migrate(self, imported_vm, existing_shared_sr):
         def live_migrate(vm, dest_host, dest_sr, check_vdis=False):
             vm.migrate(dest_host, dest_sr)

--- a/tests/misc/test_cross_pool_migration.py
+++ b/tests/misc/test_cross_pool_migration.py
@@ -5,6 +5,7 @@ from lib.common import wait_for, wait_for_not
 
 @pytest.mark.multi_vms # run on a variety of VMs
 @pytest.mark.big_vm # and also on a really big VM ideally
+@pytest.mark.usefixtures('hosts_with_xo')
 def test_cross_pool_migration(hostB1, imported_vm):
     vm = imported_vm.clone()
     try:

--- a/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_cephfs_sr, cephfs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_cephfs_sr, host, cephfs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_cephfs_sr, cephfs_sr):
         live_storage_migration_then_come_back(vm_on_cephfs_sr, host, cephfs_sr, hostA2, cephfs_sr)

--- a/tests/storage/ext/test_ext_sr_crosspool_migration.py
+++ b/tests/storage/ext/test_ext_sr_crosspool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_ext_sr, ext_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_ext_sr, host, ext_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/ext/test_ext_sr_intrapool_migration.py
+++ b/tests/storage/ext/test_ext_sr_intrapool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host, hostA2, vm_on_ext_sr, ext_sr, local_sr_on_hostA2):
         cold_migration_then_come_back(vm_on_ext_sr, host, ext_sr, hostA2, local_sr_on_hostA2)

--- a/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1", "sr_disk_for_all_hosts")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1", "sr_disk_for_all_hosts")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_glusterfs_sr, glusterfs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_glusterfs_sr, host, glusterfs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2", "sr_disk_for_all_hosts")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2", "sr_disk_for_all_hosts")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_glusterfs_sr, glusterfs_sr):
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, glusterfs_sr, hostA2, glusterfs_sr)

--- a/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_linstor_sr, linstor_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_linstor_sr, host, linstor_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_linstor_sr, linstor_sr):
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, linstor_sr, hostA2, linstor_sr)

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvm_sr, lvm_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_lvm_sr, host, lvm_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host, hostA2, vm_on_lvm_sr, lvm_sr, local_sr_on_hostA2):
         cold_migration_then_come_back(vm_on_lvm_sr, host, lvm_sr, hostA2, local_sr_on_hostA2)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvmoiscsi_sr, lvmoiscsi_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, lvmoiscsi_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_lvmoiscsi_sr, lvmoiscsi_sr):
         live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, lvmoiscsi_sr, hostA2, lvmoiscsi_sr)

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_moosefs_sr, moosefs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_moosefs_sr, host, moosefs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_moosefs_sr, moosefs_sr):
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, moosefs_sr, hostA2, moosefs_sr)

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_nfs_sr, nfs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_nfs_sr, host, nfs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -10,7 +10,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_nfs_sr, nfs_sr):
         live_storage_migration_then_come_back(vm_on_nfs_sr, host, nfs_sr, hostA2, nfs_sr)

--- a/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_xfs_sr, xfs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_xfs_sr, host, xfs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host, hostA2, vm_on_xfs_sr, xfs_sr, local_sr_on_hostA2):
         cold_migration_then_come_back(vm_on_xfs_sr, host, xfs_sr, hostA2, local_sr_on_hostA2)

--- a/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "hosts_with_xo", "local_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_zfs_sr, zfs_sr, local_sr_on_hostB1):
         cold_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "hosts_with_xo", "local_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host, hostA2, vm_on_zfs_sr, zfs_sr, local_sr_on_hostA2):
         cold_migration_then_come_back(vm_on_zfs_sr, host, zfs_sr, hostA2, local_sr_on_hostA2)


### PR DESCRIPTION
Maintaining a connection to XO adds causes for test failure, so let's not connect it when not strictly required, that is, in the only place where we only use it currectly: live migration tests.