### PR TITLE
Add a fixture to get a unique ID identified sr_disk

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -229,7 +229,7 @@ def sr_disk(request, host):
 
 @pytest.fixture(scope="session")
 def sr_disk_devid(host, sr_disk):
-    # [5:] remove /dev/ at is not expected by normal sr_disk fixture
+    # Remove /dev/ as it is not expected by normal `sr_disk` fixture
     yield host.disk_devid(sr_disk)[0][len("/dev/"):]
 
 @pytest.fixture(scope='session')

--- a/conftest.py
+++ b/conftest.py
@@ -229,7 +229,7 @@ def sr_disk(request, host):
 
 @pytest.fixture(scope="session")
 def sr_disk_devid(host, sr_disk):
-    #[5:] remove /dev/ at is not expected by normal sr_disk fixture
+    # [5:] remove /dev/ at is not expected by normal sr_disk fixture
     yield host.disk_devid(sr_disk)[0][len("/dev/"):]
 
 @pytest.fixture(scope='session')

--- a/conftest.py
+++ b/conftest.py
@@ -227,6 +227,11 @@ def sr_disk(request, host):
             f"disk or block device {disk} is either not present or already used on master host"
     yield disk
 
+@pytest.fixture(scope="session")
+def sr_disk_devid(host, sr_disk):
+    #[5:] remove /dev/ at is not expected by normal sr_disk fixture
+    yield host.disk_devid(sr_disk)[0][len("/dev/"):]
+
 @pytest.fixture(scope='session')
 def sr_disk_for_all_hosts(request, host):
     disk = request.param

--- a/lib/host.py
+++ b/lib/host.py
@@ -406,6 +406,9 @@ class Host:
         """
         return [disk for disk in self.disks() if self.disk_is_available(disk)]
 
+    def disk_devid(self, disk):
+        return self.ssh(["find", "-L", "/dev/disk/by-id/", "-samefile", "/dev/"+disk]).splitlines()
+
     def file_exists(self, filepath, regular_file=True):
         option = '-f' if regular_file else '-e'
         return self.ssh_with_result(['test', option, filepath]).returncode == 0

--- a/lib/host.py
+++ b/lib/host.py
@@ -407,7 +407,7 @@ class Host:
         return [disk for disk in self.disks() if self.disk_is_available(disk)]
 
     def disk_devid(self, disk):
-        return self.ssh(["find", "-L", "/dev/disk/by-id/", "-samefile", "/dev/"+disk]).splitlines()
+        return self.ssh(["find", "-L", "/dev/disk/by-id/", "-samefile", "/dev/" + disk]).splitlines()
 
     def file_exists(self, filepath, regular_file=True):
         option = '-f' if regular_file else '-e'


### PR DESCRIPTION
Add a `sr_disk_devid` fixture to create a SR on top of a unique disk ID.
`disk_devid` obtain the `/dev/disk/by-id/` identifier of a disk on the host. 
It is written to be an inplace replacement of the `sr_disk` fixture.

It is mainly interesting for the new LargeBlock SR tests since those fails if the disk is not the right one in the PBD.
EXTSR doesn't use the `device-config:device` for attach and detach, it obtains the VG name and LV name to mount by using the SR UUID.
LargeBlockSR creates the loop device on top of the device each time. If the device in the PBD is not the right one, the loop device will be created on top of the wrong device.