### PR TITLE
run `quicktest` on ISO SR as well

### DIFF
--- a/tests/storage/iso/test_cifs_iso_sr.py
+++ b/tests/storage/iso/test_cifs_iso_sr.py
@@ -35,6 +35,9 @@ class TestCIFSISOSRCreateDestroy:
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("cifs_iso_sr")
 class TestCIFSISOSR:
+    @pytest.mark.quicktest
+    def test_quicktest(self, cifs_iso_sr):
+        cifs_iso_sr.run_quicktest()
 
     def test_iso_mount_and_read(self, host, cifs_iso_sr, running_unix_vm):
         # create the ISO SR on CIFS

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -41,6 +41,10 @@ class TestLocalISOSRCreateDestroy:
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("local_iso_sr")
 class TestLocalISOSR:
+    @pytest.mark.quicktest
+    def test_quicktest(self, local_iso_sr):
+        sr, _ = local_iso_sr
+        sr.run_quicktest()
 
     def test_iso_mount_and_read(self, host, local_iso_sr, unix_vm):
         sr, location = local_iso_sr

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -37,6 +37,9 @@ class TestNFSISOSRCreateDestroy:
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("nfs_iso_sr")
 class TestNFSISOSR:
+    @pytest.mark.quicktest
+    def test_quicktest(self, nfs_iso_sr):
+        nfs_iso_sr.run_quicktest()
 
     def test_iso_mount_and_read(self, host, nfs_iso_sr, running_unix_vm):
         # create the ISO SR on NFS


### PR DESCRIPTION
replaces https://github.com/xcp-ng/xcp-ng-tests/pull/186