### PR TITLE
Disabled "thick" SR type tests due to instability during teardown.

### DIFF
--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -45,7 +45,7 @@ def lvm_disks(host, sr_disks_for_all_hosts, provisioning_type):
 def storage_pool_name(provisioning_type):
     return GROUP_NAME if provisioning_type == "thick" else STORAGE_POOL_NAME
 
-@pytest.fixture(params=["thin", "thick"], scope="session")
+@pytest.fixture(params=["thin"], scope="session")
 def provisioning_type(request):
     return request.param
 


### PR DESCRIPTION
Occasional teardown failures caused by conflicts, such as: `Logical volume linstor_group/xcp-persistent-database_00000 is used by another device`, are interfering with `sr-destroy` and causing environmental instability.

Until this behavior is stabilized and teardown becomes reliable, thick provisioning tests are being temporarily excluded.