### PR TITLE
xen: Check for a valid Xen ChangeSet in 'xl dmesg'

### DIFF
--- a/tests/xen/test_misc.py
+++ b/tests/xen/test_misc.py
@@ -1,0 +1,22 @@
+import logging
+import pytest
+import re
+
+# Misc tests for Xen host
+#
+# Requirements:
+# - XCP-ng host
+
+# Check for a valid "Latest ChangeSet" trace in 'xl dmesg'
+def test_xen_changeset(host):
+    changeset = host.ssh(['xl', 'dmesg', '|', 'grep', '"Latest ChangeSet"'])
+    regexp = r'.*Latest ChangeSet:\s*(([^,]+),.*)'
+
+    m = re.match(regexp, changeset)
+    assert m is not None, "'Latest ChangeSet' should be found in 'xl dmesg'"
+
+    full_changeset, git_sha = m.groups()
+    logging.info(f"Xen Latest ChangeSet: {full_changeset}")
+
+    m = re.match(r'[0-9a-fA-F]+', git_sha)
+    assert m is not None, "Xen Latest ChangeSet should be set and formatted as a commit hash"


### PR DESCRIPTION
This commit adds the xen/test_misc.py file. The first test defined is test_xen_changeset() that checks for a valid git sha1 in the 'Latest ChangeSet' trace from 'xl dmesg'.