### PR TITLE
lint python code with ruff

### DIFF
--- a/.github/workflows/code-checkers.yml
+++ b/.github/workflows/code-checkers.yml
@@ -32,3 +32,18 @@ jobs:
       run: cp data.py-dist data.py
     - name: Check with pyright
       run: uv run pyright lib/ conftest.py pkgfixtures.py # tests/
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "0.7.x"
+    - name: Install dependencies
+      run: uv sync --frozen
+    - name: Create a dummy data.py
+      run: cp data.py-dist data.py
+    - name: Check with ruff
+      run: uv run ruff check lib/ tests/

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,13 @@
+from typing import Dict
+
+import pytest
+
 import itertools
 import logging
 import os
 import tempfile
-from typing import Dict
 
 import git
-import pytest
 from packaging import version
 
 import lib.config as global_config

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import pytest
 
 import itertools
@@ -32,6 +30,8 @@ from lib.xo import xo_cli
 # then import them in individual packages to fix the buggy package scope handling by pytest, we also
 # need to import them in the global conftest.py so that they are recognized as fixtures.
 from pkgfixtures import formatted_and_mounted_ext4_disk, sr_disk_wiped
+
+from typing import Dict
 
 # Do we cache VMs?
 try:

--- a/conftest.py
+++ b/conftest.py
@@ -1,19 +1,25 @@
 import itertools
-import git
 import logging
 import os
-import pytest
 import tempfile
-
-from packaging import version
 from typing import Dict
 
-import lib.config as global_config
+import git
+import pytest
+from packaging import version
 
+import lib.config as global_config
 from lib import pxe
-from lib.common import callable_marker, shortened_nodeid, prefix_object_name
-from lib.common import wait_for, vm_image, is_uuid
-from lib.common import setup_formatted_and_mounted_disk, teardown_formatted_and_mounted_disk
+from lib.common import (
+    callable_marker,
+    is_uuid,
+    prefix_object_name,
+    setup_formatted_and_mounted_disk,
+    shortened_nodeid,
+    teardown_formatted_and_mounted_disk,
+    vm_image,
+    wait_for,
+)
 from lib.netutil import is_ipv6
 from lib.pool import Pool
 from lib.sr import SR

--- a/jobs.py
+++ b/jobs.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import subprocess
 import sys
