### PR TITLE
feat(storage/linstor): Enhance multi-disk support and provisioning flexibility in Linstor SR tests

### DIFF
--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -2,13 +2,13 @@ import logging
 import pytest
 import time
 
-from .conftest import STORAGE_POOL_NAME, LINSTOR_PACKAGE
+from .conftest import LINSTOR_PACKAGE
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for, vm_image
 from tests.storage import vdi_is_open
 
 # Requirements:
-# - one XCP-ng host >= 8.2 with an additional unused disk for the SR
+# - two or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR
 # - access to XCP-ng RPM repository from the host
 
 class TestLinstorSRCreateDestroy:
@@ -18,15 +18,15 @@ class TestLinstorSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_sr_without_linstor(self, host, lvm_disk):
+    def test_create_sr_without_linstor(self, host, lvm_disks, provisioning_type, storage_pool_name):
         # This test must be the first in the series in this module
         assert not host.is_package_installed('python-linstor'), \
             "linstor must not be installed on the host at the beginning of the tests"
         try:
             sr = host.sr_create('linstor', 'LINSTOR-SR-test', {
-                'group-name': STORAGE_POOL_NAME,
+                'group-name': storage_pool_name,
                 'redundancy': '1',
-                'provisioning': 'thin'
+                'provisioning': provisioning_type
             }, shared=True)
             try:
                 sr.destroy()
@@ -36,13 +36,13 @@ class TestLinstorSRCreateDestroy:
         except SSHCommandFailed as e:
             logging.info("SR creation failed, as expected: {}".format(e))
 
-    def test_create_and_destroy_sr(self, pool_with_linstor):
+    def test_create_and_destroy_sr(self, pool_with_linstor, provisioning_type, storage_pool_name):
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         master = pool_with_linstor.master
         sr = master.sr_create('linstor', 'LINSTOR-SR-test', {
-            'group-name': STORAGE_POOL_NAME,
+            'group-name': storage_pool_name,
             'redundancy': '1',
-            'provisioning': 'thin'
+            'provisioning': provisioning_type
         }, shared=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_linstor_sr fixture used in
         # the next tests, because errors in fixtures break teardown
@@ -147,7 +147,7 @@ def _ensure_resource_remain_diskless(host, controller_option, volume_name, diskl
 
 class TestLinstorDisklessResource:
     @pytest.mark.small_vm
-    def test_diskless_kept(self, host, linstor_sr, vm_on_linstor_sr):
+    def test_diskless_kept(self, host, linstor_sr, vm_on_linstor_sr, storage_pool_name):
         vm = vm_on_linstor_sr
         vdi_uuids = vm.vdi_uuids(sr_uuid=linstor_sr.uuid)
         vdi_uuid = vdi_uuids[0]
@@ -157,10 +157,12 @@ class TestLinstorDisklessResource:
         for member in host.pool.hosts:
             controller_option += f"{member.hostname_or_ip},"
 
+        sr_group_name = "xcp-sr-" + storage_pool_name.replace("/", "_")
+
         # Get volume name from VDI uuid
         # "xcp/volume/{vdi_uuid}/volume-name": "{volume_name}"
         output = host.ssh([
-            "linstor-kv-tool", "--dump-volumes", "-g", "xcp-sr-linstor_group_thin_device",
+            "linstor-kv-tool", "--dump-volumes", "-g", sr_group_name,
             "|", "grep", "volume-name", "|", "grep", vdi_uuid
         ])
         volume_name = output.split(': ')[1].split('"')[1]

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -53,8 +53,16 @@ class TestLinstorSRCreateDestroy:
 @pytest.mark.usefixtures("linstor_sr")
 class TestLinstorSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, linstor_sr):
-        linstor_sr.run_quicktest()
+    def test_quicktest(self, linstor_sr, provisioning_type):
+        try:
+            linstor_sr.run_quicktest()
+        except Exception:
+            if provisioning_type == "thick":
+                pytest.xfail(reason="Known failure for thick provisioning")
+            raise # Let thin failures fail test
+        else:
+            if provisioning_type == "thick":
+                pytest.fail("Expected failure for thick provisioning did not occur (XPASS)")
 
     def test_vdi_is_not_open(self, vdi_on_linstor_sr):
         assert not vdi_is_open(vdi_on_linstor_sr)


### PR DESCRIPTION
- Added `sr_disks_for_all_hosts` fixture to support multiple disks, ensuring availability across all hosts and handling "auto" selection dynamically.
- Updated `lvm_disk` fixture to provision multiple disks collectively, refining vgcreate and pvcreate logic.
- Introduced `provisioning_type` and `storage_pool_name` fixtures to dynamically configure storage provisioning (thin or thick).
- Refactored Linstor SR test cases to use the new fixtures, improving test coverage across provisioning types.
- Optimized Linstor installation and cleanup using concurrent execution, reducing setup time.
- Enhanced validation and logging for disk selection.