### PR TITLE
Add test for rolling pool update with VM availability check on updated host

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -359,9 +359,10 @@ class Host:
         else:
             return self.xe('vm-list', {'uuid': vm_uuid}, minimal=True) == vm_uuid
 
-    def install_updates(self):
+    def install_updates(self, enablerepo=None):
         logging.info("Install updates on host %s" % self)
-        return self.ssh(['yum', 'update', '-y'])
+        enablerepo_cmd = ['--enablerepo=%s' % enablerepo] if enablerepo is not None else []
+        return self.ssh(['yum', 'update', '-y'] + enablerepo_cmd)
 
     def restart_toolstack(self, verify=False):
         logging.info("Restart toolstack on host %s" % self)
@@ -376,10 +377,11 @@ class Host:
             # If XAPI is not ready yet, or the host is down, this will throw. We return False in that case.
             return False
 
-    def has_updates(self):
+    def has_updates(self, enablerepo=None):
+        enablerepo_cmd = ['--enablerepo=%s' % enablerepo] if enablerepo is not None else []
         try:
             # yum check-update returns 100 if there are updates, 1 if there's an error, 0 if no updates
-            self.ssh(['yum', 'check-update'])
+            self.ssh(['yum', 'check-update'] + enablerepo_cmd)
             # returned 0, else there would have been a SSHCommandFailed
             return False
         except commands.SSHCommandFailed as e:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ markers =
     default_vm: mark a test with a default VM in case no --vm parameter was given.
 
     # *** Markers used to select tests at collect stage ***
+    upgrade_test: mark a test which will upgrade packages from testing repo
 
     # * Host-related markers, automatically set based on fixtures
     hostA2: a second member in the first pool.

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -49,9 +49,20 @@ def storage_pool_name(provisioning_type):
 def provisioning_type(request):
     return request.param
 
+def pytest_configure(config):
+    config._linstor_upgrade_test = False
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if item.get_closest_marker("upgrade_test"):
+            config._linstor_upgrade_test = True
+            break
+
 @pytest.fixture(scope='package')
-def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state):
+def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state, request):
     import concurrent.futures
+
+    dont_use_testing_repo = request.config._linstor_upgrade_test
     pool = pool_with_saved_yum_state
 
     def check_linstor_installed(host):
@@ -66,7 +77,10 @@ def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state):
     def install_linstor(host):
         logging.info(f"Installing {LINSTOR_PACKAGE} on host {host}...")
         host.yum_install([LINSTOR_RELEASE_PACKAGE])
-        host.yum_install([LINSTOR_PACKAGE], enablerepo="xcp-ng-linstor-testing")
+        if dont_use_testing_repo:
+            host.yum_install([LINSTOR_PACKAGE])
+        else:
+            host.yum_install([LINSTOR_PACKAGE], enablerepo="xcp-ng-linstor-testing")
         # Needed because the linstor driver is not in the xapi sm-plugins list
         # before installing the LINSTOR packages.
         host.ssh(["systemctl", "restart", "multipathd"])


### PR DESCRIPTION
Added `test_linstor_sr_pool_update` for rolling pool update with VM availability check.

It performs
- A rolling update and reboot of all hosts in a LINSTOR SR pool (starting with the master).
- Verifies VM can start and shutdown successfully on each host after update.
- Ensures SR remains usable throughout the process.