### PR TITLE
add pyright/basedpyright configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pyright]
+typeCheckingMode = "standard"


### PR DESCRIPTION
pyright and basedpyright are not using the same default typeCheckingMode. With that change we ensure that we get the same level of diagnostics in our IDEs and in the CI