### PR TITLE
Print the full error message for failed systemd units

### DIFF
--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -16,6 +16,7 @@ white_list_issues = [
     "Cannot add dependency job for unit getty@tty1.service, ignoring: Unit is masked.",
     "Cannot add dependency job for unit display-manager.service, ignoring: Unit not found.",
     "Cannot add dependency job for unit qemuback.service, ignoring: Unit not found.",
+    "Cannot add dependency job for unit sr_health_check.timer, ignoring: Unit not found.",
 ]
 
 pytest.fixture(scope='module')

--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -15,6 +15,7 @@ def test_failed_units(host):
 white_list_issues = [
     "Cannot add dependency job for unit getty@tty1.service, ignoring: Unit is masked.",
     "Cannot add dependency job for unit display-manager.service, ignoring: Unit not found.",
+    "Cannot add dependency job for unit qemuback.service, ignoring: Unit not found.",
 ]
 
 pytest.fixture(scope='module')

--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -9,10 +9,8 @@ pytest.fixture(scope='module')
 def test_failed_units(host):
     failed_services = host.ssh(['systemctl', '--state=failed', '--full', '--all',
                                '--no-pager', '--no-legend'])
-    for unit in failed_services.splitlines():
-        logging.error(f"Unit {unit.split()[0]} failed")
-
-    assert not failed_services
+    if failed_services:
+        pytest.fail(failed_services)
 
 white_list_issues = [
     "Cannot add dependency job for unit getty@tty1.service, ignoring: Unit is masked.",


### PR DESCRIPTION
The test now uses pytest.fail() if units are in failed state, printing out the full error message.