### PR TITLE
Use Python 3.8 in job checking action

### DIFF
--- a/.github/workflows/jobs-check.yml
+++ b/.github/workflows/jobs-check.yml
@@ -9,6 +9,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
This helps detect the use of unsupported language features. Unfortunately there's no easy way to detect use of unsupported library features.

Other actions stay on the latest Python version.