### PR TITLE
feat(coalesce): Add tests for coalesce

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -94,6 +94,13 @@ def pytest_addoption(parser):
              "4KiB blocksize to be formatted and used in storage tests. "
              "Set it to 'auto' to let the fixtures auto-detect available disks."
     )
+    parser.addoption(
+        "--image-format",
+        action="append",
+        default=[],
+        help="Format of VDI to execute tests on."
+        "Example: vhd,qcow2"
+    )
 
 def pytest_configure(config):
     global_config.ignore_ssh_banner = config.getoption('--ignore-ssh-banner')
@@ -105,6 +112,12 @@ def pytest_generate_tests(metafunc):
         if not vms:
             vms = [None] # no --vm parameter does not mean skip the test, for us, it means use the default
         metafunc.parametrize("vm_ref", vms, indirect=True, scope="module")
+
+    if "image_format" in metafunc.fixturenames:
+        image_format = metafunc.config.getoption("image_format")
+        if len(image_format) == 0:
+            image_format = ["vhd"] # Not giving image-format will default to doing tests on vhd
+        metafunc.parametrize("image_format", image_format, scope="session")
 
 def pytest_collection_modifyitems(items, config):
     # Automatically mark tests based on fixtures they require.

--- a/conftest.py
+++ b/conftest.py
@@ -304,6 +304,13 @@ def host_no_ipv6(host):
     if is_ipv6(host.hostname_or_ip):
         pytest.skip(f"This test requires an IPv4 XCP-ng")
 
+@pytest.fixture(scope="session")
+def shared_sr(host):
+    sr = host.pool.first_shared_sr()
+    assert sr, "No shared SR available on hosts"
+    logging.info(">> Shared SR on host present: {} of type {}".format(sr.uuid, sr.get_type()))
+    yield sr
+
 @pytest.fixture(scope='session')
 def local_sr_on_hostA1(hostA1):
     """ A local SR on the pool's master. """
@@ -311,7 +318,7 @@ def local_sr_on_hostA1(hostA1):
     assert len(srs) > 0, "a local SR is required on the pool's master"
     # use the first local SR found
     sr = srs[0]
-    logging.info(">> local SR on hostA1 present : %s" % sr.uuid)
+    logging.info(">> local SR on hostA1 present: {} of type {}".format(sr.uuid, sr.get_type()))
     yield sr
 
 @pytest.fixture(scope='session')
@@ -321,7 +328,7 @@ def local_sr_on_hostA2(hostA2):
     assert len(srs) > 0, "a local SR is required on the pool's second host"
     # use the first local SR found
     sr = srs[0]
-    logging.info(">> local SR on hostA2 present : %s" % sr.uuid)
+    logging.info(">> local SR on hostA2 present: {} of type {}".format(sr.uuid, sr.get_type()))
     yield sr
 
 @pytest.fixture(scope='session')
@@ -331,7 +338,7 @@ def local_sr_on_hostB1(hostB1):
     assert len(srs) > 0, "a local SR is required on the second pool's master"
     # use the first local SR found
     sr = srs[0]
-    logging.info(">> local SR on hostB1 present : %s" % sr.uuid)
+    logging.info(">> local SR on hostB1 present: {} of type {}".format(sr.uuid, sr.get_type()))
     yield sr
 
 @pytest.fixture(scope='session')

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, overload
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, overload
 
 if TYPE_CHECKING:
     import lib.host
@@ -59,7 +59,7 @@ class BaseVM:
     def _disk_list(self):
         raise NotImplementedError()
 
-    def vdi_uuids(self, sr_uuid=None):
+    def vdi_uuids(self, sr_uuid: Optional[str] = None) -> List[str]:
         output = self._disk_list()
         if output == '':
             return []

--- a/lib/host.py
+++ b/lib/host.py
@@ -67,6 +67,7 @@ class Host:
         self.uuid = self.inventory['INSTALLATION_UUID']
         self.xcp_version = version.parse(self.inventory['PRODUCT_VERSION'])
         self.xcp_version_short = f"{self.xcp_version.major}.{self.xcp_version.minor}"
+        self._dom0: Optional[VM] = None
 
     def __str__(self):
         return self.hostname_or_ip
@@ -711,3 +712,20 @@ class Host:
     def disable_hsts_header(self):
         self.ssh(['rm', '-f', f'{XAPI_CONF_DIR}/00-XCP-ng-tests-enable-hsts-header.conf'])
         self.restart_toolstack(verify=True)
+
+    def get_dom0_uuid(self):
+        return self.inventory["CONTROL_DOMAIN_UUID"]
+
+    def get_dom0_vm(self) -> VM:
+        if not self._dom0:
+            self._dom0 = VM(self.get_dom0_uuid(), self)
+        return self._dom0
+
+    def get_sr_from_vdi_uuid(self, vdi_uuid: str) -> Optional[SR]:
+        sr_uuid = self.xe("vdi-param-get", {
+            "param-name": "sr-uuid",
+            "uuid": vdi_uuid,
+        })
+        if not sr_uuid:
+            return None
+        return SR(sr_uuid, self.pool)

