### PR TITLE
Fix parameter order for BaseVM.param_set

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -297,7 +297,7 @@ def imported_vm(host, vm_ref):
         logging.info(">> Clone cached VM before running tests")
         vm = vm_orig.clone()
         # Remove the description, which may contain a cache identifier
-        vm.param_set('name-description', None, "")
+        vm.param_set('name-description', "")
     else:
         vm = vm_orig
 

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -17,7 +17,7 @@ class BaseVM:
     def param_get(self, param_name, key=None, accept_unknown_key=False):
         return _param_get(self.host, BaseVM.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
 
-    def param_set(self, param_name, key, value):
+    def param_set(self, param_name, value, key=None):
         _param_set(self.host, BaseVM.xe_prefix, self.uuid, param_name, value, key)
 
     def param_remove(self, param_name, key, accept_unknown_key=False):

--- a/lib/host.py
+++ b/lib/host.py
@@ -230,13 +230,13 @@ class Host:
         logging.info("VM UUID: %s" % vm_uuid)
         vm_name = prefix_object_name(self.xe('vm-param-get', {'uuid': vm_uuid, 'param-name': 'name-label'}))
         vm = VM(vm_uuid, self)
-        vm.param_set('name-label', None, vm_name)
+        vm.param_set('name-label', vm_name)
         # Set VM VIF networks to the host's management network
         for vif in vm.vifs():
             vif.move(self.management_network())
         if use_cache:
             logging.info(f"Marking VM {vm.uuid} as cached")
-            vm.param_set('name-description', None, cache_key)
+            vm.param_set('name-description', cache_key)
         return vm
 
     def pool_has_vm(self, vm_uuid, vm_type='vm'):

--- a/tests/uefi_sb/conftest.py
+++ b/tests/uefi_sb/conftest.py
@@ -29,7 +29,7 @@ def uefi_vm_and_snapshot(uefi_vm):
     # secure boot specific variables
     vm.set_uefi_setup_mode()
     logging.info('Set platform.secureboot to false for VM')
-    vm.param_set('platform', 'secureboot', False)
+    vm.param_set('platform', False, key='secureboot')
     snapshot = vm.snapshot()
 
     yield vm, snapshot

--- a/tests/uefi_sb/test_uefistored_sb.py
+++ b/tests/uefi_sb/test_uefistored_sb.py
@@ -40,52 +40,52 @@ class TestGuestLinuxUEFISecureBoot:
         vm = uefi_vm
         vm.host.pool.install_custom_uefi_certs([self.PK, self.KEK, self.db])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_boot_success_when_vm_db_set_and_images_signed(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_boot_fails_when_pool_db_set_and_images_unsigned(self, uefi_vm):
         vm = uefi_vm
         vm.host.pool.install_custom_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_fails_when_vm_db_set_and_images_unsigned(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_succeeds_when_pool_certs_set_and_sb_disabled(self, uefi_vm):
         vm = uefi_vm
         vm.host.pool.install_custom_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', False)
+        vm.param_set('platform', False, key='secureboot')
         boot_and_check_no_sb_errors(vm)
 
     def test_boot_succeeds_when_vm_certs_set_and_sb_disabled(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', False)
+        vm.param_set('platform', False, key='secureboot')
         boot_and_check_no_sb_errors(vm)
 
     def test_boot_fails_when_pool_dbx_revokes_signed_images(self, uefi_vm):
         vm = uefi_vm
         vm.host.pool.install_custom_uefi_certs([self.PK, self.KEK, self.db, self.dbx])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_fails_when_vm_dbx_revokes_signed_images(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db, self.dbx])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_success_when_initial_pool_keys_not_signed_by_parent(self, uefi_vm):
@@ -93,7 +93,7 @@ class TestGuestLinuxUEFISecureBoot:
         PK, KEK, db, _ = generate_keys(self_signed=True)
         vm.host.pool.install_custom_uefi_certs([PK, KEK, db])
         sign_efi_bins(vm, db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_boot_success_when_initial_vm_keys_not_signed_by_parent(self, uefi_vm):
@@ -101,14 +101,14 @@ class TestGuestLinuxUEFISecureBoot:
         PK, KEK, db, _ = generate_keys(self_signed=True)
         vm.install_uefi_certs([PK, KEK, db])
         sign_efi_bins(vm, db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_sb_off_really_means_off(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', False)
+        vm.param_set('platform', False, key='secureboot')
         vm.start()
         vm.wait_for_vm_running_and_ssh_up()
         logging.info("Check that SB is NOT enabled according to the OS.")
@@ -131,13 +131,13 @@ class TestGuestWindowsUEFISecureBoot:
         vm = uefi_vm
         PK, KEK, db, _ = generate_keys(self_signed=True)
         vm.host.pool.install_custom_uefi_certs([PK, KEK, db])
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     @pytest.mark.multi_vms # test that SB works on every Windows VM we have
     def test_windows_succeeds(self, uefi_vm):
         vm = uefi_vm
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         # Install default certs. This requires internet access from the host.
         logging.info("Install default certs on pool with secureboot-certs install")
         vm.host.ssh(['secureboot-certs', 'install'])
@@ -151,7 +151,7 @@ class TestCertsMissingAndSbOn:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):
         vm, snapshot = uefi_vm_and_snapshot
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         yield
         revert_vm_state(vm, snapshot)
         # clear pool certs for next test

--- a/tests/uefi_sb/test_varstored_sb.py
+++ b/tests/uefi_sb/test_varstored_sb.py
@@ -34,26 +34,26 @@ class TestGuestLinuxUEFISecureBoot:
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_boot_fails_when_vm_db_set_and_images_unsigned(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_succeeds_when_vm_certs_set_and_sb_disabled(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
-        vm.param_set('platform', 'secureboot', False)
+        vm.param_set('platform', False, key='secureboot')
         boot_and_check_no_sb_errors(vm)
 
     def test_boot_fails_when_vm_dbx_revokes_signed_images(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db, self.dbx])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     def test_boot_success_when_initial_vm_keys_not_signed_by_parent(self, uefi_vm):
@@ -61,14 +61,14 @@ class TestGuestLinuxUEFISecureBoot:
         PK, KEK, db, _ = generate_keys(self_signed=True)
         vm.install_uefi_certs([PK, KEK, db])
         sign_efi_bins(vm, db)
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_succeeded(vm)
 
     def test_sb_off_really_means_off(self, uefi_vm):
         vm = uefi_vm
         vm.install_uefi_certs([self.PK, self.KEK, self.db])
         sign_efi_bins(vm, self.db)
-        vm.param_set('platform', 'secureboot', False)
+        vm.param_set('platform', False, key='secureboot')
         vm.start()
         vm.wait_for_vm_running_and_ssh_up()
         logging.info("Check that SB is NOT enabled according to the OS.")
@@ -89,13 +89,13 @@ class TestGuestWindowsUEFISecureBoot:
         vm = uefi_vm
         PK, KEK, db, _ = generate_keys(self_signed=True)
         vm.install_uefi_certs([PK, KEK, db])
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         boot_and_check_sb_failed(vm)
 
     @pytest.mark.multi_vms # test that SB works on every Windows VM we have
     def test_windows_succeeds(self, uefi_vm):
         vm = uefi_vm
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         # Install certs in the VM. They must be official MS certs.
         # We install them first in the pool with `secureboot-certs install`, which requires internet access
         logging.info("Install MS certs on pool with secureboot-certs install")
@@ -111,7 +111,7 @@ class TestCertsMissingAndSbOn:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):
         vm, snapshot = uefi_vm_and_snapshot
-        vm.param_set('platform', 'secureboot', True)
+        vm.param_set('platform', True, key='secureboot')
         yield
         revert_vm_state(vm, snapshot)
 


### PR DESCRIPTION
key and value were inverted in this method, which is not consistent with the definition of _param_set, nor with the othr param_set methods on other classes.

This makes calls a bit awkward when a key must be specified in addition to the parameter name, but it's consistent, mais we can make it reasonably readable by specifying key as a named parameter in method calls.