### PR TITLE
Use PCI of a PGPU for PCI passthrough tests

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -401,7 +401,7 @@ JOBS = {
     "pci-passthrough": {
         "description": "Testing PCI passthrough functionalities",
         "requirements": [
-            "A XCP-ng host >= 8.3 with a PGPU and a PCI to passthrough.",
+            "A XCP-ng host >= 8.3 with a PGPU to passthrough.",
             "The host will be rebooted by the tests."
         ],
         "nb_pools": 1,


### PR DESCRIPTION
Instead a picking a random PCI that could break the host when passthroughed: use the PCI of a PGPU that will also be used in PGPU passthrough tests anyway.