### PR TITLE
ssh: don't use a separate logger

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -59,12 +59,6 @@ def _ellide_log_lines(log):
         reduced_message.append("(...)")
     return "\n{}".format("\n".join(reduced_message))
 
-OUPUT_LOGGER = logging.getLogger('output')
-OUPUT_LOGGER.propagate = False
-OUTPUT_HANDLER = logging.StreamHandler()
-OUPUT_LOGGER.addHandler(OUTPUT_HANDLER)
-OUTPUT_HANDLER.setFormatter(logging.Formatter('%(message)s'))
-
 def _ssh(hostname_or_ip, cmd, check, simple_output, suppress_fingerprint_warnings,
          background, target_os, decode, options):
     opts = list(options)
@@ -111,7 +105,7 @@ def _ssh(hostname_or_ip, cmd, check, simple_output, suppress_fingerprint_warning
     for line in iter(process.stdout.readline, b''):
         readable_line = line.decode(errors='replace').strip()
         stdout.append(line)
-        OUPUT_LOGGER.debug(readable_line)
+        logging.debug("> %s", readable_line)
     _, stderr = process.communicate()
     res = subprocess.CompletedProcess(ssh_cmd, process.returncode, b''.join(stdout), stderr)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ markers =
     flaky: flaky tests. Usually pass, but sometimes fail unexpectedly.
     complex_prerequisites: tests whose prerequisites are complex and may require special attention.
     quicktest: runs `quicktest`.
+log_level = debug
 log_cli = 1
 log_cli_level = info
 log_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --maxfail=1 -s
+addopts = -ra --maxfail=1
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.


### PR DESCRIPTION
The logger setup was confusing when using --log-file-level=DEBUG, showing this debug-level output inside default --log-cli-level=INFO output, but without the debug context that only went into the logfile, and without any hint of what kind of output it was.

This makes it use the same logger as all other debug output, preventing it from appearing in the wrong place, and adds a marker to hint it is output data - at the same time fixing a potential formatting issue, where arbitrary ssh output lines were interpreted as *format strings*.