### PR TITLE
plugin_updater: fix pkgfixture usage

### DIFF
--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -2,6 +2,12 @@ import logging
 import pytest
 import urllib.request
 
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
+from pkgfixtures import host_with_saved_yum_state
+# Requirements:
+# From --hosts parameter:
+# - host(A1): any master host of a pool, with access to XCP-ng RPM repositories and reports.xcp-ng.org.
+
 @pytest.fixture(scope="session")
 def extra_pkgs(host):
     version = host.xcp_version_short

--- a/tests/packages/extra/test_extra_group_pkgs.py
+++ b/tests/packages/extra/test_extra_group_pkgs.py
@@ -1,10 +1,3 @@
-# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state
-
-# Requirements:
-# From --hosts parameter:
-# - host(A1): any master host of a pool, with access to XCP-ng RPM repositories and reports.xcp-ng.org.
-
 def test_extra_group_packages_url_resolved(host, extra_pkgs):
     for p in extra_pkgs:
         host.ssh(['yumdownloader', '--resolve', '--urls', p])

--- a/tests/xapi-plugins/plugin_updater/conftest.py
+++ b/tests/xapi-plugins/plugin_updater/conftest.py
@@ -1,0 +1,1 @@
+from pkgfixtures import host_with_saved_yum_state

--- a/tests/xapi-plugins/plugin_updater/test_updater.py
+++ b/tests/xapi-plugins/plugin_updater/test_updater.py
@@ -1,4 +1,3 @@
-from pkgfixtures import host_with_saved_yum_state
 import json
 
 # Requirements:


### PR DESCRIPTION
pkgfixture stuff must *always* be used from conftest.py, or else strange problems appear because of the result shown in https://github.com/pytest-dev/pytest/issues/8189#issuecomment-2158537878

For this case it results in a test failure when test ordering changes, because of a safeguard added to the fixture.  And "stop using a test parameter for sr_disk" commit does cause such a change in test ordering.