### PR TITLE
Fix snapshot tests failing on Windows VMs

### DIFF
--- a/lib/vm.py
+++ b/lib/vm.py
@@ -133,7 +133,8 @@ class VM(BaseVM):
     def ssh_touch_file(self, filepath):
         logging.info("Create file on VM (%s)" % filepath)
         self.ssh(['touch', filepath])
-        self.ssh(['sync', filepath])
+        if not self.is_windows:
+            self.ssh(['sync', filepath])
         logging.info("Check file created")
         self.ssh(['test -f ' + filepath])
 


### PR DESCRIPTION
For some reason `sync` on Windows VM fails with "permission denied". Luckily it looks like the tests there do not require an explicit sync, so just skip it.

Another regression from #217 