--- a/lib/snapshot.py
+++ b/lib/snapshot.py
@@ -2,7 +2,18 @@ import logging
 
 from lib.basevm import BaseVM
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+    from lib.vm import VM
+
+
 class Snapshot(BaseVM):
+    def __init__(self, uuid: str, host: "Host", vm: "VM"):
+        self.basevm = vm
+        super(Snapshot, self).__init__(uuid, host)
+
     def _disk_list(self):
         return self.host.xe('snapshot-disk-list', {'uuid': self.uuid, 'vbd-params': ''},
                             minimal=True)
@@ -21,3 +32,4 @@ class Snapshot(BaseVM):
     def revert(self):
         logging.info("Revert to snapshot %s", self.uuid)
         self.host.xe('snapshot-revert', {'uuid': self.uuid})
+        self.basevm.create_vdis_list() # We reset the base VM object VDIs list because it changed following the revert

--- a/lib/sr.py
+++ b/lib/sr.py
@@ -1,10 +1,17 @@
 import logging
 import time
-from typing import Optional
 
 import lib.commands as commands
-from lib.common import prefix_object_name, safe_split, strtobool, wait_for, wait_for_not
+from lib.common import (
+    prefix_object_name,
+    safe_split,
+    strtobool,
+    wait_for,
+    wait_for_not,
+)
 from lib.vdi import VDI
+
+from typing import Optional
 
 class SR:
     def __init__(self, uuid, pool):

--- a/lib/vdi.py
+++ b/lib/vdi.py
@@ -25,11 +25,7 @@ class VDI:
         # TODO: use a different approach when migration is possible
         if sr is None:
             assert host
-            sr_uuid = host.pool.get_vdi_sr_uuid(uuid)
-            # avoid circular import
-            # FIXME should get it from Host instead
-            from lib.sr import SR
-            self.sr = SR(sr_uuid, host.pool)
+            self.sr = host.get_sr_from_vdi_uuid(self.uuid)
         else:
             self.sr = sr
 

--- a/lib/vdi.py
+++ b/lib/vdi.py
@@ -50,6 +50,12 @@ class VDI:
     def __str__(self):
         return f"VDI {self.uuid} on SR {self.sr.uuid}"
 
+    def get_parent(self) -> Optional[str]:
+        return self.param_get("sm-config", key="vhd-parent", accept_unknown_key=True)
+
+    def get_image_format(self) -> Optional[str]:
+        return self.param_get("sm-config", key="image-format", accept_unknown_key=True)
+
     @overload
     def param_get(self, param_name: str, key: Optional[str] = ...,
                   accept_unknown_key: Literal[False] = ...) -> str:

--- a/tests/storage/coalesce/conftest.py
+++ b/tests/storage/coalesce/conftest.py
@@ -1,0 +1,53 @@
+import pytest
+
+import logging
+
+from lib.vdi import VDI
+
+MAX_LENGTH = 1 * 1024 * 1024 * 1024 # 1GiB
+
+@pytest.fixture(scope="module")
+def vdi_on_local_sr(host, local_sr_on_hostA1, image_format):
+    sr = local_sr_on_hostA1
+    vdi = sr.create_vdi("testVDI", MAX_LENGTH, image_format=image_format)
+    logging.info(">> Created VDI {} of type {}".format(vdi.uuid, image_format))
+
+    yield vdi
+
+    logging.info("<< Destroying VDI {}".format(vdi.uuid))
+    vdi.destroy()
+
+@pytest.fixture(scope="module")
+def vdi_with_vbd_on_dom0(host, vdi_on_local_sr):
+    dom0 = host.get_dom0_vm()
+    dom0.connect_vdi(vdi_on_local_sr)
+
+    yield vdi_on_local_sr
+
+    dom0.disconnect_vdi(vdi_on_local_sr)
+
+@pytest.fixture(scope="function")
+def data_file_on_host(host):
+    filename = "/root/data.bin"
+    logging.info(f">> Creating data file {filename} on host")
+    size = 1 * 1024 * 1024 # 1MiB
+    assert size <= MAX_LENGTH, "Size of the data file bigger than the VDI size"
+
+    host.ssh(["dd", "if=/dev/urandom", f"of={filename}", f"bs={size}", "count=1"])
+
+    yield filename
+
+    logging.info("<< Deleting data file")
+    host.ssh(["rm", filename])
+
+@pytest.fixture(scope="module")
+def tapdev(local_sr_on_hostA1, vdi_with_vbd_on_dom0):
+    """
+    A tapdev is a blockdevice allowing access to a VDI from the Dom0.
+
+    It is usually used to give access to the VDI to Qemu for emulating devices
+    before PV driver are loaded in the guest.
+    """
+    sr_uuid = local_sr_on_hostA1.uuid
+    vdi_uuid = vdi_with_vbd_on_dom0.uuid
+    yield f"/dev/sm/backend/{sr_uuid}/{vdi_uuid}"

