### PR TITLE
don't check the type of priv_key

### DIFF
--- a/lib/efi.py
+++ b/lib/efi.py
@@ -218,7 +218,6 @@ def sign(payload, key_file, cert_file):
     """Returns a signed PKCS7 of payload signed by key and cert."""
     with open(key_file, 'rb') as f:
         priv_key = serialization.load_pem_private_key(f.read(), password=None)
-        assert isinstance(priv_key, (pkcs7.PKCS7PrivateKeyTypes))
 
     with open(cert_file, 'rb') as f:
         cert = x509.load_pem_x509_certificate(f.read())
@@ -232,7 +231,7 @@ def sign(payload, key_file, cert_file):
     return (
         pkcs7.PKCS7SignatureBuilder()
         .set_data(payload)
-        .add_signer(cert, priv_key, hashes.SHA256())
+        .add_signer(cert, priv_key, hashes.SHA256())  # type: ignore
         .sign(serialization.Encoding.DER, options)
     )
 


### PR DESCRIPTION
it breaks the CI:

~~~
>           assert isinstance(priv_key, (pkcs7.PKCS7PrivateKeyTypes))
E           AttributeError: module 'cryptography.hazmat.primitives.serialization.pkcs7' has no attribute 'PKCS7PrivateKeyTypes'
~~~