### PR TITLE
Tests for the SMAPIv3 ZFS-ng driver

### DIFF
--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -1,0 +1,35 @@
+import logging
+import pytest
+
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
+from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped
+
+@pytest.fixture(scope='package')
+def host_with_zfsvol(host_with_saved_yum_state):
+    host = host_with_saved_yum_state
+    host.yum_install(['xcp-ng-xapi-storage-volume-zfsvol'])
+    yield host
+
+@pytest.fixture(scope='package')
+def zfsvol_sr(host, sr_disk_wiped, host_with_zfsvol):
+    """ A ZFS Volume SR on first host. """
+    device = '/dev/' + sr_disk_wiped
+    sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': device})
+    yield sr
+    # teardown violently - we don't want to require manual recovery when a test fails
+    sr.forget()
+    host.ssh(["wipefs", "-a", device])
+
+@pytest.fixture(scope='module')
+def vdi_on_zfsvol_sr(zfsvol_sr):
+    vdi = zfsvol_sr.create_vdi('ZFS-local-VDI-test')
+    yield vdi
+    vdi.destroy()
+
+@pytest.fixture(scope='module')
+def vm_on_zfsvol_sr(host, zfsvol_sr, vm_ref):
+    vm = host.import_vm(vm_ref, sr_uuid=zfsvol_sr.uuid)
+    yield vm
+    # teardown
+    logging.info("<< Destroy VM")
+    vm.destroy(verify=True)

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -1,0 +1,73 @@
+import logging
+import time
+import pytest
+
+from lib.commands import SSHCommandFailed
+from lib.common import wait_for, vm_image
+from tests.storage import vdi_is_open
+
+# Requirements:
+# - one XCP-ng host >= 8.3 with an additional unused disk for the SR
+# - access to XCP-ng RPM repository from the host
+
+pytestmark = pytest.mark.usefixtures("host_at_least_8_3")
+
+class TestZfsvolSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_and_destroy_sr(self, host, sr_disk_wiped):
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': '/dev/' + sr_disk_wiped}, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)
+
+@pytest.mark.usefixtures("zfsvol_sr")
+class TestZfsvolVm:
+
+    @pytest.mark.xfail
+    @pytest.mark.quicktest
+    def test_quicktest(self, zfsvol_sr):
+        zfsvol_sr.run_quicktest()
+
+    @pytest.mark.small_vm # run with a small VM to test the features
+    @pytest.mark.big_vm # and ideally with a big VM to test it scales
+    def test_start_and_shutdown_VM(self, vm_on_zfsvol_sr):
+        vm = vm_on_zfsvol_sr
+        vm.start()
+        vm.wait_for_os_booted()
+        vm.shutdown(verify=True)
+
+    @pytest.mark.xfail # needs support for destroying snapshots
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_snapshot(self, vm_on_zfsvol_sr):
+        vm = vm_on_zfsvol_sr
+        vm.start()
+        try:
+            vm.wait_for_os_booted()
+            vm.test_snapshot_on_running_vm()
+        finally:
+            vm.shutdown(verify=True)
+
+    # *** tests with reboots (longer tests).
+
+    @pytest.mark.reboot
+    @pytest.mark.small_vm
+    def test_reboot(self, vm_on_zfsvol_sr, host, zfsvol_sr):
+        sr = zfsvol_sr
+        vm = vm_on_zfsvol_sr
+        host.reboot(verify=True)
+        wait_for(sr.all_pbds_attached, "Wait for PBD attached")
+        # start the VM as a way to check that the underlying SR is operational
+        vm.start()
+        vm.wait_for_os_booted()
+        vm.shutdown(verify=True)
+
+    # *** End of tests with reboots

--- a/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
@@ -1,0 +1,26 @@
+import pytest
+from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
+
+# Requirements:
+# From --hosts parameter:
+# - host(A1): first XCP-ng host >= 8.2 with an additional unused disk for the SR.
+# - hostB1: Master of a second pool. Any local SR.
+# From --vm parameter
+# - A VM to import to the ZFS-ng SR
+# And:
+# - access to XCP-ng RPM repository from hostA1
+
+@pytest.mark.xfail
+@pytest.mark.small_vm # run with a small VM to test the features
+@pytest.mark.big_vm # and ideally with a big VM to test it scales
+@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+class Test:
+    def test_cold_crosspool_migration(self, host, hostB1, vm_on_zfsvol_sr,
+                                      zfsvol_sr, local_sr_on_hostB1):
+        cold_migration_then_come_back(
+            vm_on_zfsvol_sr, host, zfsvol_sr, hostB1, local_sr_on_hostB1)
+
+    def test_live_crosspool_migration(self, host, hostB1, vm_on_zfsvol_sr,
+                                      zfsvol_sr, local_sr_on_hostB1):
+        live_storage_migration_then_come_back(
+            vm_on_zfsvol_sr, host, zfsvol_sr, hostB1, local_sr_on_hostB1)

--- a/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
@@ -1,0 +1,26 @@
+import pytest
+from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
+
+# Requirements:
+# From --hosts parameter:
+# - host(A1): first XCP-ng host >= 8.2 with an additional unused disk for the SR.
+# - hostA2: Second member of the pool. Can have any local SR. No need to specify it on CLI.
+# From --vm parameter
+# - A VM to import to the ZFS-ng SR
+# And:
+# - access to XCP-ng RPM repository from hostA1
+
+@pytest.mark.xfail
+@pytest.mark.small_vm # run with a small VM to test the features
+@pytest.mark.big_vm # and ideally with a big VM to test it scales
+@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+class Test:
+    def test_cold_intrapool_migration(self, host, hostA2, vm_on_zfsvol_sr,
+                                      zfsvol_sr, local_sr_on_hostA2):
+        cold_migration_then_come_back(
+            vm_on_zfsvol_sr, host, zfsvol_sr, hostA2, local_sr_on_hostA2)
+
+    def test_live_intrapool_migration(self, host, hostA2, vm_on_zfsvol_sr,
+                                      zfsvol_sr, local_sr_on_hostA2):
+        live_storage_migration_then_come_back(
+            vm_on_zfsvol_sr, host, zfsvol_sr, hostA2, local_sr_on_hostA2)


### PR DESCRIPTION
Those tests are essentially adapted from those existing for SMAPIv1 SR drivers.

Note:
- this PR is stacked over #217
- those tests depend on the zfs-vol RPM from xcp-ng-rpms/xcp-ng-xapi-storage#3