### PR TITLE
guest-tools/win: Fix type hint compatibility with Python 3.8

### DIFF
--- a/tests/guest-tools/win/__init__.py
+++ b/tests/guest-tools/win/__init__.py
@@ -2,7 +2,7 @@ import enum
 import logging
 import re
 import time
-from typing import Any
+from typing import Any, Dict, Union
 
 from data import ISO_DOWNLOAD_URL
 from lib.commands import SSHCommandFailed
@@ -23,7 +23,7 @@ class PowerAction(enum.Enum):
     Reboot = "reboot"
 
 
-def iso_create(host: Host, sr: SR, param: dict[str, Any]):
+def iso_create(host: Host, sr: SR, param: Dict[str, Any]):
     if param["download"]:
         vdi = host.import_iso(ISO_DOWNLOAD_URL + param["name"], sr)
         new_param = param.copy()
@@ -55,7 +55,7 @@ def wait_for_vm_running_and_ssh_up_without_tools(vm: VM):
     wait_for(vm.is_ssh_up, "Wait for SSH up")
 
 
-def enable_testsign(vm: VM, rootcert: str | None):
+def enable_testsign(vm: VM, rootcert: Union[str, None]):
     if rootcert is not None:
         vm.execute_powershell_script(
             f"""certutil -addstore -f Root '{rootcert}';

--- a/tests/guest-tools/win/conftest.py
+++ b/tests/guest-tools/win/conftest.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Dict, Tuple
 import pytest
 
 from data import OTHER_GUEST_TOOLS, OTHER_GUEST_TOOLS_ISO, WIN_GUEST_TOOLS_ISOS
@@ -47,7 +47,7 @@ def unsealed_windows_vm_and_snapshot(running_windows_vm_without_tools: VM):
 
 
 @pytest.fixture
-def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: tuple[VM, Snapshot]):
+def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot]):
     vm, snapshot = unsealed_windows_vm_and_snapshot
     vm.start()
     wait_for_vm_running_and_ssh_up_without_tools(vm)
@@ -56,7 +56,7 @@ def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: tuple[VM, Snap
 
 
 @pytest.fixture(scope="class")
-def vm_install_test_tools_per_test_class(unsealed_windows_vm_and_snapshot, guest_tools_iso: dict[str, Any]):
+def vm_install_test_tools_per_test_class(unsealed_windows_vm_and_snapshot, guest_tools_iso: Dict[str, Any]):
     vm, snapshot = unsealed_windows_vm_and_snapshot
     vm.start()
     wait_for_vm_running_and_ssh_up_without_tools(vm)
@@ -66,7 +66,7 @@ def vm_install_test_tools_per_test_class(unsealed_windows_vm_and_snapshot, guest
 
 
 @pytest.fixture
-def vm_install_test_tools_no_reboot(running_unsealed_windows_vm: VM, guest_tools_iso: dict[str, Any]):
+def vm_install_test_tools_no_reboot(running_unsealed_windows_vm: VM, guest_tools_iso: Dict[str, Any]):
     install_guest_tools(running_unsealed_windows_vm, guest_tools_iso, PowerAction.Nothing)
     return running_unsealed_windows_vm
 
@@ -87,8 +87,8 @@ def other_tools_iso(host: Host, nfs_iso_sr: SR):
 
 @pytest.fixture(ids=list(OTHER_GUEST_TOOLS.keys()), params=list(OTHER_GUEST_TOOLS.values()))
 def vm_install_other_drivers(
-    unsealed_windows_vm_and_snapshot: tuple[VM, Snapshot],
-    other_tools_iso: dict[str, Any],
+    unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot],
+    other_tools_iso: Dict[str, Any],
     request: pytest.FixtureRequest,
 ):
     vm, snapshot = unsealed_windows_vm_and_snapshot

--- a/tests/guest-tools/win/guest_tools.py
+++ b/tests/guest-tools/win/guest_tools.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import PureWindowsPath
-from typing import Any
+from typing import Any, Dict
 
 from lib.common import wait_for
 from lib.vm import VM
@@ -21,7 +21,7 @@ ERROR_SUCCESS_REBOOT_REQUIRED = 3010
 GUEST_TOOLS_COPY_PATH = "C:\\package.msi"
 
 
-def install_guest_tools(vm: VM, guest_tools_iso: dict[str, Any], action: PowerAction, check: bool = True):
+def install_guest_tools(vm: VM, guest_tools_iso: Dict[str, Any], action: PowerAction, check: bool = True):
     insert_cd_safe(vm, guest_tools_iso["name"])
 
     if guest_tools_iso.get("testsign_cert"):

--- a/tests/guest-tools/win/other_tools.py
+++ b/tests/guest-tools/win/other_tools.py
@@ -1,13 +1,13 @@
 import logging
 from pathlib import PureWindowsPath
-from typing import Any
+from typing import Any, Dict
 
 from lib.common import wait_for
 from lib.vm import VM
 from . import WINDOWS_SHUTDOWN_COMMAND, enable_testsign, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
 
 
-def install_other_drivers(vm: VM, other_tools_iso_name: str, param: dict[str, Any]):
+def install_other_drivers(vm: VM, other_tools_iso_name: str, param: Dict[str, Any]):
     if param.get("vendor_device"):
         assert not vm.param_get("has-vendor-device")
         vm.param_set("has-vendor-device", True)

--- a/tests/guest-tools/win/test_xenclean.py
+++ b/tests/guest-tools/win/test_xenclean.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import PureWindowsPath
-from typing import Any
+from typing import Any, Dict
 import pytest
 from lib.common import wait_for
 from lib.vm import VM
@@ -8,7 +8,7 @@ from lib.vm import VM
 from . import WINDOWS_SHUTDOWN_COMMAND, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
 
 
-def run_xenclean(vm: VM, guest_tools_iso: dict[str, Any]):
+def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any]):
     insert_cd_safe(vm, guest_tools_iso["name"])
 
     logging.info("Run XenClean")


### PR DESCRIPTION
The `str | None` type hint syntax is only for 3.10 and up.