### PR TITLE
Avoid having two ISO SRs at the same time during tests

### DIFF
--- a/tests/storage/iso/conftest.py
+++ b/tests/storage/iso/conftest.py
@@ -13,7 +13,7 @@ def create_local_iso_sr(host, location):
     }
     return host.sr_create('iso', "ISO-local-SR-test", device_config, verify=True)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def local_iso_sr(host, formatted_and_mounted_ext4_disk):
     """ An ISO SR on first host. """
     location = formatted_and_mounted_ext4_disk + '/iso_sr'
@@ -22,7 +22,7 @@ def local_iso_sr(host, formatted_and_mounted_ext4_disk):
     # teardown
     sr.destroy()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs_iso_device_config(sr_device_config):
     if sr_device_config is not None:
         # SR device config from CLI param
@@ -39,7 +39,7 @@ def nfs_iso_device_config(sr_device_config):
             raise Exception("No default NFS ISO device-config found, neither in CLI nor in data.py defaults")
     return config
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def cifs_iso_device_config(sr_device_config):
     if sr_device_config is not None:
         # SR device config from CLI param
@@ -56,7 +56,7 @@ def cifs_iso_device_config(sr_device_config):
             raise Exception("No default CIFS ISO device-config found, neither in CLI nor in data.py defaults")
     return config
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs_iso_sr(host, nfs_iso_device_config):
     """ A NFS ISO SR. """
     sr = host.sr_create('iso', "ISO-NFS-SR-test", nfs_iso_device_config, shared=True, verify=True)
@@ -64,7 +64,7 @@ def nfs_iso_sr(host, nfs_iso_device_config):
     # teardown
     sr.forget()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def cifs_iso_sr(host, cifs_iso_device_config):
     """ A Samba/CIFS SR. """
     sr = host.sr_create('iso', "ISO-CIFS-SR-test", cifs_iso_device_config, shared=True, verify=True)


### PR DESCRIPTION
In ISO SR tests, there are package-scoped fixtures for SRs, which is what we usually do in other storage tests. But here, in the same package, we test ISO SR, NFS ISO SR, and CIFS ISO SR.

As a result we start creating a new SR when the previous one hasn't been teared down yet.

By giving these fixtures the `module` scope, we ensure teardown happens at the end of each test file. The counterpart is that we may create and destroy the same SR twice, successively, because there are two test files per SR type. However, since the second file is each time dedicated to tests with reboot, and that we usually run these in a separate job, this doesn't add any overhead to the current test jobs.