### PR TITLE
lib/vdi: Add VDI resize support and integrate into VM & linstor operations

### DIFF
--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -100,14 +100,14 @@ def pool_with_linstor(
     import concurrent.futures
     pool = pool_with_saved_yum_state
 
-    def check_linstor_installed(host: Host):
+    def assert_linstor_not_installed(host):
         if host.is_package_installed(LINSTOR_PACKAGE):
             raise Exception(
                 f'{LINSTOR_PACKAGE} is already installed on host {host}. This should not be the case.'
             )
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(check_linstor_installed, pool.hosts)
+        executor.map(assert_linstor_not_installed, pool.hosts)
 
     def install_linstor(host: Host):
         logging.info(f"Installing {LINSTOR_PACKAGE} on host {host}...")

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -88,6 +88,15 @@ class TestLinstorSR:
         finally:
             vm.shutdown(verify=True)
 
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_resize_vdi(self, vm_on_linstor_sr):
+        vm = vm_on_linstor_sr
+        logging.info("VDI Resize started")
+        for vdi_uuid in vm.vdi_uuids():
+            vm.vdi_resize(vdi_uuid)
+        logging.info("VDI Resize completed")
+
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot


### PR DESCRIPTION
- Added `resize` method to `VDI` class to allow resizing of VDIs via `xe vdi-resize`.
- Introduced `vdi_resize` method in VM class to support 2x VDI resizing.
- Implemented `test_resize_vdi` in Linstor and basic VM tests, verifying VDI resize functionality and ensuring VM boot post-resize.
- Refactored VM operations to include `wait_for_vm_running`.