### PR TITLE
Don't skip empty lines...

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -110,9 +110,8 @@ def _ssh(hostname_or_ip, cmd, check=True, simple_output=True, suppress_fingerpri
     stdout = []
     for line in iter(process.stdout.readline, b''):
         readable_line = line.decode(errors='replace').strip()
-        if readable_line != '':
-            stdout.append(line)
-            OUPUT_LOGGER.debug(readable_line)
+        stdout.append(line)
+        OUPUT_LOGGER.debug(readable_line)
     _, stderr = process.communicate()
     res = subprocess.CompletedProcess(ssh_cmd, process.returncode, b''.join(stdout), stderr)
 


### PR DESCRIPTION
For some tricky cases we cannot skip empty line. For example when getting a key from varstored with ssh we can have within the key a sequence of two 0x0a bytes. The issue is that readline will split it with an empty line. If we skip it we basically remove one 0x0a from the key and then of course the checksum will failed.