### PR TITLE
jobs.py: Fix subprocess.run() output capture

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -397,11 +397,12 @@ def build_pytest_cmd(job_data, hosts=None, pytest_args=[]):
         try:
             host = hosts.split(',')[0]
             cmd = ["ssh", host, "lsb_release", "-sr"]
-            res = subprocess.run(cmd, capture_output=True, text=True)
+            res = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
             if res.returncode == 0:
-                host_version = res.stdout.strip()
+                host_version = res.stdout.decode().strip()
         except Exception as e:
             print(e, file=sys.stderr)
+    print(f"Host version is '{host_version}'")
 
     def _join_pytest_args(arg, option):
         cli_args = []


### PR DESCRIPTION
The 'capture_output' prameter for subprocess.run() has been introduced in python 3.7. Use 'stdout=subprocess.PIPE' and 'stderr=subprocess.PIPE' instead for our Jenkins server running python 3.6.

Also print more information about the host version under test.