### PR TITLE
vm cache: shorten vm description by stripping .xva suffix

### DIFF
--- a/lib/common.py
+++ b/lib/common.py
@@ -1,6 +1,7 @@
 import getpass
 import inspect
 import logging
+import sys
 import time
 import traceback
 from enum import Enum
@@ -74,6 +75,20 @@ def parse_xe_dict(xe_dict):
 def safe_split(text, sep=','):
     """ A split function that returns an empty list if the input string is empty. """
     return text.split(sep) if len(text) > 0 else []
+
+def strip_prefix(string, prefix):
+    if sys.version_info >= (3, 9):
+        return string.removeprefix(prefix)
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    return string
+
+def strip_suffix(string, suffix):
+    if sys.version_info >= (3, 9):
+        return string.removesuffix(suffix)
+    if string.endswith(suffix):
+        return string[:-len(suffix)]
+    return string
 
 def setup_formatted_and_mounted_disk(host, sr_disk, fs_type, mountpoint):
     if fs_type == 'ext4':

--- a/lib/host.py
+++ b/lib/host.py
@@ -8,7 +8,7 @@ from packaging import version
 
 import lib.commands as commands
 
-from lib.common import _param_get, safe_split, to_xapi_bool, wait_for, wait_for_not
+from lib.common import _param_get, safe_split, strip_suffix, to_xapi_bool, wait_for, wait_for_not
 from lib.common import prefix_object_name
 from lib.netutil import wrap_ip
 from lib.sr import SR
@@ -202,7 +202,7 @@ class Host:
 
     @staticmethod
     def vm_cache_key(uri):
-        return f"[Cache for {uri}]"
+        return f"[Cache for {strip_suffix(uri, '.xva')}]"
 
     def cached_vm(self, uri, sr_uuid):
         assert sr_uuid, "A SR UUID is necessary to use import cache"


### PR DESCRIPTION
With install tests the description becomes really long, use chars sparingly.
