### PR TITLE
Fix wait_for behavior

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -32,15 +32,14 @@ def prefix_object_name(label):
 def wait_for(fn, msg=None, timeout_secs=2 * 60, retry_delay_secs=2, invert=False):
     if msg is not None:
         logging.info(msg)
-    time_left = timeout_secs
+    start_time = time.perf_counter()
     while True:
         ret = fn()
         if not invert and ret:
             return
         if invert and not ret:
             return
-        time_left -= retry_delay_secs
-        if time_left <= 0:
+        if time.perf_counter() - start_time >= timeout_secs:
             expected = 'True' if not invert else 'False'
             raise TimeoutError(
                 "Timeout reached while waiting for fn call to yield %s (%s)." % (expected, timeout_secs)

--- a/lib/host.py
+++ b/lib/host.py
@@ -384,9 +384,9 @@ class Host:
         if verify:
             wait_for_not(self.is_enabled, "Wait for host down")
             wait_for(lambda: not os.system(f"ping -c1 {self.hostname_or_ip} > /dev/null 2>&1"),
-                     "Wait for host up", retry_delay_secs=10)
+                     "Wait for host up", timeout_secs=10 * 60, retry_delay_secs=10)
             wait_for(lambda: not os.system(f"nc -zw5 {self.hostname_or_ip} 22"),
-                     "Wait for ssh up on host", retry_delay_secs=5)
+                     "Wait for ssh up on host", timeout_secs=10 * 60, retry_delay_secs=5)
             wait_for(self.is_enabled, "Wait for XAPI to be ready", timeout_secs=30 * 60)
 
     def management_network(self):


### PR DESCRIPTION
- The old version does not take into account the execution time of `fn`. So instead of waiting 2 minutes (using the default timeout_secs delay), we can end up with much longer delays like 4 minutes.

- And for basic functions, the timeout is not respected. For example if I patch common.py like that:

```
def toto():
  return False

wait_for(toto, timeout_secs=10)
```

Run wait_for call:
```
> time ./common.py
Traceback (most recent call last):
  File "/home/ronan/Projets/sm/./test.py", line 27, in <module>
    wait_for(toto, timeout_secs=10)
  File "/home/ronan/Projets/sm/./test.py", line 18, in wait_for
    raise TimeoutError(
Exception: Timeout reached while waiting for fn call to yield True (10).

real    0m8,040s
user    0m0,021s
sys     0m0,016s
```
