### PR TITLE
uefi_sb: Test pool and VM cert states when no custom cert installed

### DIFF
--- a/tests/uefi_sb/test_varstored_cert_flow.py
+++ b/tests/uefi_sb/test_varstored_cert_flow.py
@@ -51,6 +51,8 @@ class TestPoolToDiskCertPropagationToAllHosts:
         for h in host.pool.hosts:
             logging.info(f"Check host {h} has no custom certificates on disk.")
             assert h.is_symlink(host.varstore_dir())
+            logging.info(f"Check host {h} only has PK, and no other certs.")
+            assert h.ssh(['ls', '/var/lib/varstored/']) == 'PK.auth'
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_at_least_8_3")
@@ -116,9 +118,23 @@ class TestPoolToVMCertInheritance:
         pool_auths = generate_keys(as_dict=True)
         vm.host.pool.install_custom_uefi_certs([pool_auths[key] for key in ['PK', 'KEK', 'db', 'dbx']])
         vm.start()
-        logging.info("Check that the VM certs were updated")
+        logging.info("Check that the VM certs were updated: PK, KEK, db, dbx")
         for key in ['PK', 'KEK', 'db', 'dbx']:
             check_vm_cert_md5sum(vm, key, pool_auths[key].auth)
+
+    def test_start_vm_without_uefi_vars_on_pool_with_only_pk(self, uefi_vm):
+        # When a VM first starts but the pool doesn't have certs configured,
+        # this used, until late in 8.3 development, to *not* propagate the certs to the VM
+        # and we had no test that detected this situation.
+        # We have now changed the behaviour, propagating the certs even if just PK is present.
+        vm = uefi_vm
+        vm.clear_uefi_variables()
+        vm.host.pool.clear_custom_uefi_certs()
+        vm.start()
+        logging.info("Check that the VM certs were updated: PK only")
+        assert vm.is_cert_present('PK')
+        for key in ['KEK', 'db', 'dbx']:
+            assert not vm.is_cert_present(key)
 
     def test_start_vm_in_setup_mode(self, uefi_vm):
         # In setup mode, no cert is set, but other UEFI variables are present.


### PR DESCRIPTION
We previously didn't check that a pool without custom certs only has PK.auth in `/var/lib/varstored`. Check this.

We also didn't test what happens when you boot a fresh UEFI VM on a pool which only has PK.auth, and this bit us. We thought it would behave some way, and it actually behaved the other way. We changed it so that it behaves as we need, so add a test which ensures this works and doesn't regress in the future.