### PR TITLE
Fix XTF run on xcp-ng 8.2

### DIFF
--- a/tests/xen/conftest.py
+++ b/tests/xen/conftest.py
@@ -1,6 +1,8 @@
 import logging
 import pytest
 
+from packaging import version
+
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state
 
@@ -25,14 +27,21 @@ def host_with_dynamically_disabled_ept_sp(host):
     host.ssh(['xl', 'set-parameters', 'ept=exec-sp'])
 
 @pytest.fixture(scope="package")
-def host_with_git_and_gcc(host_with_saved_yum_state):
+def host_with_git_and_gcc_and_py3(host_with_saved_yum_state):
     host = host_with_saved_yum_state
+    host_less_8_3 = host.xcp_version < version.parse("8.3")
+    if host_less_8_3:
+        # XTF needs to be run with python3
+        host.yum_install(['python36'])
+        host.ssh(['ln', '-s', '/usr/bin/python36', '/usr/bin/python3'])
     host.yum_install(['git', 'gcc'])
     yield host
+    if host_less_8_3:
+        host.ssh(['rm', '/usr/bin/python3'])
 
 @pytest.fixture(scope="package")
-def xtf_runner(host_with_git_and_gcc):
-    host = host_with_git_and_gcc
+def xtf_runner(host_with_git_and_gcc_and_py3):
+    host = host_with_git_and_gcc_and_py3
     logging.info("Download and build XTF")
     tmp_dir = host.ssh(['mktemp', '-d'])
     try:


### PR DESCRIPTION
XTF needs py3 to be ran.
Install py3 on XCP-ng < 8.3 to fix XTF run.

See: https://github.com/andyhhp/xtf/commit/4172faef1c0dee027ddd3ffdbc88fe20eb711e9c