### PR TITLE
Fix VM list for job tools-unix

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -266,7 +266,7 @@ JOBS = {
         ],
         "nb_pools": 1,
         "params": {
-            "--vm": "single/small_vm_efitools",
+            "--vm": "single/small_vm_unix_tools",
         },
         "paths": ["tests/guest-tools/unix"],
         "markers": "",


### PR DESCRIPTION
The VM list for this job has been wrong since I created jobs.py. Instead of using a VM which is supported by our guest tools installer from the guest tools ISO, it used one which is not guaranteed to be supported. In our case, this would use Alpine, which isn't supported by the installer, so most tests would be skipped.

No harm done, though, because the tools-unix-multi job does execute the test on various VMs which do support it.