### PR TITLE
Add a test to check compatibility between mellanox drivers

### DIFF
--- a/tests/packages/mlx/conftest.py
+++ b/tests/packages/mlx/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+import logging
+
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
+from pkgfixtures import host_with_saved_yum_state
+
+@pytest.fixture(scope="package")
+def host_without_mlx_compat_loaded(host_with_saved_yum_state):
+    host = host_with_saved_yum_state
+
+    # We need to check if mlx_compat module is loaded. If it is already loaded,
+    # we need to unload it before starting the test and load it again when the test ends.
+    mlx_compat_loaded = host.ssh_with_result(['lsmod', '|', 'grep', 'mlx_compat']).returncode == 0
+    if mlx_compat_loaded:
+        logging.info("mlx_compat is loaded so unload it before testing")
+        host.ssh(['modprobe', '-r', '-v', 'mlx_compat'])
+    else:
+        logging.info("mlx_compat is not loaded")
+
+    yield host
+
+    # Reload the mlx_compat module if it was loaded when starting the test
+    if mlx_compat_loaded:
+        logging.info("test is done so reload mlx_compat")
+        host.ssh(['modprobe', '-v', 'mlx_compat'])

--- a/tests/packages/mlx/test_mellanox-modules-compat.py
+++ b/tests/packages/mlx/test_mellanox-modules-compat.py
@@ -1,0 +1,26 @@
+# Requirements:
+# From --hosts parameter:
+# - host(A1): any master host of a pool, with access to XCP-ng RPM repositories.
+
+MLX4_MODULE = 'mlx4_en'
+
+def load_unload_mlx_module(host):
+    host.ssh(['modprobe', '-v', MLX4_MODULE])
+    host.ssh(['modprobe', '-r', '-v', MLX4_MODULE])
+
+def test_install_mlx_modules_alt(host_without_mlx_compat_loaded):
+    host = host_without_mlx_compat_loaded
+
+    # Ensure the modules are unloaded
+    host.yum_remove(['mlx4-modules-alt', 'mellanox-mlnxen-alt'])
+
+    # Start by loading mlx4
+    host.yum_install(['mlx4-modules-alt'])
+    load_unload_mlx_module(host)
+
+    # Ensure that mlx_compat is still unloaded
+    assert host.ssh_with_result(['lsmod', '|', 'grep', 'mlx_compat']).returncode == 1
+
+    # Now load mellanox-mlnxen-alt
+    host.yum_install(['mellanox-mlnxen-alt'])
+    load_unload_mlx_module(host)


### PR DESCRIPTION
The mlx4 driver requires mlx_compat.ko from the mlx5 driver and the version differ. Someday compatibility may break. This test will detect it.