### PR TITLE
packages: import pkgfixture only once

### DIFF
--- a/tests/packages/conftest.py
+++ b/tests/packages/conftest.py
@@ -1,0 +1,2 @@
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
+from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -4,9 +4,6 @@ import urllib.request
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state
-# Requirements:
-# From --hosts parameter:
-# - host(A1): any master host of a pool, with access to XCP-ng RPM repositories and reports.xcp-ng.org.
 
 @pytest.fixture(scope="session")
 def extra_pkgs(host):

--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -2,9 +2,6 @@ import logging
 import pytest
 import urllib.request
 
-# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state
-
 @pytest.fixture(scope="session")
 def extra_pkgs(host):
     version = host.xcp_version_short

--- a/tests/packages/extra/test_extra_group_pkgs.py
+++ b/tests/packages/extra/test_extra_group_pkgs.py
@@ -1,3 +1,7 @@
+# Requirements:
+# From --hosts parameter:
+# - host(A1): any master host of a pool, with access to XCP-ng RPM repositories and reports.xcp-ng.org.
+
 def test_extra_group_packages_url_resolved(host, extra_pkgs):
     for p in extra_pkgs:
         host.ssh(['yumdownloader', '--resolve', '--urls', p])

--- a/tests/packages/netdata/conftest.py
+++ b/tests/packages/netdata/conftest.py
@@ -1,8 +1,5 @@
 import pytest
 
-# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state
-
 @pytest.fixture(scope="package")
 def host_with_netdata(host_with_saved_yum_state):
     host = host_with_saved_yum_state


### PR DESCRIPTION
With current pytest (8.2.2) having the fixture imported in 2 subpackages of "tests.packages" causes confusion on the execution order of setup/teardown and causes host_with_saved_yum_state to be run nested, triggering protective assertion.

This is a (tentative) workaround for pytest handling of package-scoped fixtures, and can possibly break something else.