### PR TITLE
tests/storage/linstor: Added `test_linstor_sr_expand_host` and `test_linstor_sr_expand_disk` to test expand Linstor SR

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -75,6 +75,13 @@ def pytest_addoption(parser):
              "4KiB blocksize to be formatted and used in storage tests. "
              "Set it to 'auto' to let the fixtures auto-detect available disks."
     )
+    parser.addoption(
+        "--expansion-sr-disk",
+        action="append",
+        default=[],
+        help="Name of an available disk (sdc) or partition device (sdc2) to be formatted and used in storage tests. "
+             "Set it to 'auto' to let the fixtures auto-detect available disks."
+    )
 
 def pytest_configure(config):
     global_config.ignore_ssh_banner = config.getoption('--ignore-ssh-banner')

--- a/lib/host.py
+++ b/lib/host.py
@@ -516,7 +516,22 @@ class Host:
         disks.sort()
         return disks
 
-    def disk_is_available(self, disk):
+    def raw_disk_is_available(self, disk: str) -> bool:
+        """
+        Check if a raw disk (without any identifiable filesystem or partition label) is available.
+        It suggests the disk is "raw" and likely unformatted thus available.
+        """
+        return self.ssh_with_result(['blkid', '/dev/' + disk]).returncode == 2
+
+    def disk_is_available(self, disk: str) -> bool:
+        """
+        Check if a disk is unmounted and appears available for use.
+        It may or may not contain identifiable filesystem or partition label.
+        If there are no mountpoints, it is assumed that the disk is not in use.
+
+        Warn: This function may misclassify LVM_member disks (e.g. in XOSTOR, RAID, ZFS) as "available".
+        Such disks may not have mountpoints but still be in use.
+        """
         return len(self.ssh(['lsblk', '-n', '-o', 'MOUNTPOINT', '/dev/' + disk]).strip()) == 0
 
     def available_disks(self, blocksize=512):

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -37,9 +37,10 @@ def lvm_disks(host, sr_disks_for_all_hosts, provisioning_type):
     yield devices
 
     for host in hosts:
+        devices = host.ssh('vgs ' + GROUP_NAME + ' -o pv_name --no-headings').split("\n")
         host.ssh(['vgremove', '-f', GROUP_NAME])
         for device in devices:
-            host.ssh(['pvremove', device])
+            host.ssh(['pvremove', '-ff', '-y', device.strip()])
 
 @pytest.fixture(scope="package")
 def storage_pool_name(provisioning_type):


### PR DESCRIPTION
This PR is rebased from https://github.com/xcp-ng/xcp-ng-tests/pull/301. 
For `test_linstor_sr_expand_disk` to work correctly, it is important to find an available disk that is not only mounted but also `raw` in nature so that it can be made `LVM_member` for Linstor SR.