### PR TITLE
Reduce usage of pytest test-parameters

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -55,12 +55,6 @@ def pytest_addoption(parser):
              "Example: 'server:10.0.0.1,serverpath:/vms,nfsversion:4.1'.",
     )
     parser.addoption(
-        "--additional-repos",
-        action="append",
-        default=[],
-        help="Additional repo URLs added to the yum config"
-    )
-    parser.addoption(
         "--second-network",
         action="store",
         default=None,
@@ -456,14 +450,6 @@ def pytest_generate_tests(metafunc):
             # For us it means use the defaults.
             configs = [None]
         metafunc.parametrize("sr_device_config", configs, indirect=True, scope="session")
-    if "additional_repos" in metafunc.fixturenames:
-        repos = metafunc.config.getoption("additional_repos")
-        if not repos:
-            # No --additional-repos parameter doesn't mean skip the test.
-            # It's an optional parameter, if missing we must execute additional_repos fixture
-            # without error.
-            repos = [None]
-        metafunc.parametrize("additional_repos", repos, indirect=True, scope="session")
     if "second_network" in metafunc.fixturenames:
         second_network = metafunc.config.getoption("second_network")
         metafunc.parametrize("second_network", [second_network], indirect=True, scope="session")

--- a/conftest.py
+++ b/conftest.py
@@ -48,13 +48,6 @@ def pytest_addoption(parser):
         help="VM key or OVA URL for tests that require only one VM",
     )
     parser.addoption(
-        "--sr-device-config",
-        action="append",
-        default=[],
-        help="device-config keys and values for a remote SR. "
-             "Example: 'server:10.0.0.1,serverpath:/vms,nfsversion:4.1'.",
-    )
-    parser.addoption(
         "--second-network",
         action="store",
         default=None,
@@ -378,21 +371,6 @@ def uefi_vm(imported_vm):
     yield vm
 
 @pytest.fixture(scope='session')
-def sr_device_config(request):
-    raw_config = request.param
-
-    if raw_config is None:
-        # Use defaults
-        return None
-
-    config = {}
-    for key_val in raw_config.split(','):
-        key = key_val.split(':')[0]
-        value = key_val[key_val.index(':') + 1:]
-        config[key] = value
-    return config
-
-@pytest.fixture(scope='session')
 def additional_repos(request, hosts):
     if request.param is None:
         yield []
@@ -444,13 +422,6 @@ def pytest_generate_tests(metafunc):
         if not vms:
             vms = [None] # no --vm parameter does not mean skip the test, for us, it means use the default
         metafunc.parametrize("vm_ref", vms, indirect=True, scope="module")
-    if "sr_device_config" in metafunc.fixturenames:
-        configs = metafunc.config.getoption("sr_device_config")
-        if not configs:
-            # No --sr-device-config parameter doesn't mean skip the test.
-            # For us it means use the defaults.
-            configs = [None]
-        metafunc.parametrize("sr_device_config", configs, indirect=True, scope="session")
 
 def pytest_collection_modifyitems(items, config):
     # Automatically mark tests based on fixtures they require.

--- a/conftest.py
+++ b/conftest.py
@@ -226,8 +226,11 @@ def local_sr_on_hostB1(hostB1):
     yield sr
 
 @pytest.fixture(scope='session')
-def sr_disk(request, host):
-    disk = request.param
+def sr_disk(pytestconfig, host):
+    disks = pytestconfig.getoption("sr_disk")
+    if len(disks) != 1:
+        pytest.fail("This test requires exactly one --sr-disk parameter")
+    disk = disks[0]
     if disk == "auto":
         logging.info(">> Check for the presence of a free disk device on the master host")
         disks = host.available_disks()
@@ -241,8 +244,11 @@ def sr_disk(request, host):
     yield disk
 
 @pytest.fixture(scope='session')
-def sr_disk_4k(request, host):
-    disk = request.param
+def sr_disk_4k(pytestconfig, host):
+    disks = pytestconfig.getoption("sr_disk_4k")
+    if len(disks) != 1:
+        pytest.fail("This test requires exactly one --sr-disks-4k parameter")
+    disk = disks[0]
     if disk == "auto":
         logging.info(">> Check for the presence of a free 4KiB block device on the master host")
         disks = host.available_disks(4096)
@@ -256,8 +262,11 @@ def sr_disk_4k(request, host):
     yield disk
 
 @pytest.fixture(scope='session')
-def sr_disk_for_all_hosts(request, host):
-    disk = request.param
+def sr_disk_for_all_hosts(pytestconfig, request, host):
+    disks = pytestconfig.getoption("sr_disk")
+    if len(disks) != 1:
+        pytest.fail("This test requires exactly one --sr-disk parameter")
+    disk = disks[0]
     master_disks = host.available_disks()
     assert len(master_disks) > 0, "a free disk device is required on the master host"
 
@@ -458,15 +467,6 @@ def pytest_generate_tests(metafunc):
     if "second_network" in metafunc.fixturenames:
         second_network = metafunc.config.getoption("second_network")
         metafunc.parametrize("second_network", [second_network], indirect=True, scope="session")
-    if "sr_disk" in metafunc.fixturenames:
-        disk = metafunc.config.getoption("sr_disk")
-        metafunc.parametrize("sr_disk", disk, indirect=True, scope="session")
-    if "sr_disk_4k" in metafunc.fixturenames:
-        disk = metafunc.config.getoption("sr_disk_4k")
-        metafunc.parametrize("sr_disk_4k", disk, indirect=True, scope="session")
-    if "sr_disk_for_all_hosts" in metafunc.fixturenames:
-        disk = metafunc.config.getoption("sr_disk")
-        metafunc.parametrize("sr_disk_for_all_hosts", disk, indirect=True, scope="session")
 
 def pytest_collection_modifyitems(items, config):
     # Automatically mark tests based on fixtures they require.

--- a/data.py-dist
+++ b/data.py-dist
@@ -54,25 +54,25 @@ DEFAULT_SR = 'default'
 CACHE_IMPORTED_VM = False
 
 # Default NFS device config:
-DEFAULT_NFS_DEVICE_CONFIG = {
+NFS_DEVICE_CONFIG = {
 #    'server': '10.0.0.2', # URL/Hostname of NFS server
 #    'serverpath': '/path/to/shared/mount' # Path to shared mountpoint
 }
 
 # Default NFS4+ only device config:
-DEFAULT_NFS4_DEVICE_CONFIG = {
+NFS4_DEVICE_CONFIG = {
 #    'server': '10.0.0.2', # URL/Hostname of NFS server
 #    'serverpath': '/path_to_shared_mount' # Path to shared mountpoint
 #    'nfsversion': '4.1'
 }
 
 # Default NFS ISO device config:
-DEFAULT_NFS_ISO_DEVICE_CONFIG = {
+NFS_ISO_DEVICE_CONFIG = {
 #    'location': '10.0.0.2:/path/to/shared/mount' # URL/Hostname of NFS server and path to shared mountpoint
 }
 
 # Default CIFS ISO device config:
-DEFAULT_CIFS_ISO_DEVICE_CONFIG = {
+CIFS_ISO_DEVICE_CONFIG = {
 #    'location': r'\\10.0.0.2\<shared folder name>',
 #    'username': '<user>',
 #    'cifspassword': '<password>',
@@ -80,20 +80,29 @@ DEFAULT_CIFS_ISO_DEVICE_CONFIG = {
 #    'vers': '<1.0> or <3.0>'
 }
 
-DEFAULT_CEPHFS_DEVICE_CONFIG = {
+CEPHFS_DEVICE_CONFIG = {
 #    'server': '10.0.0.2',
 #    'serverpath': '/vms'
 }
 
-DEFAULT_MOOSEFS_DEVICE_CONFIG = {
+MOOSEFS_DEVICE_CONFIG = {
 #    'masterhost': 'mfsmaster',
 #    'masterport': '9421',
 #    'rootpath': '/vms'
 }
 
-DEFAULT_LVMOISCSI_DEVICE_CONFIG = {
+LVMOISCSI_DEVICE_CONFIG = {
 #    'target': '192.168.1.1',
 #    'port': '3260',
 #    'targetIQN': 'target.example',
 #    'SCSIid': 'id'
 }
+
+# compatibility settings for older tests
+DEFAULT_NFS_DEVICE_CONFIG = NFS_DEVICE_CONFIG
+DEFAULT_NFS4_DEVICE_CONFIG = NFS4_DEVICE_CONFIG
+DEFAULT_NFS_ISO_DEVICE_CONFIG = NFS_ISO_DEVICE_CONFIG
+DEFAULT_CIFS_ISO_DEVICE_CONFIG = CIFS_ISO_DEVICE_CONFIG
+DEFAULT_CEPHFS_DEVICE_CONFIG = CEPHFS_DEVICE_CONFIG
+DEFAULT_MOOSEFS_DEVICE_CONFIG = MOOSEFS_DEVICE_CONFIG
+DEFAULT_LVMOISCSI_DEVICE_CONFIG = LVMOISCSI_DEVICE_CONFIG

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,6 +1,10 @@
 ignore_ssh_banner = False
 ssh_output_max_lines = 20
 
-def sr_device_config(datakey):
+def sr_device_config(datakey, *, required=[]):
     import data # import here to avoid depending on this user file for collecting tests
-    return getattr(data, datakey)
+    config = getattr(data, datakey)
+    for required_field in required:
+        if required_field not in config:
+            raise Exception(f"{datakey} lacks mandatory {required_field!r}")
+    return config

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,2 +1,6 @@
 ignore_ssh_banner = False
 ssh_output_max_lines = 20
+
+def sr_device_config(datakey):
+    import data # import here to avoid depending on this user file for collecting tests
+    return getattr(data, datakey)

--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 
 from lib.common import exec_nofail, raise_errors
+from lib import config
 
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state
@@ -22,21 +23,8 @@ def pool_with_ceph(pool_without_ceph, pool_with_saved_yum_state):
     yield pool
 
 @pytest.fixture(scope='package')
-def cephfs_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_CEPHFS_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_CEPHFS_DEVICE_CONFIG = {}
-        if DEFAULT_CEPHFS_DEVICE_CONFIG:
-            config = DEFAULT_CEPHFS_DEVICE_CONFIG
-        else:
-            raise Exception("No default CephFS device-config found, neither in CLI nor in data.py defaults")
-    return config
+def cephfs_device_config():
+    return config.sr_device_config("CEPHFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
 def cephfs_sr(host, cephfs_device_config, pool_with_ceph):

--- a/tests/storage/iso/conftest.py
+++ b/tests/storage/iso/conftest.py
@@ -2,6 +2,8 @@ import pytest
 import time
 import os
 
+from lib import config
+
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import formatted_and_mounted_ext4_disk
 
@@ -23,38 +25,12 @@ def local_iso_sr(host, formatted_and_mounted_ext4_disk):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def nfs_iso_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_NFS_ISO_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_NFS_ISO_DEVICE_CONFIG = {}
-        if DEFAULT_NFS_ISO_DEVICE_CONFIG:
-            config = DEFAULT_NFS_ISO_DEVICE_CONFIG
-        else:
-            raise Exception("No default NFS ISO device-config found, neither in CLI nor in data.py defaults")
-    return config
+def nfs_iso_device_config():
+    return config.sr_device_config("NFS_ISO_DEVICE_CONFIG")
 
 @pytest.fixture(scope='module')
-def cifs_iso_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_CIFS_ISO_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_CIFS_ISO_DEVICE_CONFIG = {}
-        if DEFAULT_CIFS_ISO_DEVICE_CONFIG:
-            config = DEFAULT_CIFS_ISO_DEVICE_CONFIG
-        else:
-            raise Exception("No default CIFS ISO device-config found, neither in CLI nor in data.py defaults")
-    return config
+def cifs_iso_device_config():
+    return config.sr_device_config("CIFS_ISO_DEVICE_CONFIG")
 
 @pytest.fixture(scope='module')
 def nfs_iso_sr(host, nfs_iso_device_config):

--- a/tests/storage/iso/conftest.py
+++ b/tests/storage/iso/conftest.py
@@ -26,7 +26,7 @@ def local_iso_sr(host, formatted_and_mounted_ext4_disk):
 
 @pytest.fixture(scope='module')
 def nfs_iso_device_config():
-    return config.sr_device_config("NFS_ISO_DEVICE_CONFIG")
+    return config.sr_device_config("NFS_ISO_DEVICE_CONFIG", required=['location'])
 
 @pytest.fixture(scope='module')
 def cifs_iso_device_config():

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -1,22 +1,11 @@
 import logging
 import pytest
 
+from lib import config
+
 @pytest.fixture(scope='package')
-def lvmoiscsi_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_LVMOISCSI_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_LVMOISCSI_DEVICE_CONFIG = {}
-        if DEFAULT_LVMOISCSI_DEVICE_CONFIG:
-            config = DEFAULT_LVMOISCSI_DEVICE_CONFIG
-        else:
-            raise Exception("No default lvmoiscsi device-config found, neither in CLI nor in data.py defaults")
-    return config
+def lvmoiscsi_device_config():
+    return config.sr_device_config("LVMOISCSI_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
 def lvmoiscsi_sr(host, lvmoiscsi_device_config):

--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -1,6 +1,8 @@
 import logging
 import pytest
 
+from lib import config
+
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state
 
@@ -35,21 +37,8 @@ def pool_with_moosefs_enabled(pool_with_moosefs_installed):
     pool.exec_on_hosts_on_error_continue(disable_moosefs)
 
 @pytest.fixture(scope='package')
-def moosefs_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_MOOSEFS_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_MOOSEFS_DEVICE_CONFIG = {}
-        if DEFAULT_MOOSEFS_DEVICE_CONFIG:
-            config = DEFAULT_MOOSEFS_DEVICE_CONFIG
-        else:
-            raise Exception("No default MooseFS device-config found, neither in CLI nor in data.py defaults")
-    return config
+def moosefs_device_config():
+    return config.sr_device_config("MOOSEFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
 def moosefs_sr(moosefs_device_config, pool_with_moosefs_enabled):

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -1,6 +1,8 @@
 import logging
 import pytest
 
+from lib import config
+
 # --- Dispatch fixture for NFS versions ----------------------------------------
 
 @pytest.fixture
@@ -10,21 +12,8 @@ def dispatch_nfs(request):
 # --- NFS3 fixtures ------------------------------------------------------------
 
 @pytest.fixture(scope='package')
-def nfs_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_NFS_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_NFS_DEVICE_CONFIG = {}
-        if DEFAULT_NFS_DEVICE_CONFIG:
-            config = DEFAULT_NFS_DEVICE_CONFIG
-        else:
-            raise Exception("No default NFS device-config found, neither in CLI nor in data.py defaults")
-    return config
+def nfs_device_config():
+    return config.sr_device_config("NFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
 def nfs_sr(host, nfs_device_config):
@@ -51,21 +40,8 @@ def vm_on_nfs_sr(host, nfs_sr, vm_ref):
 # --- NFS4+ only fixtures ------------------------------------------------------
 
 @pytest.fixture(scope='package')
-def nfs4_device_config(sr_device_config):
-    if sr_device_config is not None:
-        # SR device config from CLI param
-        config = sr_device_config
-    else:
-        # SR device config from data.py defaults
-        try:
-            from data import DEFAULT_NFS4_DEVICE_CONFIG
-        except ImportError:
-            DEFAULT_NFS4_DEVICE_CONFIG = {}
-        if DEFAULT_NFS4_DEVICE_CONFIG:
-            config = DEFAULT_NFS4_DEVICE_CONFIG
-        else:
-            raise Exception("No default NFS4+ device-config found, neither in CLI nor in data.py defaults")
-    return config
+def nfs4_device_config():
+    return config.sr_device_config("NFS4_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
 def nfs4_sr(host, nfs4_device_config):

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -20,7 +20,7 @@ class TestNFSSRCreateDestroy:
         sr.destroy(verify=True)
 
 # Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config', 'hosts')
+@pytest.mark.usefixtures('sr_device_config')
 class TestNFSSR:
     @pytest.mark.quicktest
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -5,8 +5,6 @@ from tests.storage import vdi_is_open
 # Requirements:
 # - one XCP-ng host >= 8.0 with an additional unused disk for the SR
 
-# Make sure this fixture is called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config')
 class TestNFSSRCreateDestroy:
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_device_config', 'nfs4_device_config'], indirect=True)
     def test_create_and_destroy_sr(self, host, dispatch_nfs):
@@ -19,8 +17,6 @@ class TestNFSSRCreateDestroy:
         vm.destroy(verify=True)
         sr.destroy(verify=True)
 
-# Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config')
 class TestNFSSR:
     @pytest.mark.quicktest
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 # Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config', 'vm_ref', 'hosts')
+@pytest.mark.usefixtures('sr_device_config', 'vm_ref')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     def test_cold_crosspool_migration(self, host, hostB1, dispatch_nfs, local_sr_on_hostB1):

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 # Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config', 'vm_ref')
+@pytest.mark.usefixtures('vm_ref')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     def test_cold_crosspool_migration(self, host, hostB1, dispatch_nfs, local_sr_on_hostB1):

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 # Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config', 'vm_ref', 'hosts')
+@pytest.mark.usefixtures('sr_device_config', 'vm_ref')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     def test_live_intrapool_shared_migration(self, host, hostA2, dispatch_nfs):

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -12,7 +12,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 # Make sure these fixtures are called before the parametrized one
-@pytest.mark.usefixtures('sr_device_config', 'vm_ref')
+@pytest.mark.usefixtures('vm_ref')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     def test_live_intrapool_shared_migration(self, host, hostA2, dispatch_nfs):


### PR DESCRIPTION
There is no real need to store the parameters coming from the CLI in a (single) test param, and it makes it much harder to describe test dependencies.

This PR deals with `--hosts` and `--sr-disk` (easily tested), applies same strategy to  `--second-network` (untested), and removes unused `--additional-repos`.

The same can be applied at least to `--sr-device-config`, but I'm leaving it out for now as it is more complex to test.