--- a/tests/storage/coalesce/test_coalesce.py
+++ b/tests/storage/coalesce/test_coalesce.py
@@ -1,0 +1,42 @@
+import pytest
+
+import logging
+
+from .utils import compare_data, copy_data_to_tapdev, operation_on_vdi, wait_for_vdi_coalesce
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+    from lib.vdi import VDI
+
+class Test:
+    def test_write_data(self, host: "Host", tapdev: str, data_file_on_host: str):
+        length = 1 * 1024 * 1024
+        offset = 0
+
+        logging.info("Copying data to tapdev")
+        copy_data_to_tapdev(host, data_file_on_host, tapdev, offset, length)
+
+        logging.info("Comparing data to tapdev")
+        assert compare_data(host, tapdev, data_file_on_host, offset, length)
+
+    @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
+    def test_coalesce(self, host: "Host", tapdev: str, vdi_with_vbd_on_dom0: "VDI", data_file_on_host: str, vdi_op):
+        vdi = vdi_with_vbd_on_dom0
+        vdi_uuid = vdi.uuid
+        length = 1 * 1024 * 1024
+        offset = 0
+
+        new_vdi = operation_on_vdi(host, vdi_uuid, vdi_op)
+
+        logging.info("Copying data to tapdev")
+        copy_data_to_tapdev(host, data_file_on_host, tapdev, offset, length)
+
+        logging.info(f"Removing VDI {vdi_op}")
+        host.xe("vdi-destroy", {"uuid": new_vdi})
+
+        wait_for_vdi_coalesce(vdi)
+
+        logging.info("Comparing data to tapdev")
+        assert compare_data(host, tapdev, data_file_on_host, offset, length)

--- a/tests/storage/coalesce/utils.py
+++ b/tests/storage/coalesce/utils.py
@@ -1,0 +1,48 @@
+import logging
+
+from lib.common import wait_for_not
+from lib.host import Host
+from lib.vdi import VDI
+
+from typing import Literal
+
+def wait_for_vdi_coalesce(vdi: VDI):
+    wait_for_not(lambda: vdi.get_parent(), msg="Waiting for coalesce")
+    logging.info("Coalesce done")
+
+def copy_data_to_tapdev(host: Host, data_file: str, tapdev: str, offset: int, length: int):
+    # if offset == 0:
+    #     off = "0"
+    # else:
+    #     off = f"{offset}B" # Doesn't work with `dd` version of XCP-ng 8.3
+
+    bs = 1
+    off = int(offset / bs)
+    count = length / bs
+    count += length % bs
+    count = int(count)
+    cmd = ["dd", f"if={data_file}", f"of={tapdev}", f"bs={bs}", f"seek={off}", f"count={count}"]
+    host.ssh(cmd)
+
+def get_data(host: Host, file: str, offset: int, length: int, checksum: bool = False) -> str:
+    cmd = ["xxd", "-p", "-seek", str(offset), "-len", str(length), file]
+    if checksum:
+        cmd = cmd + ["|", "sha256sum"]
+    return host.ssh(cmd)
+
+def get_hashed_data(host: Host, file: str, offset: int, length: int):
+    return get_data(host, file, offset, length, True).split()[0]
+
+def operation_on_vdi(host: Host, vdi_uuid: str, vdi_op: Literal["snapshot", "clone"]) -> str:
+    new_vdi = host.xe(f"vdi-{vdi_op}", {"uuid": vdi_uuid})
+    logging.info(f"{vdi_op.capitalize()} VDI {vdi_uuid}: {new_vdi}")
+    return new_vdi
+
+def compare_data(host: Host, tapdev: str, data_file: str, offset: int, length: int) -> bool:
+    logging.info("Getting data from VDI and file")
+    vdi_checksum = get_hashed_data(host, tapdev, offset, length)
+    file_checksum = get_hashed_data(host, data_file, 0, length)
+    logging.info(f"VDI: {vdi_checksum}")
+    logging.info(f"FILE: {file_checksum}")
+
+    return vdi_checksum == file_checksum


### PR DESCRIPTION
The tests create a VDI, connect it to Dom0 then use the tapdev to write random data somewhere in it.
It then compare the data of the VDI to the original data we have to see if it has changed.
The test create snapshot/clone before deleting them and waiting for the coalesce to have happened by observing `sm-config:vhd-parent` before checking the integrity of the data.

Also add `--vdi-type` parameter that default to `vhd` to prepare to tests multiple VDI types, i.e. qcow2.