### PR TITLE
Typing fixes

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import shlex

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import subprocess


### PR DESCRIPTION
- fixes a mistake we missed in #284 that only shows with older python and would likely bomb out on current Jenkins setup
- adds a few method hints to deal with mypy reporting `annotation-unchecked` "notes" since #284 