+
 from lib.commands import ssh
 
 JOBS = {

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -1,8 +1,6 @@
 import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional, overload
 
-import lib.commands as commands
-
 if TYPE_CHECKING:
     import lib.host
 

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -85,10 +85,7 @@ class BaseVM:
         return True
 
     def all_vdis_on_sr(self, sr) -> bool:
-        for vdi_uuid in self.vdi_uuids():
-            if self.host.pool.get_vdi_sr_uuid(vdi_uuid) != sr.uuid:
-                return False
-        return True
+        return all(self.host.pool.get_vdi_sr_uuid(vdi_uuid) == sr.uuid for vdi_uuid in self.vdi_uuids())
 
     def get_sr(self):
         # in this method we assume the SR of the first VDI is the VM SR

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -1,8 +1,8 @@
 import logging
-
-from typing import Any, Literal, Optional, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, Optional, overload
 
 import lib.commands as commands
+
 if TYPE_CHECKING:
     import lib.host
 

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -1,5 +1,6 @@
-import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional, overload
+
+import logging
 
 if TYPE_CHECKING:
     import lib.host

--- a/lib/basevm.py
+++ b/lib/basevm.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, Literal, Optional, overload
-
 import logging
+
+from typing import TYPE_CHECKING, Any, Literal, Optional, overload
 
 if TYPE_CHECKING:
     import lib.host

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -2,12 +2,10 @@ import base64
 import logging
 import shlex
 import subprocess
-from typing import List, Literal, overload, Union
-
+from typing import List, Literal, Union, overload
 
 import lib.config as config
 from lib.netutil import wrap_ip
-
 
 class BaseCommandFailed(Exception):
     __slots__ = 'returncode', 'stdout', 'cmd'

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1,8 +1,9 @@
+from typing import List, Literal, Union, overload
+
 import base64
 import logging
 import shlex
 import subprocess
-from typing import List, Literal, Union, overload
 
 import lib.config as config
 from lib.netutil import wrap_ip

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1,5 +1,3 @@
-from typing import List, Literal, Union, overload
-
 import base64
 import logging
 import shlex
@@ -7,6 +5,8 @@ import subprocess
 
 import lib.config as config
 from lib.netutil import wrap_ip
+
+from typing import List, Literal, Union, overload
 
 class BaseCommandFailed(Exception):
     __slots__ = 'returncode', 'stdout', 'cmd'

--- a/lib/common.py
+++ b/lib/common.py
@@ -7,13 +7,14 @@ import sys
 import time
 import traceback
 from enum import Enum
-from typing import Callable, cast, Dict, Literal, Optional, overload, TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, TypeVar, Union, cast, overload
 from uuid import UUID
 
 import pytest
 import requests
 
 import lib.commands as commands
+
 if TYPE_CHECKING:
     import lib.host
 
@@ -26,7 +27,7 @@ class PackageManagerEnum(Enum):
 
 # Common VM images used in tests
 def vm_image(vm_key):
-    from data import VM_IMAGES, DEF_VM_URL
+    from data import DEF_VM_URL, VM_IMAGES
     url = VM_IMAGES[vm_key]
     if not url.startswith('http'):
         url = DEF_VM_URL + url

--- a/lib/common.py
+++ b/lib/common.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, TypeVar, Union, cast, overload
-
 import pytest
 
 import getpass
@@ -16,6 +14,8 @@ from uuid import UUID
 import requests
 
 import lib.commands as commands
+
+from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, TypeVar, Union, cast, overload
 
 if TYPE_CHECKING:
     import lib.host

--- a/lib/common.py
+++ b/lib/common.py
@@ -1,3 +1,7 @@
+from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, TypeVar, Union, cast, overload
+
+import pytest
+
 import getpass
 import inspect
 import itertools
@@ -7,10 +11,8 @@ import sys
 import time
 import traceback
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Dict, Literal, Optional, TypeVar, Union, cast, overload
 from uuid import UUID
 
-import pytest
 import requests
 
 import lib.commands as commands

--- a/lib/config.py
+++ b/lib/config.py
@@ -2,7 +2,7 @@ ignore_ssh_banner = False
 ssh_output_max_lines = 20
 
 def sr_device_config(datakey, *, required=[]):
-    import data # import here to avoid depending on this user file for collecting tests
+    import data  # import here to avoid depending on this user file for collecting tests
     config = getattr(data, datakey)
     for required_field in required:
         if required_field not in config:

--- a/lib/efi.py
+++ b/lib/efi.py
@@ -19,7 +19,6 @@ from cryptography.hazmat.primitives.serialization import Encoding, pkcs7
 
 import lib.commands as commands
 
-
 class GUID(UUID):
     def as_bytes(self):
         return self.bytes_le

--- a/lib/host.py
+++ b/lib/host.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import shlex
-import subprocess
 import tempfile
 import uuid
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload

--- a/lib/host.py
+++ b/lib/host.py
@@ -6,18 +6,30 @@ import shlex
 import subprocess
 import tempfile
 import uuid
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
 
 from packaging import version
-from typing import Dict, List, Literal, Optional, overload, TYPE_CHECKING, Union
 
 import lib.commands as commands
 import lib.pif as pif
+
 if TYPE_CHECKING:
     import lib.pool
 
-from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set, strtobool
-from lib.common import safe_split, strip_suffix, to_xapi_bool, wait_for, wait_for_not
-from lib.common import prefix_object_name
+from lib.common import (
+    _param_add,
+    _param_clear,
+    _param_get,
+    _param_remove,
+    _param_set,
+    prefix_object_name,
+    safe_split,
+    strip_suffix,
+    strtobool,
+    to_xapi_bool,
+    wait_for,
+    wait_for_not,
+)
 from lib.netutil import wrap_ip
 from lib.sr import SR
 from lib.vdi import VDI
@@ -29,7 +41,7 @@ XAPI_CONF_DIR = '/etc/xapi.conf.d'
 
 def host_data(hostname_or_ip):
     # read from data.py
-    from data import HOST_DEFAULT_USER, HOST_DEFAULT_PASSWORD, HOSTS
+    from data import HOST_DEFAULT_PASSWORD, HOST_DEFAULT_USER, HOSTS
     if hostname_or_ip in HOSTS:
         h_data = HOSTS[hostname_or_ip]
         return h_data

--- a/lib/host.py
+++ b/lib/host.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
+
 import logging
 import os
 import shlex
 import tempfile
 import uuid
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
 
 from packaging import version
 

--- a/lib/host.py
+++ b/lib/host.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
-
 import logging
 import os
 import shlex
@@ -12,6 +10,8 @@ from packaging import version
 
 import lib.commands as commands
 import lib.pif as pif
+
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
 
 if TYPE_CHECKING:
     import lib.pool

--- a/lib/installer.py
+++ b/lib/installer.py
@@ -2,7 +2,7 @@ import logging
 import time
 import xml.etree.ElementTree as ET
 
-from lib.commands import ssh, SSHCommandFailed
+from lib.commands import SSHCommandFailed, ssh
 from lib.common import wait_for
 
 class AnswerFile:

--- a/lib/pif.py
+++ b/lib/pif.py
@@ -1,4 +1,3 @@
-import lib.commands as commands
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set
 
 class PIF:

--- a/lib/pif.py
+++ b/lib/pif.py
@@ -1,5 +1,4 @@
 import lib.commands as commands
-
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set
 
 class PIF:

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -10,7 +10,6 @@ from lib.common import _param_get, _param_set, safe_split, wait_for, wait_for_no
 from lib.host import Host
 from lib.sr import SR
 
-
 class Pool:
     xe_prefix = "pool"
 

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Optional
-
 import logging
 import os
 import traceback
@@ -10,6 +8,8 @@ import lib.commands as commands
 from lib.common import _param_get, _param_set, safe_split, wait_for, wait_for_not
 from lib.host import Host
 from lib.sr import SR
+
+from typing import Any, Dict, Optional
 
 class Pool:
     xe_prefix = "pool"

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -1,7 +1,8 @@
+from typing import Any, Dict, Optional
+
 import logging
 import os
 import traceback
-from typing import Any, Dict, Optional
 
 from packaging import version
 

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import traceback
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 from packaging import version
 

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -264,7 +264,7 @@ class Pool:
             assert 'db' in auths_dict
 
             logging.info('Installing auths to pool: %s' % list(auths_dict.keys()))
-            for key in auths_dict.keys():
+            for key in auths_dict:
                 value = host.ssh([f'md5sum {auths_dict[key]} | cut -d " " -f 1'])
                 logging.debug('Key: %s, value: %s' % (key, value))
             params = [auths_dict['PK'], auths_dict['KEK'], auths_dict['db']]

--- a/lib/pxe.py
+++ b/lib/pxe.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from lib.commands import ssh, scp
 from data import ARP_SERVER, PXE_CONFIG_SERVER
+from lib.commands import scp, ssh
 
 PXE_CONFIG_DIR = "/pxe/configs/custom"
 

--- a/lib/sr.py
+++ b/lib/sr.py
@@ -2,7 +2,6 @@ import logging
 import time
 
 import lib.commands as commands
-
 from lib.common import prefix_object_name, safe_split, strtobool, wait_for, wait_for_not
 from lib.vdi import VDI
 

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -1,5 +1,6 @@
-import sys
 from typing import TypedDict
+
+import sys
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -1,6 +1,6 @@
-from typing import TypedDict
-
 import sys
+
+from typing import TypedDict
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired

--- a/lib/vdi.py
+++ b/lib/vdi.py
@@ -1,5 +1,6 @@
-import logging
 from typing import TYPE_CHECKING, Literal, Optional, overload
+
+import logging
 
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set, strtobool
 

--- a/lib/vdi.py
+++ b/lib/vdi.py
@@ -1,7 +1,8 @@
 import logging
+from typing import TYPE_CHECKING, Literal, Optional, overload
 
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set, strtobool
-from typing import Literal, Optional, overload, TYPE_CHECKING
+
 if TYPE_CHECKING:
     from lib.host import Host
     from lib.sr import SR

--- a/lib/vdi.py
+++ b/lib/vdi.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Literal, Optional, overload
-
 import logging
 
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set, strtobool
+
+from typing import TYPE_CHECKING, Literal, Optional, overload
 
 if TYPE_CHECKING:
     from lib.host import Host

--- a/lib/vif.py
+++ b/lib/vif.py
@@ -1,4 +1,3 @@
-import lib.commands as commands
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set
 
 class VIF:

--- a/lib/vif.py
+++ b/lib/vif.py
@@ -1,5 +1,4 @@
 import lib.commands as commands
-
 from lib.common import _param_add, _param_clear, _param_get, _param_remove, _param_set
 
 class VIF:

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -4,14 +4,21 @@ import logging
 import os
 import subprocess
 import tempfile
-from typing import Dict, List, Literal, Optional, overload, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
 
 import lib.commands as commands
 import lib.efi as efi
-
 from lib.basevm import BaseVM
-from lib.common import PackageManagerEnum, parse_xe_dict, safe_split, strtobool, wait_for, wait_for_not
-from lib.common import shortened_nodeid, expand_scope_relative_nodeid
+from lib.common import (
+    PackageManagerEnum,
+    expand_scope_relative_nodeid,
+    parse_xe_dict,
+    safe_split,
+    shortened_nodeid,
+    strtobool,
+    wait_for,
+    wait_for_not,
+)
 from lib.snapshot import Snapshot
 from lib.vbd import VBD
 from lib.vif import VIF

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 import os
-import subprocess
 import tempfile
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
 
 import lib.commands as commands
 import lib.efi as efi

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
+
 import logging
 import os
 import tempfile
-from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
 
 import lib.commands as commands
 import lib.efi as efi

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
-
 import logging
 import os
 import tempfile
@@ -22,6 +20,8 @@ from lib.common import (
 from lib.snapshot import Snapshot
 from lib.vbd import VBD
 from lib.vif import VIF
+
+from typing import TYPE_CHECKING, List, Literal, Optional, Union, overload
 
 if TYPE_CHECKING:
     from lib.host import Host

--- a/lib/xo.py
+++ b/lib/xo.py
@@ -2,7 +2,6 @@ import json
 import subprocess
 from typing import Any, Dict, Literal, Union, overload
 
-
 @overload
 def xo_cli(action: str, args: Dict[str, str] = {}, *, check: bool = True, simple_output: Literal[True] = True,
            use_json: Literal[False] = False) -> str:

--- a/lib/xo.py
+++ b/lib/xo.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict, Literal, Union, overload
+
 import json
 import subprocess
-from typing import Any, Dict, Literal, Union, overload
 
 @overload
 def xo_cli(action: str, args: Dict[str, str] = {}, *, check: bool = True, simple_output: Literal[True] = True,

--- a/lib/xo.py
+++ b/lib/xo.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, Literal, Union, overload
-
 import json
 import subprocess
+
+from typing import Any, Dict, Literal, Union, overload
 
 @overload
 def xo_cli(action: str, args: Dict[str, str] = {}, *, check: bool = True, simple_output: Literal[True] = True,

--- a/pkgfixtures.py
+++ b/pkgfixtures.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import setup_formatted_and_mounted_disk, teardown_formatted_and_mounted_disk
 

--- a/pkgfixtures.py
+++ b/pkgfixtures.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import setup_formatted_and_mounted_disk, teardown_formatted_and_mounted_disk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort.sections]
-testing = ["pytest"]
+testing = ["pytest*"]
 typing = ["typing"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,10 @@ typing = ["typing"]
 lines-after-imports = 1
 section-order = [
     "future",
-    "typing",
     "testing",
     "standard-library",
     "third-party",
     "first-party",
     "local-folder",
+    "typing",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,5 +61,18 @@ ignore = [
   "F811",  # F811 redefined-while-unused
 ]
 
+[tool.ruff.lint.isort.sections]
+testing = ["pytest"]
+typing = ["typing"]
+
 [tool.ruff.lint.isort]
 lines-after-imports = 1
+section-order = [
+    "future",
+    "typing",
+    "testing",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,42 @@ dev = [
     "pydocstyle",
     "pyright",
     "pyyaml>=6.0",
+    "ruff",
     "types-requests",
     "typing-extensions",
 ]
 
 [tool.pyright]
 typeCheckingMode = "standard"
+
+[tool.ruff]
+preview = true
+line-length = 120
+exclude = ["data.py", "vm_data.py", ".git"]
+
+[tool.ruff.format]
+quote-style = "preserve"
+
+[tool.ruff.lint]
+select = [
+  "F",  # Pyflakes
+  "I",  # isort
+  "SLF",  # flake8-self
+  "SIM",  # flake8-simplify
+]
+# don't use some of the SIM rules
+ignore = [
+  "SIM105",  # suppressible-exception
+  "SIM108",  # if-else-block-instead-of-if-exp
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+# pytest requires some import and function arguments to match, but
+# the linter doesn't know that
+"tests/**/*.py" = [
+  "F401",  # F401 unused-import
+  "F811",  # F811 redefined-while-unused
+]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,7 @@ flake8
 pydocstyle
 pyright
 pyyaml>=6.0
+ruff
 types-requests
 typing-extensions
 -r base.txt

--- a/scripts/ansible/runner.py
+++ b/scripts/ansible/runner.py
@@ -6,7 +6,6 @@ import logging
 import os
 import sys
 import tempfile
-import __main__
 from signal import SIGABRT, SIGINT, SIGQUIT, SIGTERM, signal
 from subprocess import run
 from typing import List
@@ -14,6 +13,8 @@ from typing import List
 import requests
 import yaml
 from bs4 import BeautifulSoup
+
+import __main__
 
 try:
     from yaml import CDumper as Dumper

--- a/scripts/ansible/runner.py
+++ b/scripts/ansible/runner.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from typing import List
-
 import argparse
 import atexit
 import logging
@@ -16,6 +14,8 @@ import yaml
 from bs4 import BeautifulSoup
 
 import __main__
+
+from typing import List
 
 try:
     from yaml import CDumper as Dumper

--- a/scripts/ansible/runner.py
+++ b/scripts/ansible/runner.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from typing import List
+
 import argparse
 import atexit
 import logging
@@ -8,7 +10,6 @@ import sys
 import tempfile
 from signal import SIGABRT, SIGINT, SIGQUIT, SIGTERM, signal
 from subprocess import run
-from typing import List
 
 import requests
 import yaml

--- a/scripts/install_xcpng.py
+++ b/scripts/install_xcpng.py
@@ -5,20 +5,20 @@ import atexit
 import logging
 import os
 import random
-import requests
 import string
 import subprocess
 import sys
 import tempfile
 import time
 
+import requests
 from packaging import version
 
 # flake8: noqa: E402
 sys.path.append(f"{os.path.abspath(os.path.dirname(__file__))}/..")
 from lib import pxe
-from lib.commands import ssh, scp, SSHCommandFailed
-from lib.common import wait_for, is_uuid
+from lib.commands import SSHCommandFailed, scp, ssh
+from lib.common import is_uuid, wait_for
 from lib.host import host_data
 from lib.pool import Pool
 from lib.vm import VM

--- a/scripts/xcpng-fs-diff.py
+++ b/scripts/xcpng-fs-diff.py
@@ -39,14 +39,14 @@
 #
 
 import argparse
-import sys
-import subprocess
 import json
-import tempfile
 import os
 import shlex
-from fnmatch import fnmatch
+import subprocess
+import sys
+import tempfile
 from enum import StrEnum, auto
+from fnmatch import fnmatch
 
 class DataType(StrEnum):
     FILE = auto()

--- a/tests/fs_diff/test_fs_diff.py
+++ b/tests/fs_diff/test_fs_diff.py
@@ -10,7 +10,7 @@ pytest.fixture(scope='module')
 def test_fs_diff(hosts):
     assert len(hosts) == 2, "This test requires exactly 2 hosts"
 
-    assert (hosts[0].xcp_version == hosts[1].xcp_version), f"Host versions must be the same"
+    assert (hosts[0].xcp_version == hosts[1].xcp_version), "Host versions must be the same"
 
     fsdiff = os.path.realpath(f"{os.path.dirname(__file__)}/../../scripts/xcpng-fs-diff.py")
 

--- a/tests/fs_diff/test_fs_diff.py
+++ b/tests/fs_diff/test_fs_diff.py
@@ -1,7 +1,7 @@
+import pytest
+
 import os
 import subprocess
-
-import pytest
 
 # Requirements:
 # - 2 XCP-ng host of same version

--- a/tests/fs_diff/test_fs_diff.py
+++ b/tests/fs_diff/test_fs_diff.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 import subprocess
+
+import pytest
 
 # Requirements:
 # - 2 XCP-ng host of same version

--- a/tests/guest_tools/unix/test_guest_tools_unix.py
+++ b/tests/guest_tools/unix/test_guest_tools_unix.py
@@ -1,7 +1,9 @@
 import logging
-import pytest
 import time
-from lib.common import wait_for, PackageManagerEnum
+
+import pytest
+
+from lib.common import PackageManagerEnum, wait_for
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/guest_tools/unix/test_guest_tools_unix.py
+++ b/tests/guest_tools/unix/test_guest_tools_unix.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.common import PackageManagerEnum, wait_for
 

--- a/tests/guest_tools/win/__init__.py
+++ b/tests/guest_tools/win/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Union
-
 import enum
 import logging
 import re
@@ -11,6 +9,8 @@ from lib.common import wait_for
 from lib.host import Host
 from lib.sr import SR
 from lib.vm import VM
+
+from typing import Any, Dict, Union
 
 # HACK: I originally thought that using Stop-Computer -Force would cause the SSH session to sometimes fail.
 # I could never confirm this in the end, but use a slightly delayed shutdown just to be safe anyway.

--- a/tests/guest_tools/win/__init__.py
+++ b/tests/guest_tools/win/__init__.py
@@ -11,7 +11,6 @@ from lib.host import Host
 from lib.sr import SR
 from lib.vm import VM
 
-
 # HACK: I originally thought that using Stop-Computer -Force would cause the SSH session to sometimes fail.
 # I could never confirm this in the end, but use a slightly delayed shutdown just to be safe anyway.
 WINDOWS_SHUTDOWN_COMMAND = "shutdown.exe -s -f -t 5"

--- a/tests/guest_tools/win/__init__.py
+++ b/tests/guest_tools/win/__init__.py
@@ -1,8 +1,9 @@
+from typing import Any, Dict, Union
+
 import enum
 import logging
 import re
 import time
-from typing import Any, Dict, Union
 
 from data import ISO_DOWNLOAD_URL
 from lib.commands import SSHCommandFailed

--- a/tests/guest_tools/win/conftest.py
+++ b/tests/guest_tools/win/conftest.py
@@ -1,7 +1,8 @@
-import logging
 from typing import Any, Dict, Tuple
 
 import pytest
+
+import logging
 
 from data import OTHER_GUEST_TOOLS, OTHER_GUEST_TOOLS_ISO, WIN_GUEST_TOOLS_ISOS
 from lib.common import wait_for

--- a/tests/guest_tools/win/conftest.py
+++ b/tests/guest_tools/win/conftest.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Tuple
-
 import pytest
 
 import logging
@@ -20,6 +18,8 @@ from . import (
 )
 from .guest_tools import install_guest_tools
 from .other_tools import install_other_drivers
+
+from typing import Any, Dict, Tuple
 
 @pytest.fixture(scope="module")
 def running_windows_vm_without_tools(imported_vm: VM) -> VM:

--- a/tests/guest_tools/win/conftest.py
+++ b/tests/guest_tools/win/conftest.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Dict, Tuple
+
 import pytest
 
 from data import OTHER_GUEST_TOOLS, OTHER_GUEST_TOOLS_ISO, WIN_GUEST_TOOLS_ISOS
@@ -8,6 +9,7 @@ from lib.host import Host
 from lib.snapshot import Snapshot
 from lib.sr import SR
 from lib.vm import VM
+
 from . import (
     WINDOWS_SHUTDOWN_COMMAND,
     PowerAction,
@@ -17,7 +19,6 @@ from . import (
 )
 from .guest_tools import install_guest_tools
 from .other_tools import install_other_drivers
-
 
 @pytest.fixture(scope="module")
 def running_windows_vm_without_tools(imported_vm: VM) -> VM:

--- a/tests/guest_tools/win/guest_tools.py
+++ b/tests/guest_tools/win/guest_tools.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict
+
 import logging
 from pathlib import PureWindowsPath
-from typing import Any, Dict
 
 from lib.common import wait_for
 from lib.vm import VM

--- a/tests/guest_tools/win/guest_tools.py
+++ b/tests/guest_tools/win/guest_tools.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from lib.common import wait_for
 from lib.vm import VM
+
 from . import (
     WINDOWS_SHUTDOWN_COMMAND,
     PowerAction,
@@ -11,7 +12,6 @@ from . import (
     insert_cd_safe,
     wait_for_vm_running_and_ssh_up_without_tools,
 )
-
 
 ERROR_SUCCESS = 0
 ERROR_INSTALL_FAILURE = 1603

--- a/tests/guest_tools/win/guest_tools.py
+++ b/tests/guest_tools/win/guest_tools.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 import logging
 from pathlib import PureWindowsPath
 
@@ -13,6 +11,8 @@ from . import (
     insert_cd_safe,
     wait_for_vm_running_and_ssh_up_without_tools,
 )
+
+from typing import Any, Dict
 
 ERROR_SUCCESS = 0
 ERROR_INSTALL_FAILURE = 1603

--- a/tests/guest_tools/win/other_tools.py
+++ b/tests/guest_tools/win/other_tools.py
@@ -1,6 +1,7 @@
+from typing import Any, Dict
+
 import logging
 from pathlib import PureWindowsPath
-from typing import Any, Dict
 
 from lib.common import strtobool, wait_for
 from lib.vm import VM

--- a/tests/guest_tools/win/other_tools.py
+++ b/tests/guest_tools/win/other_tools.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 import logging
 from pathlib import PureWindowsPath
 
@@ -7,6 +5,8 @@ from lib.common import strtobool, wait_for
 from lib.vm import VM
 
 from . import WINDOWS_SHUTDOWN_COMMAND, enable_testsign, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
+
+from typing import Any, Dict
 
 def install_other_drivers(vm: VM, other_tools_iso_name: str, param: Dict[str, Any]):
     if param.get("vendor_device"):

--- a/tests/guest_tools/win/other_tools.py
+++ b/tests/guest_tools/win/other_tools.py
@@ -4,8 +4,8 @@ from typing import Any, Dict
 
 from lib.common import strtobool, wait_for
 from lib.vm import VM
-from . import WINDOWS_SHUTDOWN_COMMAND, enable_testsign, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
 
+from . import WINDOWS_SHUTDOWN_COMMAND, enable_testsign, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
 
 def install_other_drivers(vm: VM, other_tools_iso_name: str, param: Dict[str, Any]):
     if param.get("vendor_device"):

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from . import PowerAction, wait_for_vm_running_and_ssh_up_without_tools
 from .guest_tools import (

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from . import PowerAction, wait_for_vm_running_and_ssh_up_without_tools
@@ -7,7 +8,6 @@ from .guest_tools import (
     install_guest_tools,
     uninstall_guest_tools,
 )
-
 
 # Requirements:
 # - XCP-ng >= 8.2.

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -1,12 +1,13 @@
 import logging
 from pathlib import PureWindowsPath
 from typing import Any, Dict, Tuple
+
 import pytest
+
 from lib.common import wait_for
 from lib.vm import VM
 
 from . import WINDOWS_SHUTDOWN_COMMAND, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
-
 
 def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any]):
     insert_cd_safe(vm, guest_tools_iso["name"])

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -54,6 +54,6 @@ class TestXenClean:
         if param.get("vendor_device"):
             pytest.skip("Skipping XenClean with vendor device present")
             return
-        logging.info(f"XenClean with other tools")
+        logging.info("XenClean with other tools")
         run_xenclean(vm, guest_tools_iso)
         assert vm.are_windows_tools_uninstalled()

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, Tuple
-
 import pytest
 
 import logging
@@ -9,6 +7,8 @@ from lib.common import wait_for
 from lib.vm import VM
 
 from . import WINDOWS_SHUTDOWN_COMMAND, insert_cd_safe, wait_for_vm_running_and_ssh_up_without_tools
+
+from typing import Any, Dict, Tuple
 
 def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any]):
     insert_cd_safe(vm, guest_tools_iso["name"])

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -1,8 +1,9 @@
-import logging
-from pathlib import PureWindowsPath
 from typing import Any, Dict, Tuple
 
 import pytest
+
+import logging
+from pathlib import PureWindowsPath
 
 from lib.common import wait_for
 from lib.vm import VM

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -1,5 +1,3 @@
-from typing import Generator, Sequence, Union
-
 import pytest
 import pytest_dependency  # type: ignore
 
@@ -13,6 +11,8 @@ from lib import installer, pxe
 from lib.commands import local_cmd
 from lib.common import callable_marker, url_download, wait_for
 from lib.installer import AnswerFile
+
+from typing import Generator, Sequence, Union
 
 # Return true if the version of the ISO doesn't support the source type.
 # Note: this is a quick-win hack, to avoid explicit enumeration of supported

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -1,18 +1,17 @@
 import logging
 import os
-from typing import Generator, Sequence, Union
-import pytest
-import pytest_dependency        # type: ignore
 import tempfile
 import xml.etree.ElementTree as ET
+from typing import Generator, Sequence, Union
 
+import pytest
+import pytest_dependency  # type: ignore
+
+from data import ARP_SERVER, ISO_IMAGES, ISO_IMAGES_BASE, ISO_IMAGES_CACHE, TEST_SSH_PUBKEY, TOOLS
 from lib import installer, pxe
+from lib.commands import local_cmd
 from lib.common import callable_marker, url_download, wait_for
 from lib.installer import AnswerFile
-from lib.commands import local_cmd
-
-from data import (ISO_IMAGES, ISO_IMAGES_BASE, ISO_IMAGES_CACHE,
-                  ARP_SERVER, TEST_SSH_PUBKEY, TOOLS)
 
 # Return true if the version of the ISO doesn't support the source type.
 # Note: this is a quick-win hack, to avoid explicit enumeration of supported

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -29,7 +29,7 @@ def skip_package_source(version, package_source):
     if package_source == "net":
         # Net install is not valid if there is no netinstall URL
         # FIXME: ISO includes a default URL so we should be able to omit net-url
-        if 'net-url' not in ISO_IMAGES[version].keys():
+        if 'net-url' not in ISO_IMAGES[version]:
             return True, "net-url required for netinstall was not found for {}".format(version)
 
         return False, "do not skip"

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -1,13 +1,12 @@
 from typing import Generator, Sequence, Union
 
 import pytest
+import pytest_dependency  # type: ignore
 
 import logging
 import os
 import tempfile
 import xml.etree.ElementTree as ET
-
-import pytest_dependency  # type: ignore
 
 from data import ARP_SERVER, ISO_IMAGES, ISO_IMAGES_BASE, ISO_IMAGES_CACHE, TEST_SSH_PUBKEY, TOOLS
 from lib import installer, pxe

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -1,10 +1,12 @@
+from typing import Generator, Sequence, Union
+
+import pytest
+
 import logging
 import os
 import tempfile
 import xml.etree.ElementTree as ET
-from typing import Generator, Sequence, Union
 
-import pytest
 import pytest_dependency  # type: ignore
 
 from data import ARP_SERVER, ISO_IMAGES, ISO_IMAGES_BASE, ISO_IMAGES_CACHE, TEST_SSH_PUBKEY, TOOLS

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 from uuid import uuid4
-
-import pytest
 
 from data import ISO_IMAGES, NETWORKS
 from lib import commands, installer, pxe

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -1,7 +1,9 @@
 import logging
-import pytest
 from uuid import uuid4
 
+import pytest
+
+from data import ISO_IMAGES, NETWORKS
 from lib import commands, installer, pxe
 from lib.common import safe_split, wait_for
 from lib.installer import AnswerFile
@@ -9,7 +11,6 @@ from lib.pif import PIF
 from lib.pool import Pool
 from lib.vdi import VDI
 
-from data import ISO_IMAGES, NETWORKS
 assert "MGMT" in NETWORKS
 
 # Requirements:

--- a/tests/install/test_fixtures.py
+++ b/tests/install/test_fixtures.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.installer import AnswerFile

--- a/tests/install/test_fixtures.py
+++ b/tests/install/test_fixtures.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.installer import AnswerFile
 

--- a/tests/migration/test_cross_pool_migration.py
+++ b/tests/migration/test_cross_pool_migration.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import wait_for, wait_for_not
 

--- a/tests/migration/test_cross_pool_migration.py
+++ b/tests/migration/test_cross_pool_migration.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import wait_for, wait_for_not

--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -1,10 +1,12 @@
 import logging
+
 import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for
+
 # The pool needs a shared SR to use `host.evacuate`. All three fixtures below are needed.
-from tests.storage.nfs.conftest import vm_on_nfs_sr, nfs_sr, nfs_device_config
+from tests.storage.nfs.conftest import nfs_device_config, nfs_sr, vm_on_nfs_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for

--- a/tests/misc/test_access_links.py
+++ b/tests/misc/test_access_links.py
@@ -1,6 +1,7 @@
-import pytest
-import subprocess
 import hashlib
+import subprocess
+
+import pytest
 
 from lib import commands
 

--- a/tests/misc/test_access_links.py
+++ b/tests/misc/test_access_links.py
@@ -1,7 +1,7 @@
+import pytest
+
 import hashlib
 import subprocess
-
-import pytest
 
 from lib import commands
 

--- a/tests/misc/test_basic_without_ssh.py
+++ b/tests/misc/test_basic_without_ssh.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import wait_for
 from lib.host import Host

--- a/tests/misc/test_basic_without_ssh.py
+++ b/tests/misc/test_basic_without_ssh.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import wait_for

--- a/tests/misc/test_export.py
+++ b/tests/misc/test_export.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/misc/test_export.py
+++ b/tests/misc/test_export.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 # Requirements:

--- a/tests/misc/test_file_server.py
+++ b/tests/misc/test_file_server.py
@@ -1,8 +1,8 @@
-import pytest
 import re
 
-import lib.commands as commands
+import pytest
 
+import lib.commands as commands
 from lib.netutil import wrap_ip
 
 # These tests are meant to test an host fileserver behavior.

--- a/tests/misc/test_file_server.py
+++ b/tests/misc/test_file_server.py
@@ -1,6 +1,6 @@
-import re
-
 import pytest
+
+import re
 
 import lib.commands as commands
 from lib.netutil import wrap_ip

--- a/tests/misc/test_vm_basic_operations.py
+++ b/tests/misc/test_vm_basic_operations.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import wait_for_not
 from lib.vm import VM

--- a/tests/misc/test_vm_basic_operations.py
+++ b/tests/misc/test_vm_basic_operations.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import wait_for_not

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -4,4 +4,4 @@ import pytest
 def host_no_sdn_controller(host):
     """ An XCP-ng with no SDN controller. """
     if host.xe('sdn-controller-list', minimal=True):
-        pytest.skip(f"This test requires an XCP-ng with no SDN controller")
+        pytest.skip("This test requires an XCP-ng with no SDN controller")

--- a/tests/network/test_vif_allowed_ip.py
+++ b/tests/network/test_vif_allowed_ip.py
@@ -1,7 +1,7 @@
+import pytest
+
 import ipaddress
 import os
-
-import pytest
 
 # Requirements:
 # - one XCP-ng host (--host) >= 8.2 (>= 8.3 for the CIDR tests) with no SDN controller configured

--- a/tests/network/test_vif_allowed_ip.py
+++ b/tests/network/test_vif_allowed_ip.py
@@ -1,5 +1,6 @@
 import ipaddress
 import os
+
 import pytest
 
 # Requirements:

--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import urllib.request
-
-import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/extra/conftest.py
+++ b/tests/packages/extra/conftest.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import urllib.request
+
+import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/linux_image/conftest.py
+++ b/tests/packages/linux_image/conftest.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import urllib.request
-
-import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/linux_image/conftest.py
+++ b/tests/packages/linux_image/conftest.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import urllib.request
+
+import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/linux_image/conftest.py
+++ b/tests/packages/linux_image/conftest.py
@@ -10,7 +10,7 @@ from pkgfixtures import host_with_saved_yum_state
 def host_with_perf(host_at_least_8_3, host_with_saved_yum_state):
     host = host_with_saved_yum_state
 
-    logging.info(f"Getting perf package")
+    logging.info("Getting perf package")
 
     host.yum_install(['perf'])
     yield host

--- a/tests/packages/mlx/conftest.py
+++ b/tests/packages/mlx/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/mlx/conftest.py
+++ b/tests/packages/mlx/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state

--- a/tests/packages/netdata/test_netdata.py
+++ b/tests/packages/netdata/test_netdata.py
@@ -1,6 +1,6 @@
-import subprocess
-
 import pytest
+
+import subprocess
 
 from lib.netutil import wrap_ip
 

--- a/tests/packages/netdata/test_netdata.py
+++ b/tests/packages/netdata/test_netdata.py
@@ -1,5 +1,6 @@
-import pytest
 import subprocess
+
+import pytest
 
 from lib.netutil import wrap_ip
 

--- a/tests/pci_passthrough/conftest.py
+++ b/tests/pci_passthrough/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import safe_split
 

--- a/tests/pci_passthrough/conftest.py
+++ b/tests/pci_passthrough/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import safe_split

--- a/tests/pci_passthrough/test_pci_passthrough.py
+++ b/tests/pci_passthrough/test_pci_passthrough.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Requirements:
 # - an XCP-ng host (--hosts) >= 8.3 with a PGPU to hide from dom0

--- a/tests/pci_passthrough/test_pci_passthrough.py
+++ b/tests/pci_passthrough/test_pci_passthrough.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 
 # Requirements:
 # - an XCP-ng host (--hosts) >= 8.3 with a PGPU to hide from dom0

--- a/tests/security/test_tls.py
+++ b/tests/security/test_tls.py
@@ -26,11 +26,11 @@ def test_tls_disabled(host: str, protocol_name: str):
 
     with pytest.raises(ssl.SSLError):
         context = ssl.SSLContext(protocol)
-        with socket.create_connection((str(host), PORT), timeout=10) as sock:
-            with context.wrap_socket(sock, server_hostname=str(host)) as ssock:
-                ssock.do_handshake()
-                # If we reach this point, the protocol is enabled (test should fail)
-                pytest.fail(f"Protocol {protocol} should be disabled but connection succeeded")
+        with socket.create_connection((str(host), PORT), timeout=10) as sock, \
+             context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+            ssock.do_handshake()
+            # If we reach this point, the protocol is enabled (test should fail)
+            pytest.fail(f"Protocol {protocol} should be disabled but connection succeeded")
 
 @pytest.mark.parametrize("protocol_name", ["TLSv1.2"])
 def test_enabled(host: str, protocol_name: str):
@@ -48,9 +48,9 @@ def test_enabled(host: str, protocol_name: str):
 
     try:
         context = ssl.SSLContext(protocol)
-        with socket.create_connection((str(host), PORT), timeout=10) as sock:
-            with context.wrap_socket(sock, server_hostname=str(host)) as ssock:
-                ssock.do_handshake()
-                assert ssock.version()
+        with socket.create_connection((str(host), PORT), timeout=10) as sock, \
+             context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+            ssock.do_handshake()
+            assert ssock.version()
     except ssl.SSLError as e:
         pytest.fail(f"{protocol_name} should be enabled, but got SSLError: {e}")

--- a/tests/security/test_tls.py
+++ b/tests/security/test_tls.py
@@ -1,7 +1,8 @@
-import pytest
-import ssl
-import socket
 import logging
+import socket
+import ssl
+
+import pytest
 
 # This test is designed to verify that TLS connections is secured
 #

--- a/tests/security/test_tls.py
+++ b/tests/security/test_tls.py
@@ -1,8 +1,8 @@
+import pytest
+
 import logging
 import socket
 import ssl
-
-import pytest
 
 # This test is designed to verify that TLS connections is secured
 #

--- a/tests/snapshot/conftest.py
+++ b/tests/snapshot/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import exec_nofail, raise_errors

--- a/tests/snapshot/conftest.py
+++ b/tests/snapshot/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import exec_nofail, raise_errors
 

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -1,1 +1,6 @@
-from .storage import *
+from .storage import (
+    cold_migration_then_come_back,
+    live_storage_migration_then_come_back,
+    try_to_create_sr_with_missing_device,
+    vdi_is_open,
+)

--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib import config
 from lib.common import exec_nofail, raise_errors

--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -1,8 +1,9 @@
 import logging
+
 import pytest
 
-from lib.common import exec_nofail, raise_errors
 from lib import config
+from lib.common import exec_nofail, raise_errors
 
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state

--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -1,9 +1,10 @@
 import logging
-import pytest
 import time
 
+import pytest
+
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 @pytest.fixture(scope='package')

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 @pytest.fixture(scope='package')
 def ext_sr(host, sr_disk):

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -1,5 +1,6 @@
 import pytest
-from lib.common import wait_for, vm_image
+
+from lib.common import vm_image, wait_for
 from tests.storage import try_to_create_sr_with_missing_device, vdi_is_open
 
 # Requirements:

--- a/tests/storage/ext/test_ext_sr_crosspool_migration.py
+++ b/tests/storage/ext/test_ext_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/ext/test_ext_sr_intrapool_migration.py
+++ b/tests/storage/ext/test_ext_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/fsp/test_fsp_sr.py
+++ b/tests/storage/fsp/test_fsp_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import os
-
-import pytest
 
 from .conftest import DIRECTORIES_PATH
 

--- a/tests/storage/fsp/test_fsp_sr.py
+++ b/tests/storage/fsp/test_fsp_sr.py
@@ -1,6 +1,7 @@
-import pytest
-import os
 import logging
+import os
+
+import pytest
 
 from .conftest import DIRECTORIES_PATH
 

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import exec_nofail, raise_errors, setup_formatted_and_mounted_disk, teardown_formatted_and_mounted_disk
 from lib.netutil import is_ipv6

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import exec_nofail, raise_errors, setup_formatted_and_mounted_disk, teardown_formatted_and_mounted_disk

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -105,7 +105,7 @@ def _fallback_gluster_teardown(host):
         try:
             # Volume might already be stopped if failure happened on delete
             h.ssh(['gluster', '--mode=script', 'volume', 'stop', 'vol0'])
-        except Exception as e:
+        except Exception:
             pass
 
         h.ssh(['gluster', '--mode=script', 'volume', 'delete', 'vol0'])

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -1,8 +1,9 @@
 import logging
+
 import pytest
 
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/iso/conftest.py
+++ b/tests/storage/iso/conftest.py
@@ -1,6 +1,7 @@
-import pytest
-import time
 import os
+import time
+
+import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import formatted_and_mounted_ext4_disk

--- a/tests/storage/iso/conftest.py
+++ b/tests/storage/iso/conftest.py
@@ -1,7 +1,7 @@
+import pytest
+
 import os
 import time
-
-import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import formatted_and_mounted_ext4_disk

--- a/tests/storage/iso/test_cifs_iso_sr.py
+++ b/tests/storage/iso/test_cifs_iso_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import os
-
-import pytest
 
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 

--- a/tests/storage/iso/test_cifs_iso_sr.py
+++ b/tests/storage/iso/test_cifs_iso_sr.py
@@ -1,7 +1,9 @@
-import pytest
 import logging
 import os
-from .conftest import copy_tools_iso_to_iso_sr, check_iso_mount_and_read_from_vm, remove_iso_from_sr
+
+import pytest
+
+from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_cifs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_cifs_iso_sr_reboot.py
@@ -1,7 +1,10 @@
-import pytest
 import os
+
+import pytest
+
 from lib.common import wait_for
-from .conftest import copy_tools_iso_to_iso_sr, check_iso_mount_and_read_from_vm, remove_iso_from_sr
+
+from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_cifs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_cifs_iso_sr_reboot.py
@@ -1,6 +1,6 @@
-import os
-
 import pytest
+
+import os
 
 from lib.common import wait_for
 

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import os
-
-import pytest
 
 from .conftest import (
     check_iso_mount_and_read_from_vm,

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -1,8 +1,14 @@
-import pytest
 import logging
 import os
-from .conftest import create_local_iso_sr, copy_tools_iso_to_iso_sr, \
-    check_iso_mount_and_read_from_vm, remove_iso_from_sr
+
+import pytest
+
+from .conftest import (
+    check_iso_mount_and_read_from_vm,
+    copy_tools_iso_to_iso_sr,
+    create_local_iso_sr,
+    remove_iso_from_sr,
+)
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_local_iso_sr_reboot.py
+++ b/tests/storage/iso/test_local_iso_sr_reboot.py
@@ -1,7 +1,10 @@
-import pytest
 import os
+
+import pytest
+
 from lib.common import wait_for
-from .conftest import copy_tools_iso_to_iso_sr, check_iso_mount_and_read_from_vm, remove_iso_from_sr
+
+from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_local_iso_sr_reboot.py
+++ b/tests/storage/iso/test_local_iso_sr_reboot.py
@@ -1,6 +1,6 @@
-import os
-
 import pytest
+
+import os
 
 from lib.common import wait_for
 

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import os
-
-import pytest
 
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -1,7 +1,9 @@
-import pytest
-import os
 import logging
-from .conftest import copy_tools_iso_to_iso_sr, check_iso_mount_and_read_from_vm, remove_iso_from_sr
+import os
+
+import pytest
+
+from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_nfs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_nfs_iso_sr_reboot.py
@@ -1,7 +1,10 @@
-import pytest
 import os
+
+import pytest
+
 from lib.common import wait_for
-from .conftest import copy_tools_iso_to_iso_sr, check_iso_mount_and_read_from_vm, remove_iso_from_sr
+
+from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/storage/iso/test_nfs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_nfs_iso_sr_reboot.py
@@ -1,6 +1,6 @@
-import os
-
 import pytest
+
+import os
 
 from lib.common import wait_for
 

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 @pytest.fixture(scope='package')
 def largeblock_sr(host, sr_disk_4k):

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 @pytest.fixture(scope='package')

--- a/tests/storage/largeblock/test_largeblock_sr.py
+++ b/tests/storage/largeblock/test_largeblock_sr.py
@@ -1,5 +1,6 @@
 import pytest
-from lib.common import wait_for, vm_image
+
+from lib.common import vm_image, wait_for
 from tests.storage import try_to_create_sr_with_missing_device, vdi_is_open
 
 # Requirements:

--- a/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 import lib.commands as commands
 

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 import lib.commands as commands

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -1,11 +1,13 @@
 import logging
-import pytest
 import time
 
-from .conftest import LINSTOR_PACKAGE
+import pytest
+
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
+
+from .conftest import LINSTOR_PACKAGE
 
 # Requirements:
 # - two or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR

--- a/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 @pytest.fixture(scope='package')
 def lvm_sr(host, sr_disk):

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 @pytest.fixture(scope='package')

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -1,5 +1,6 @@
 import pytest
-from lib.common import wait_for, vm_image
+
+from lib.common import vm_image, wait_for
 from tests.storage import try_to_create_sr_with_missing_device, vdi_is_open
 
 # Requirements:

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib import config

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib import config
 

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -1,5 +1,6 @@
 import pytest
-from lib.common import wait_for, vm_image
+
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib import config

--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib import config
 

--- a/tests/storage/moosefs/test_moosefs_sr.py
+++ b/tests/storage/moosefs/test_moosefs_sr.py
@@ -1,9 +1,10 @@
 import logging
 import time
+
 import pytest
 
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/moosefs/test_moosefs_sr.py
+++ b/tests/storage/moosefs/test_moosefs_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib import config

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib import config
 

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -1,5 +1,6 @@
 import pytest
-from lib.common import wait_for, vm_image
+
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -4,7 +4,7 @@ from lib.sr import SR
 
 def try_to_create_sr_with_missing_device(sr_type, label, host):
     try:
-        sr = host.sr_create(sr_type, label, {}, verify=True)
+        host.sr_create(sr_type, label, {}, verify=True)
     except SSHCommandFailed as e:
         assert e.stdout == (
             'Error code: SR_BACKEND_FAILURE_90\nError parameters: , '

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 @pytest.fixture(scope='package')
 def host_with_xfsprogs(host):

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 @pytest.fixture(scope='package')

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -1,9 +1,10 @@
 import logging
 import time
+
 import pytest
 
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -1,11 +1,13 @@
 import logging
 import time
+
 import pytest
 
-from .conftest import POOL_PATH, POOL_NAME
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
+
+from .conftest import POOL_NAME, POOL_PATH
 
 # Requirements:
 # - one XCP-ng host >= 8.2 with an additional unused disk for the SR

--- a/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped

--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -1,9 +1,10 @@
 import logging
 import time
+
 import pytest
 
 from lib.commands import SSHCommandFailed
-from lib.common import wait_for, vm_image
+from lib.common import vm_image, wait_for
 from tests.storage import vdi_is_open
 
 # Requirements:

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import time
-
-import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for

--- a/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:

--- a/tests/system/test_irqbalance.py
+++ b/tests/system/test_irqbalance.py
@@ -1,7 +1,8 @@
 import logging
 import os
-import pytest
 import tempfile
+
+import pytest
 
 from lib.common import exec_nofail, raise_errors
 

--- a/tests/system/test_irqbalance.py
+++ b/tests/system/test_irqbalance.py
@@ -1,8 +1,8 @@
+import pytest
+
 import logging
 import os
 import tempfile
-
-import pytest
 
 from lib.common import exec_nofail, raise_errors
 

--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import re
-
-import pytest
 
 # Requirements:
 # - an XCP-ng host (--hosts) >= 8.2

--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import re
+
+import pytest
 
 # Requirements:
 # - an XCP-ng host (--hosts) >= 8.2

--- a/tests/uefi_sb/conftest.py
+++ b/tests/uefi_sb/conftest.py
@@ -1,6 +1,6 @@
 import logging
-import pytest
 
+import pytest
 from packaging import version
 
 @pytest.fixture(scope='module')

--- a/tests/uefi_sb/conftest.py
+++ b/tests/uefi_sb/conftest.py
@@ -1,6 +1,7 @@
+import pytest
+
 import logging
 
-import pytest
 from packaging import version
 
 @pytest.fixture(scope='module')

--- a/tests/uefi_sb/test_auth_var.py
+++ b/tests/uefi_sb/test_auth_var.py
@@ -2,10 +2,10 @@ import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.efi import (
+    EFI_AT_ATTRS_BYTES,
     Certificate,
     EFIAuth,
     global_variable_guid,
-    EFI_AT_ATTRS_BYTES,
 )
 
 # Requirements:

--- a/tests/uefi_sb/test_sb_state.py
+++ b/tests/uefi_sb/test_sb_state.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from .utils import generate_keys, revert_vm_state

--- a/tests/uefi_sb/test_sb_state.py
+++ b/tests/uefi_sb/test_sb_state.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from .utils import generate_keys, revert_vm_state
 

--- a/tests/uefi_sb/test_uefistored_cert_flow.py
+++ b/tests/uefi_sb/test_uefistored_cert_flow.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+
 import pytest
 
 from .utils import check_disk_cert_md5sum, check_vm_cert_md5sum, generate_keys, revert_vm_state

--- a/tests/uefi_sb/test_uefistored_cert_flow.py
+++ b/tests/uefi_sb/test_uefistored_cert_flow.py
@@ -1,7 +1,7 @@
+import pytest
+
 import hashlib
 import logging
-
-import pytest
 
 from .utils import check_disk_cert_md5sum, check_vm_cert_md5sum, generate_keys, revert_vm_state
 

--- a/tests/uefi_sb/test_uefistored_sb.py
+++ b/tests/uefi_sb/test_uefistored_sb.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for

--- a/tests/uefi_sb/test_uefistored_sb.py
+++ b/tests/uefi_sb/test_uefistored_sb.py
@@ -1,11 +1,20 @@
 import logging
+
 import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for
 
-from .utils import _test_key_exchanges, boot_and_check_no_sb_errors, boot_and_check_sb_failed, \
-    boot_and_check_sb_succeeded, generate_keys, revert_vm_state, sign_efi_bins, VM_SECURE_BOOT_FAILED
+from .utils import (
+    VM_SECURE_BOOT_FAILED,
+    _test_key_exchanges,
+    boot_and_check_no_sb_errors,
+    boot_and_check_sb_failed,
+    boot_and_check_sb_succeeded,
+    generate_keys,
+    revert_vm_state,
+    sign_efi_bins,
+)
 
 # These tests check the behaviour of XAPI and uefistored as they are in XCP-ng 8.2
 # For XCP-ng 8.3 or later, see test_varstored_sb.py

--- a/tests/uefi_sb/test_varstored_cert_flow.py
+++ b/tests/uefi_sb/test_varstored_cert_flow.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import wait_for
 

--- a/tests/uefi_sb/test_varstored_cert_flow.py
+++ b/tests/uefi_sb/test_varstored_cert_flow.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.common import wait_for

--- a/tests/uefi_sb/test_varstored_sb.py
+++ b/tests/uefi_sb/test_varstored_sb.py
@@ -1,8 +1,16 @@
 import logging
+
 import pytest
 
-from .utils import _test_key_exchanges, boot_and_check_no_sb_errors, boot_and_check_sb_failed, \
-    boot_and_check_sb_succeeded, generate_keys, revert_vm_state, sign_efi_bins
+from .utils import (
+    _test_key_exchanges,
+    boot_and_check_no_sb_errors,
+    boot_and_check_sb_failed,
+    boot_and_check_sb_succeeded,
+    generate_keys,
+    revert_vm_state,
+    sign_efi_bins,
+)
 
 # These tests check the behaviour of XAPI and varstored as they are in XCP-ng 8.3
 # For XCP-ng 8.2, see test_uefistored_sb.py

--- a/tests/uefi_sb/test_varstored_sb.py
+++ b/tests/uefi_sb/test_varstored_sb.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from .utils import (
     _test_key_exchanges,

--- a/tests/uefi_sb/utils.py
+++ b/tests/uefi_sb/utils.py
@@ -3,7 +3,7 @@ import logging
 
 from lib.commands import SSHCommandFailed
 from lib.common import wait_for
-from lib.efi import EFIAuth, EFI_AT_ATTRS_BYTES, get_md5sum_from_auth, get_secure_boot_guid
+from lib.efi import EFI_AT_ATTRS_BYTES, EFIAuth, get_md5sum_from_auth, get_secure_boot_guid
 
 VM_SECURE_BOOT_FAILED = 'VM_SECURE_BOOT_FAILED'
 

--- a/tests/vtpm/conftest.py
+++ b/tests/vtpm/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import logging
+
+import pytest
 
 from lib.common import PackageManagerEnum
 

--- a/tests/vtpm/conftest.py
+++ b/tests/vtpm/conftest.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.common import PackageManagerEnum
 

--- a/tests/vtpm/test_vtpm_basic_operations.py
+++ b/tests/vtpm/test_vtpm_basic_operations.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 import lib.commands as commands
 

--- a/tests/vtpm/test_vtpm_basic_operations.py
+++ b/tests/vtpm/test_vtpm_basic_operations.py
@@ -1,5 +1,7 @@
 import logging
+
 import pytest
+
 import lib.commands as commands
 
 # These tests are basic tests for vTPM devices.

--- a/tests/xapi/tls_verification/test_tls_verification.py
+++ b/tests/xapi/tls_verification/test_tls_verification.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.commands import SSHCommandFailed
 from lib.common import strtobool

--- a/tests/xapi/tls_verification/test_tls_verification.py
+++ b/tests/xapi/tls_verification/test_tls_verification.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.commands import SSHCommandFailed

--- a/tests/xapi_plugins/plugin_raid/test_raid.py
+++ b/tests/xapi_plugins/plugin_raid/test_raid.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/xapi_plugins/plugin_raid/test_raid.py
+++ b/tests/xapi_plugins/plugin_raid/test_raid.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 # Requirements:

--- a/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
+++ b/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 # Requirements:

--- a/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
+++ b/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
@@ -1,6 +1,6 @@
-import json
-
 import pytest
+
+import json
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/xapi_plugins/plugin_zfs/test_zfs.py
+++ b/tests/xapi_plugins/plugin_zfs/test_zfs.py
@@ -1,7 +1,7 @@
+import pytest
+
 import json
 import logging
-
-import pytest
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/xapi_plugins/plugin_zfs/test_zfs.py
+++ b/tests/xapi_plugins/plugin_zfs/test_zfs.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 import pytest
 
 # Requirements:

--- a/tests/xen/conftest.py
+++ b/tests/xen/conftest.py
@@ -1,6 +1,7 @@
+import pytest
+
 import logging
 
-import pytest
 from packaging import version
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)

--- a/tests/xen/conftest.py
+++ b/tests/xen/conftest.py
@@ -1,6 +1,6 @@
 import logging
-import pytest
 
+import pytest
 from packaging import version
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)

--- a/tests/xen/test_misc.py
+++ b/tests/xen/test_misc.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 import re
+
+import pytest
 
 # Misc tests for Xen host
 #

--- a/tests/xen/test_misc.py
+++ b/tests/xen/test_misc.py
@@ -1,7 +1,7 @@
+import pytest
+
 import logging
 import re
-
-import pytest
 
 # Misc tests for Xen host
 #

--- a/tests/xen/test_ring0.py
+++ b/tests/xen/test_ring0.py
@@ -1,9 +1,10 @@
-import logging
-import secrets
-import time
 from typing import Generator, Optional
 
 import pytest
+
+import logging
+import secrets
+import time
 
 from lib.host import Host
 from lib.vm import VM

--- a/tests/xen/test_ring0.py
+++ b/tests/xen/test_ring0.py
@@ -1,8 +1,9 @@
 import logging
-import pytest
 import secrets
 import time
 from typing import Generator, Optional
+
+import pytest
 
 from lib.host import Host
 from lib.vm import VM

--- a/tests/xen/test_ring0.py
+++ b/tests/xen/test_ring0.py
@@ -1,5 +1,3 @@
-from typing import Generator, Optional
-
 import pytest
 
 import logging
@@ -8,6 +6,8 @@ import time
 
 from lib.host import Host
 from lib.vm import VM
+
+from typing import Generator, Optional
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/xen/test_xen_dom0_tests.py
+++ b/tests/xen/test_xen_dom0_tests.py
@@ -1,7 +1,7 @@
+import pytest
+
 import json
 import logging
-
-import pytest
 
 # Requirements:
 # From --hosts parameter:

--- a/tests/xen/test_xen_dom0_tests.py
+++ b/tests/xen/test_xen_dom0_tests.py
@@ -1,5 +1,6 @@
-import logging
 import json
+import logging
+
 import pytest
 
 # Requirements:

--- a/tests/xen/test_xtf.py
+++ b/tests/xen/test_xtf.py
@@ -49,7 +49,7 @@ class TestXtf:
                              "Checking whether they belong to the allowed list...")
                 for skipped_test in skipped_tests:
                     if skipped_test not in self._common_skips:
-                        logging.error(f"... At least one doesn't")
+                        logging.error("... At least one doesn't")
                         raise
                 logging.info("... They do")
             else:

--- a/tests/xen/test_xtf.py
+++ b/tests/xen/test_xtf.py
@@ -1,6 +1,6 @@
-import logging
-
 import pytest
+
+import logging
 
 from lib.commands import SSHCommandFailed
 

--- a/tests/xen/test_xtf.py
+++ b/tests/xen/test_xtf.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from lib.commands import SSHCommandFailed

--- a/uv.lock
+++ b/uv.lock
@@ -565,6 +565,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/38/796a101608a90494440856ccfb52b1edae90de0b817e76bfade66b12d320/ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c", size = 4413426, upload-time = "2025-06-26T20:34:14.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/bf/3dba52c1d12ab5e78d75bd78ad52fb85a6a1f29cc447c2423037b82bed0d/ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b", size = 10305649, upload-time = "2025-06-26T20:33:39.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/65/dab1ba90269bc8c81ce1d499a6517e28fe6f87b2119ec449257d0983cceb/ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0", size = 11120201, upload-time = "2025-06-26T20:33:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3e/2d819ffda01defe857fa2dd4cba4d19109713df4034cc36f06bbf582d62a/ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be", size = 10466769, upload-time = "2025-06-26T20:33:44.102Z" },
+    { url = "https://files.pythonhosted.org/packages/63/37/bde4cf84dbd7821c8de56ec4ccc2816bce8125684f7b9e22fe4ad92364de/ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff", size = 10660902, upload-time = "2025-06-26T20:33:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3a/390782a9ed1358c95e78ccc745eed1a9d657a537e5c4c4812fce06c8d1a0/ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d", size = 10167002, upload-time = "2025-06-26T20:33:47.81Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/05/f2d4c965009634830e97ffe733201ec59e4addc5b1c0efa035645baa9e5f/ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd", size = 11751522, upload-time = "2025-06-26T20:33:49.857Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/4bfc519b5fcd462233f82fc20ef8b1e5ecce476c283b355af92c0935d5d9/ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010", size = 12520264, upload-time = "2025-06-26T20:33:52.199Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/7756a6925da236b3a31f234b4167397c3e5f91edb861028a631546bad719/ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e", size = 12133882, upload-time = "2025-06-26T20:33:54.231Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/00/40da9c66d4a4d51291e619be6757fa65c91b92456ff4f01101593f3a1170/ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed", size = 11608941, upload-time = "2025-06-26T20:33:56.202Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e7/f898391cc026a77fbe68dfea5940f8213622474cb848eb30215538a2dadf/ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc", size = 11602887, upload-time = "2025-06-26T20:33:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/02/0891872fc6aab8678084f4cf8826f85c5d2d24aa9114092139a38123f94b/ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9", size = 10521742, upload-time = "2025-06-26T20:34:00.465Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/98/d6534322c74a7d47b0f33b036b2498ccac99d8d8c40edadb552c038cecf1/ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13", size = 10149909, upload-time = "2025-06-26T20:34:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5c/9b7ba8c19a31e2b6bd5e31aa1e65b533208a30512f118805371dbbbdf6a9/ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c", size = 11136005, upload-time = "2025-06-26T20:34:04.723Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/34/9bbefa4d0ff2c000e4e533f591499f6b834346025e11da97f4ded21cb23e/ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6", size = 11648579, upload-time = "2025-06-26T20:34:06.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1c/20cdb593783f8f411839ce749ec9ae9e4298c2b2079b40295c3e6e2089e1/ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245", size = 10519495, upload-time = "2025-06-26T20:34:08.718Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/56/7158bd8d3cf16394928f47c637d39a7d532268cd45220bdb6cd622985760/ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013", size = 11547485, upload-time = "2025-06-26T20:34:11.008Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d0/6902c0d017259439d6fd2fd9393cea1cfe30169940118b007d5e0ea7e954/ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc", size = 10691209, upload-time = "2025-06-26T20:34:12.928Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -654,6 +679,7 @@ dev = [
     { name = "pydocstyle" },
     { name = "pyright" },
     { name = "pyyaml" },
+    { name = "ruff" },
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
@@ -679,6 +705,7 @@ dev = [
     { name = "pydocstyle" },
     { name = "pyright" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff" },
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
Ruff (or any linter) helps catch mistakes and messy code before they cause headaches. It points out things like unused imports, style issues, or potential bugs, so we don’t have to hunt them down later. It also keeps our code consistent and easy to read, which is great when working in team or with external contributors.

Ruff is very fast, easy to set up in the CI and in our IDEs.

I've used the same rules as in the xcp repository, but we probably want to remove some of them or add some more.
Look at the commit that fixes errors to get an idea of what you may or may not like.
All the available rules are documented at https://docs.astral.sh/ruff/rules/