### PR TITLE
Improvements to set_xva_bridge.sh

### DIFF
--- a/scripts/set_xva_bridge.sh
+++ b/scripts/set_xva_bridge.sh
@@ -105,10 +105,10 @@ else
     exit 1
 fi
 
+chmod -R u+rX "${TMPFOLDER}"
+
 if [ -e "${TMPFOLDER}/ova.xml" ]; then
-    chmod +rw "${TMPFOLDER}/ova.xml"
-    sed -i "s/<member><name>bridge<\/name><value>[^<]*<\/value><\/member>/<member><name>bridge<\/name><value>${BRIDGE_VALUE}<\/value><\/member>/g" ${TMPFOLDER}/ova.xml
-    chmod -rw "${TMPFOLDER}/ova.xml"
+    sed -i "s/<member><name>bridge<\/name><value>[^<]*<\/value><\/member>/<member><name>bridge<\/name><value>${BRIDGE_VALUE}<\/value><\/member>/g" "${TMPFOLDER}/ova.xml"
 else
     echo "Error: File ova.xml not found during the sed."
     exit 1
@@ -118,15 +118,11 @@ fi
 # save first file
 mv "${XVA_NAME}" "${XVA_NAME}.save"
 
-# create xva
-cd "${TMPFOLDER}"
-
 # Create the new XVA
-sudo tar -cv --${COMPRESS_METHOD} -f ${XVA_NAME} --no-recursion -T ${TMP_LIST}
+tar -C "${TMPFOLDER}" --${COMPRESS_METHOD} -cf "${XVA_NAME}" --no-recursion -T "${TMP_LIST}" --numeric-owner --owner=:0 --group=:0 --mode=ugo= --mtime=@0
 rm -f "${TMP_LIST}"
 
 # clean TMPFOLDER
-cd ..
 if [ -d "${TMPFOLDER}" ]; then
     rm -Rf "${TMPFOLDER}"
 else

--- a/scripts/set_xva_bridge.sh
+++ b/scripts/set_xva_bridge.sh
@@ -12,23 +12,6 @@ usage()
     echo "----------------------------------------------------------------------------------------"
 }
 
-# extract and read ova.xml
-get_bridge()
-{
-    TMPFOLD=$(mktemp -d /tmp/xvaXXXX)
-    tar -xf "${XVA_NAME}" -C "${TMPFOLD}" ova.xml
-    chmod +r "${TMPFOLD}/ova.xml"
-    XML_VALUE=$(grep -oE "<member><name>bridge</name><value>[^<]*</value></member>" "${TMPFOLD}/ova.xml")
-    LENGTH=${#XML_VALUE}
-    PREFIX_LENGTH=$((${LENGTH}-17))
-    NETWORK_VALUE=$(cut -c 1-${PREFIX_LENGTH} <<< ${XML_VALUE})
-    echo $(cut -c 35-${#NETWORK_VALUE} <<< ${NETWORK_VALUE})
-
-    if [ -d "${TMPFOLD}" ]; then
-        rm -Rf "${TMPFOLD}"
-    fi
-}
-
 # check parameters and prompt the usage if needed
 if [ -z "${1+set}" ]
 then
@@ -68,22 +51,6 @@ then
     exit 1
 else
     BRIDGE_VALUE=$3
-fi
-
-# we want to know the value of the network bridge.
-# then we can decide if we need to change it or not.
-BRIDGE_READVALUE=$(get_bridge)
-
-if [ -z "${BRIDGE_READVALUE}" ]
-then
-    echo "No bridge value detected in the xml file!"
-    exit 1
-else
-    if [ "${BRIDGE_READVALUE}" == "${BRIDGE_VALUE}" ]
-    then
-        echo "The bridge is already ${BRIDGE_VALUE}. Nothing to do."
-        exit 0
-    fi
 fi
 
 # we detect the compression method of the xva to uncompress it right

--- a/scripts/set_xva_bridge.sh
+++ b/scripts/set_xva_bridge.sh
@@ -96,8 +96,10 @@ fi
 PATHFOLDER=$(dirname "${XVA_NAME}")
 TMPFOLDER=$(mktemp -d "${PATHFOLDER}"/xvaXXXX)
 
+# extract and create the file list at the same time
+TMP_LIST=$(mktemp "${PATHFOLDER}"/SortedListXXXX.txt)
 if [ -f "${XVA_NAME}" ]; then
-    tar -xf $1 -C "${TMPFOLDER}"
+    tar -xvf "${XVA_NAME}" -C "${TMPFOLDER}" > "${TMP_LIST}"
 else
     echo "Error: ${XVA_NAME} not found."
     exit 1
@@ -120,8 +122,6 @@ mv "${XVA_NAME}" "${XVA_NAME}.save"
 cd "${TMPFOLDER}"
 
 # Create the new XVA
-TMP_LIST=$(mktemp /tmp/SortedListXXXX.txt)
-find . -print | cut -c3- | sort | grep -v "^Ref:[0-9]\+$" > ${TMP_LIST}
 sudo tar -cv --${COMPRESS_METHOD} -f ${XVA_NAME} --no-recursion -T ${TMP_LIST}
 rm -f "${TMP_LIST}"
 

--- a/scripts/set_xva_bridge.sh
+++ b/scripts/set_xva_bridge.sh
@@ -93,7 +93,7 @@ if [ "${OLD_COMPRESSION}" != "Zstandard" ] && [ "${OLD_COMPRESSION}" != "gzip" ]
             exit 1
 fi
 
-PATHFOLDER=$(dirname ${XVA_NAME})
+PATHFOLDER=$(dirname "${XVA_NAME}")
 TMPFOLDER=$(mktemp -d "${PATHFOLDER}"/xvaXXXX)
 
 if [ -f "${XVA_NAME}" ]; then

--- a/scripts/set_xva_bridge.sh
+++ b/scripts/set_xva_bridge.sh
@@ -87,7 +87,7 @@ else
 fi
 
 # we detect the compression method of the xva to uncompress it right
-OLD_COMPRESSION=$(file "${XVA_NAME}" | cut -f 2 -d :  | cut -f 2 -d " ")
+OLD_COMPRESSION=$(file -b "${XVA_NAME}" | cut -f 1 -d " ")
 if [ "${OLD_COMPRESSION}" != "Zstandard" ] && [ "${OLD_COMPRESSION}" != "gzip" ] && [ "${OLD_COMPRESSION}" != "tar" ]; then
             echo "Error: unknown compression type detected for ${XVA_NAME}: ${OLD_COMPRESSION}"
             exit 1


### PR DESCRIPTION
This PR introduces a few improvements to `set_xva_bridge.sh`:

- Fix cases where XVA_NAME contains spaces
- Get TMP_LIST from original archive instead of sorting to avoid situations where `sort` doesn't put ova.xml in the correct order
- Set owner and permissions in tar command instead of using `sudo` to read unreadable files
- Use `file -b` to simplify filetype parsing
- Don't check existing bridge name to avoid unnecessary tar pass