### PR TITLE
Do not hide PCI devices with dependencies

### DIFF
--- a/tests/pci_passthrough/conftest.py
+++ b/tests/pci_passthrough/conftest.py
@@ -5,7 +5,7 @@ from lib.common import safe_split
 
 @pytest.fixture(scope="session")
 def enabled_pci_uuid(host):
-    pci_uuids = safe_split(host.xe("pci-list", {"host-uuid": host.uuid}, minimal=True), ',')
+    pci_uuids = safe_split(host.xe("pci-list", {"host-uuid": host.uuid, "dependencies": ""}, minimal=True), ',')
 
     pci_uuid = None
     for uuid in pci_uuids:


### PR DESCRIPTION
This can cause issues for other devices denpending on the hidden one.