### PR TITLE
Test installer's raid1 feature

### DIFF
--- a/data.py-dist
+++ b/data.py-dist
@@ -8,8 +8,7 @@ import legacycrypt as crypt  # type: ignore[import-untyped]
 
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
-    from lib.typing import IsoImageDef
+from lib.typing import SimpleAnswerfileDict, IsoImageDef
 
 # Default user and password to connect to a host through XAPI
 # Note: this won't be used for SSH.
@@ -23,6 +22,7 @@ def hash_password(password):
     return crypt.crypt(password, salt)
 
 HOST_DEFAULT_PASSWORD_HASH = hash_password(HOST_DEFAULT_PASSWORD)
+assert isinstance(HOST_DEFAULT_PASSWORD_HASH, str)
 
 # Public keys for a private keys available to the test runner
 TEST_SSH_PUBKEY = """
@@ -240,26 +240,26 @@ LVMOHBA_DEVICE_CONFIG: dict[str, str] = {
 #    'SCSIid': 'wwid'
 }
 
-BASE_ANSWERFILES = dict(
-    INSTALL={
+BASE_ANSWERFILES: dict[str, "SimpleAnswerfileDict"] = dict(
+    INSTALL=SimpleAnswerfileDict({
         "TAG": "installation",
         "CONTENTS": (
-            {"TAG": "root-password",
-             "type": "hash",
-             "CONTENTS": HOST_DEFAULT_PASSWORD_HASH},
-            {"TAG": "timezone",
-             "CONTENTS": "Europe/Paris"},
-            {"TAG": "keymap",
-             "CONTENTS": "us"},
+            SimpleAnswerfileDict({"TAG": "root-password",
+                                  "type": "hash",
+                                  "CONTENTS": HOST_DEFAULT_PASSWORD_HASH}),
+            SimpleAnswerfileDict({"TAG": "timezone",
+                                  "CONTENTS": "Europe/Paris"}),
+            SimpleAnswerfileDict({"TAG": "keymap",
+                                  "CONTENTS": "us"}),
         ),
-    },
-    UPGRADE={
+    }),
+    UPGRADE=SimpleAnswerfileDict({
         "TAG": "installation",
         "mode": "upgrade",
-    },
-    RESTORE={
+    }),
+    RESTORE=SimpleAnswerfileDict({
         "TAG": "restore",
-    },
+    }),
 )
 
 IMAGE_EQUIVS: dict[str, str] = {

--- a/lib/installer.py
+++ b/lib/installer.py
@@ -6,14 +6,15 @@ import xml.etree.ElementTree as ET
 
 from lib.commands import SSHCommandFailed, ssh
 from lib.common import wait_for
+from lib.typing import AnswerfileDict, SimpleAnswerfileDict
 
-from typing import Any, Self
+from typing import Optional, Self, Sequence, cast
 
 class AnswerFile:
-    def __init__(self, kind: str, /):
+    def __init__(self, kind: str, /) -> None:
         from data import BASE_ANSWERFILES
-        defn = BASE_ANSWERFILES[kind]
-        self.defn = self._normalize_structure(defn)  # type: ignore
+        defn: SimpleAnswerfileDict = BASE_ANSWERFILES[kind]
+        self.defn = self._normalize_structure(defn)
 
     def write_xml(self, filename: str) -> None:
         etree = ET.ElementTree(self._defn_to_xml_et(self.defn))
@@ -21,26 +22,27 @@ class AnswerFile:
 
     # chainable mutators for lambdas
 
-    def top_append(self, *defs: dict[str, Any] | None) -> Self:
+    def top_append(self, *defs: SimpleAnswerfileDict | None | ValueError) -> Self:
+        assert not isinstance(self.defn['CONTENTS'], str), "a toplevel CONTENTS must be a list"
         for defn in defs:
             if defn is None:
                 continue
             self.defn['CONTENTS'].append(self._normalize_structure(defn))
         return self
 
-    def top_setattr(self, attrs: dict[str, Any]) -> Self:
+    def top_setattr(self, attrs: dict[str, str]) -> Self:
         assert 'CONTENTS' not in attrs
-        self.defn.update(attrs)
+        self.defn.update(cast(AnswerfileDict, attrs))
         return self
 
     # makes a mutable deep copy of all `contents`
     @staticmethod
-    def _normalize_structure(defn: dict[str, Any]) -> dict[str, Any]:
+    def _normalize_structure(defn: SimpleAnswerfileDict | ValueError) -> AnswerfileDict:
         assert isinstance(defn, dict), f"{defn!r} is not a dict"
         assert 'TAG' in defn, f"{defn} has no TAG"
 
         # type mutation through nearly-shallow copy
-        new_defn: dict[str, Any] = {
+        new_defn: AnswerfileDict = {
             'TAG': defn['TAG'],
             'CONTENTS': [],
         }
@@ -49,29 +51,39 @@ class AnswerFile:
                 if isinstance(value, str):
                     new_defn['CONTENTS'] = value
                 else:
+                    # TypedDict is not typed enough?
+                    value_as_sequence: Sequence[SimpleAnswerfileDict]
+                    if isinstance(value, Sequence):
+                        value_as_sequence = value
+                    else:
+                        # FIXME what is that?
+                        value_as_sequence = (
+                            cast(SimpleAnswerfileDict, value),
+                        )
                     new_defn['CONTENTS'] = [
                         AnswerFile._normalize_structure(item)
-                        for item in value
+                        for item in value_as_sequence
                         if item is not None
                     ]
             elif key == 'TAG':
                 pass            # already copied
             else:
-                new_defn[key] = value
+                new_defn[key] = value # type: ignore[literal-required]
 
         return new_defn
 
     # convert to a ElementTree.Element tree suitable for further
     # modification before we serialize it to XML
     @staticmethod
-    def _defn_to_xml_et(defn: dict[str, Any], *, parent: ET.Element | None = None) -> ET.Element:
+    def _defn_to_xml_et(defn: AnswerfileDict, /, *, parent: Optional[ET.Element] = None) -> ET.Element:
         assert isinstance(defn, dict)
-        defn = dict(defn)
-        name = defn.pop('TAG')
+        defn_copy = dict(defn)
+        name = defn_copy.pop('TAG')
         assert isinstance(name, str)
-        contents = defn.pop('CONTENTS', ())
+        contents = cast(str | list[AnswerfileDict], defn_copy.pop('CONTENTS', []))
         assert isinstance(contents, (str, list))
-        element = ET.Element(name, {}, **defn)
+        defn_filtered = cast(dict[str, str], defn_copy)
+        element = ET.Element(name, {}, **defn_filtered)
         if parent is not None:
             parent.append(element)
         if isinstance(contents, str):

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import sys
 
-from typing import NotRequired, TypedDict
+from typing import NotRequired, Sequence, TypedDict, Union
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired
@@ -15,3 +17,27 @@ IsoImageDef = TypedDict('IsoImageDef',
                          })
 
 JSONType = None | bool | int | float | str | list["JSONType"] | dict[str, "JSONType"]
+
+
+# Dict-based description of an Answerfile object to be built.
+AnswerfileDict = TypedDict('AnswerfileDict', {
+    'TAG': str,
+    'CONTENTS': str | list["AnswerfileDict"],
+})
+
+# Simplified version of AnswerfileDict for user input.
+# - does not require to write 0 or 1 subelement as a list
+SimpleAnswerfileDict = TypedDict('SimpleAnswerfileDict', {
+    'TAG': str,
+    'CONTENTS': NotRequired[Union[str, "SimpleAnswerfileDict", Sequence["SimpleAnswerfileDict"]]],
+
+    # No way to allow arbitrary fields in addition?  This conveys the
+    # field's type, but allows them in places we wouldn't want them,
+    # and forces every XML attribute we use to appear here.
+    'guest-storage': NotRequired[str],
+    'mode': NotRequired[str],
+    'name': NotRequired[str],
+    'proto': NotRequired[str],
+    'stage': NotRequired[str],
+    'type': NotRequired[str],
+})

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -34,6 +34,7 @@ SimpleAnswerfileDict = TypedDict('SimpleAnswerfileDict', {
     # No way to allow arbitrary fields in addition?  This conveys the
     # field's type, but allows them in places we wouldn't want them,
     # and forces every XML attribute we use to appear here.
+    'device': NotRequired[str],
     'guest-storage': NotRequired[str],
     'mode': NotRequired[str],
     'name': NotRequired[str],

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -40,5 +40,6 @@ SimpleAnswerfileDict = TypedDict('SimpleAnswerfileDict', {
     'name': NotRequired[str],
     'proto': NotRequired[str],
     'stage': NotRequired[str],
+    'swraid': NotRequired[str],
     'type': NotRequired[str],
 })

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -13,6 +13,7 @@ from lib import installer, pxe
 from lib.commands import local_cmd
 from lib.common import callable_marker, url_download, wait_for
 from lib.installer import AnswerFile
+from lib.typing import SimpleAnswerfileDict
 
 from typing import TYPE_CHECKING, Any, Generator, Sequence
 
@@ -137,8 +138,9 @@ def remastered_iso(installer_iso: dict[str, str | bool], answerfile: AnswerFile 
 
         if answerfile:
             logging.info("generating answerfile %s", answerfile_xml)
-            answerfile.top_append(dict(TAG="script", stage="filesystem-populated",
-                                       type="url", CONTENTS="file:///root/postinstall.sh"))
+            answerfile.top_append(SimpleAnswerfileDict(TAG="script", stage="filesystem-populated",
+                                                       type="url",
+                                                       CONTENTS="file:///root/postinstall.sh"))
             if unsigned:
                 answerfile.top_setattr({'gpgcheck': "false",
                                         'repo-gpgcheck': "false",

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -15,7 +15,7 @@ from lib.common import callable_marker, url_download, wait_for
 from lib.installer import AnswerFile
 from lib.typing import SimpleAnswerfileDict
 
-from typing import TYPE_CHECKING, Any, Generator, Sequence
+from typing import TYPE_CHECKING, Any, Generator, Literal, Sequence, TypeAlias
 
 if TYPE_CHECKING:
     from lib.host import Host
@@ -103,11 +103,46 @@ def installer_iso(request: pytest.FixtureRequest) -> dict[str, str | bool]:
                 unsigned=ISO_IMAGES[iso_key].get('unsigned', False),
                 )
 
+SystemDiskConfig: TypeAlias = Literal['disk'] | Literal['raid1']
+
 @pytest.fixture(scope='function')
-def system_disks_names(request: pytest.FixtureRequest) -> tuple[str, ...]:
+def system_disk_config(request: pytest.FixtureRequest) -> SystemDiskConfig:
+    """From test context, termine whether we're installing on raid1/etc.
+
+    On install tests where we specify the install parameters this
+    comes from the `system_disk_config` test parameter, and on later
+    tests it has to be infered from `installed_config`.
+    """
+    try:
+        system_disk_config = request.getfixturevalue("system_disk_config")
+    except pytest.FixtureLookupError:
+        installed_config = request.getfixturevalue("installed_config")
+        assert '-' in installed_config, (f"installed_config ({installed_config}) must include a dash"
+                                         " to extract system_disk_config")
+        # This heuristic is very ad-hoc, we should switch to a more
+        # formal encoding of `installed_config`... or rely on tracking
+        # by upcoming PaaS
+        for component in reversed(installed_config.split('-')):
+            if component in ('disk', 'raid1', 'xsraid1'):
+                system_disk_config = component
+                break
+        else:
+            assert False, f"No system_disk_config component found in {installed_config}"
+
+    return system_disk_config
+
+@pytest.fixture(scope='function')
+def system_disks_names(request: pytest.FixtureRequest, system_disk_config: SystemDiskConfig
+                       ) -> tuple[str, ...]:
     firmware = request.getfixturevalue("firmware")
     main_disk = {"uefi": "nvme0n1", "bios": "sda"}[firmware]
-    return (main_disk,)
+
+    extra_disks = {"raid1": {"uefi": ("nvme0n2",), "bios": ("sdb",)}[firmware],
+                   "disk": (),
+                   }[system_disk_config]
+
+    return (main_disk,) + extra_disks
+
 
 # Remasters the ISO sepecified by `installer_iso` mark, with:
 # - network and ssh support activated, and .ssh/authorized_key so tests can

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -103,7 +103,7 @@ def installer_iso(request: pytest.FixtureRequest) -> dict[str, str | bool]:
                 unsigned=ISO_IMAGES[iso_key].get('unsigned', False),
                 )
 
-SystemDiskConfig: TypeAlias = Literal['disk'] | Literal['raid1']
+SystemDiskConfig: TypeAlias = Literal['disk'] | Literal['raid1'] | Literal['xsraid1']
 
 @pytest.fixture(scope='function')
 def system_disk_config(request: pytest.FixtureRequest) -> SystemDiskConfig:
@@ -138,6 +138,7 @@ def system_disks_names(request: pytest.FixtureRequest, system_disk_config: Syste
     main_disk = {"uefi": "nvme0n1", "bios": "sda"}[firmware]
 
     extra_disks = {"raid1": {"uefi": ("nvme0n2",), "bios": ("sdb",)}[firmware],
+                   "xsraid1": {"uefi": ("nvme0n2",), "bios": ("sdb",)}[firmware],
                    "disk": (),
                    }[system_disk_config]
 

--- a/tests/install/test-sequences/inst+upg+rst.lst
+++ b/tests/install/test-sequences/inst+upg+rst.lst
@@ -1,2 +1,2 @@
-tests/install/test.py::TestNested::test_restore[uefi-83nightly-83nightly-83nightly-iso-ext]
-tests/install/test.py::TestNested::test_boot_rst[uefi-83nightly-83nightly-83nightly-iso-ext]
+tests/install/test.py::TestNested::test_restore[uefi-83nightly-disk-83nightly-83nightly-iso-ext]
+tests/install/test.py::TestNested::test_boot_rst[uefi-83nightly-disk-83nightly-83nightly-iso-ext]

--- a/tests/install/test-sequences/inst+upg.lst
+++ b/tests/install/test-sequences/inst+upg.lst
@@ -1,2 +1,2 @@
-tests/install/test.py::TestNested::test_upgrade[uefi-83nightly-83nightly-host1-iso-ext]
-tests/install/test.py::TestNested::test_boot_upg[uefi-83nightly-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[uefi-83nightly-disk-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[uefi-83nightly-disk-83nightly-host1-iso-ext]

--- a/tests/install/test-sequences/inst.lst
+++ b/tests/install/test-sequences/inst.lst
@@ -1,3 +1,3 @@
-tests/install/test.py::TestNested::test_install[uefi-83nightly-iso-ext]
-tests/install/test.py::TestNested::test_tune_firstboot[None-uefi-83nightly-host1-iso-ext]
-tests/install/test.py::TestNested::test_boot_inst[uefi-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_install[uefi-83nightly-disk-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-uefi-83nightly-disk-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[uefi-83nightly-disk-host1-iso-ext]

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -9,10 +9,11 @@ from lib.common import safe_split, wait_for
 from lib.installer import AnswerFile
 from lib.pif import PIF
 from lib.pool import Pool
+from lib.typing import SimpleAnswerfileDict
 from lib.vdi import VDI
 from lib.vm import VM
 
-from typing import Generator
+from typing import TYPE_CHECKING, Generator
 
 assert "MGMT" in NETWORKS
 
@@ -47,18 +48,19 @@ def helper_vm_with_plugged_disk(running_vm: VM, create_vms: list[VM]) -> Generat
 class TestNested:
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
-    @pytest.mark.parametrize("iso_version", (
-        "83nightly", "830net",
-        "830",
-        "82nightly",
-        "821.1",
-        "81", "80", "76", "75",
-        "xs8", "ch821.1",
-        "xs70",
+    @pytest.mark.parametrize(("iso_version", "system_disk_config"), (
+        ("83nightly", "disk"), ("83nightly", "raid1"),
+        ("830net", "disk"),
+        ("830", "disk"),
+        ("82nightly", "disk"),
+        ("821.1", "disk"), ("821.1", "raid1"),
+        ("81", "disk"), ("80", "disk"), ("76", "disk"), ("75", "disk"),
+        ("xs8", "disk"), ("ch821.1", "disk"),
+        ("xs70", "disk"),
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
-    @pytest.mark.vm_definitions(
-        lambda firmware: dict(
+    @pytest.mark.vm_definitions.with_args(
+        lambda firmware, system_disk_config: dict(
             name="vm1",
             template="Other install media",
             params=(
@@ -78,26 +80,42 @@ class TestNested:
                 ),
                 "bios": (),
             }[firmware],
-            vdis=[dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0")],
+            vdis=([dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0")]
+                  + ([dict(name="vm1 system disk mirror", size="100GiB", device="xvdb", userdevice="1")]
+                     if system_disk_config == "raid1" else [])
+                  ),
             cd_vbd=dict(device="xvdd", userdevice="3"),
             vifs=[dict(index=0, network_name=NETWORKS["MGMT"])],
         ))
     @pytest.mark.answerfile.with_args(
-        lambda system_disks_names, local_sr, package_source, iso_version: AnswerFile("INSTALL")
+        lambda system_disks_names, local_sr, package_source, system_disk_config, iso_version: AnswerFile("INSTALL")
         .top_setattr({} if local_sr == "nosr" else {"sr-type": local_sr})
         .top_append(
             {"iso": {"TAG": "source", "type": "local"},
              "net": {"TAG": "source", "type": "url",
                      "CONTENTS": ISO_IMAGES[iso_version]['net-url']},  # type: ignore
              }[package_source],
+
+            {"raid1": SimpleAnswerfileDict(
+                {"TAG": "raid", "device": "md127",
+                 "CONTENTS": [
+                     {"TAG": "disk", "CONTENTS": diskname} for diskname in system_disks_names
+                 ]}),
+             "disk": None,
+             }[system_disk_config],
+
             {"TAG": "admin-interface", "name": "eth0", "proto": "dhcp"},
             {"TAG": "primary-disk",
              "guest-storage": "no" if local_sr == "nosr" else "yes",
-             "CONTENTS": system_disks_names[0]},
+             "CONTENTS": {"disk": system_disks_names[0],
+                          "raid1": "md127",
+                          }[system_disk_config],
+             },
         ))
     def test_install(self, vm_booted_with_installer: VM, system_disks_names: list[str],
-                     firmware: str, iso_version: str, package_source: str, local_sr: str) -> None:
-        assert isinstance(system_disks_names, list)
+                     firmware: str, iso_version: str, package_source: str, system_disk_config: str,
+                     local_sr: str) -> None:
+        assert isinstance(system_disks_names, tuple)
         host_vm = vm_booted_with_installer
         assert host_vm.ip is not None
         installer.monitor_install(ip=host_vm.ip)
@@ -106,27 +124,42 @@ class TestNested:
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
     @pytest.mark.parametrize("machine", ("host1", "host2"))
-    @pytest.mark.parametrize("version", (
-        "83nightly", "830net",
-        "830",
-        "82nightly",
-        "821.1",
-        "81", "80",
-        "76", "75",
-        "xs8", "ch821.1",
-        "xs70",
+    @pytest.mark.parametrize("installed_config", (
+        "83nightly-disk",
+        "83nightly-raid1",
+        "830net-disk",
+        "830-disk",
+        "82nightly-disk",
+        "821.1-disk",
+        "821.1-raid1",
+        "81-disk", "80-disk", "76-disk", "75-disk",
+        "xs8-disk", "ch821.1-disk",
+        "xs70-disk",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda version, firmware, local_sr, package_source: [dict(
+        lambda installed_config, firmware, local_sr, package_source: [dict(
             vm="vm1",
-            image_test=f"TestNested::test_install[{firmware}-{version}-{package_source}-{local_sr}]")])
+            image_test=(f"TestNested::test_install[{firmware}-{installed_config}"
+                        f"-{package_source}-{local_sr}]"))])
     @pytest.mark.small_vm
     def test_tune_firstboot(self, create_vms: list[VM], helper_vm_with_plugged_disk: VM,
-                            firmware: str, version: str, machine: str, local_sr: str, package_source: str) -> None:
+                            system_disk_config: str,
+                            firmware: str, installed_config: str, machine: str, local_sr: str,
+                            package_source: str) -> None:
         helper_vm = helper_vm_with_plugged_disk
 
-        helper_vm.ssh("mount /dev/xvdb1 /mnt")
+        match system_disk_config:
+            case "disk":
+                helper_vm.ssh("mount /dev/xvdb1 /mnt")
+            case "raid1":
+                # FIXME helper VM has to be an Alpine, that should not be a random vm_ref
+                helper_vm.ssh("apk add mdadm")
+                helper_vm.ssh("mdadm -A /dev/md/127 -N localhost:127")
+                helper_vm.ssh("mount /dev/md127p1 /mnt")
+            case _:
+                raise ValueError(f"unhandled system_disk_config {system_disk_config!r}")
+
         try:
             # hostname
             logging.info("Setting hostname to %r", machine)
@@ -138,9 +171,9 @@ class TestNested:
             )
             helper_vm.ssh("grep UUID /mnt/etc/xensource-inventory")
         finally:
-            helper_vm.ssh("umount /dev/xvdb1")
+            helper_vm.ssh("umount /mnt")
 
-    def _test_firstboot(self, create_vms: list[VM], mode: str, *,
+    def _test_firstboot(self, create_vms: list[VM], installed_config: str, *,
                         machine: str = 'DEFAULT', is_restore: bool = False) -> None:
         host_vm = create_vms[0]
         vif = host_vm.vifs()[0]
@@ -149,12 +182,29 @@ class TestNested:
         logging.info("Host VM has MAC %s", mac_address)
 
         # succession of insta/upg/rst operations
-        split_mode = mode.split("-")
+        split_installed_config = installed_config.split("-")
         if is_restore:
             # restore: back to previous installed version
-            expected_rel_id = split_mode[-3]
+            assert len(split_installed_config) >= 4, ("unexpectedly-short installed_config"
+                                                      f" {installed_config!r} for restore")
+            # FIXME: this is an awful heuristic
+            if len(split_installed_config) == 4:
+                # reverting the first upgrade, must skip system_disk_config
+                expected_rel_id = split_installed_config[-4]
+            else:
+                expected_rel_id = split_installed_config[-3]
         else:
-            expected_rel_id = split_mode[-1]
+            # not a restore, looking for the last install or upgrade
+            for component in reversed(split_installed_config):
+                if component in ('disk', 'raid1', 'xsraid1'):
+                    continue
+                expected_rel_id = component
+                break
+            else:
+                assert False, f"Cannot find last version in {installed_config}"
+
+        logging.debug("installed_config=%s len=%s is_restore=%s => expected_rel_id=%s",
+                      installed_config, len(split_installed_config), is_restore, expected_rel_id)
         expected_rel = {
             "83nightly": "8.3.0",
             "830net": "8.3.0",
@@ -171,7 +221,7 @@ class TestNested:
             "xs70": "7.0.0-125380c",
         }[expected_rel_id]
 
-        # determine version info from `mode`
+        # determine version info from `installed_config`
         if expected_rel_id.startswith("xs"):
             expected_dist = "XenServer"
         elif expected_rel_id.startswith("ch"):
@@ -301,60 +351,71 @@ class TestNested:
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
     @pytest.mark.parametrize("machine", ("host1", "host2"))
-    @pytest.mark.parametrize("version", (
-        "83nightly", "830net",
-        "830",
-        "82nightly",
-        "821.1",
-        "81", "80",
-        "76", "75",
-        "xs8", "ch821.1",
-        "xs70",
+    @pytest.mark.parametrize("installed_config", (
+        "83nightly-disk",
+        "83nightly-raid1",
+        "830net-disk",
+        "830-disk",
+        "82nightly-disk",
+        "821.1-disk",
+        "821.1-raid1",
+        "81-disk", "80-disk", "76-disk", "75-disk",
+        "xs8-disk", "ch821.1-disk",
+        "xs70-disk",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda firmware, version, machine, local_sr, package_source: [
+        lambda firmware, installed_config, machine, local_sr, package_source: [
             dict(vm="vm1",
                  image_test=("TestNested::test_tune_firstboot"
-                             f"[None-{firmware}-{version}-{machine}-{package_source}-{local_sr}]"))])
+                             f"[None-{firmware}-{installed_config}"
+                             f"-{machine}-{package_source}-{local_sr}]"))])
     def test_boot_inst(self, create_vms: list[VM],
-                       firmware: str, version: str, machine: str, package_source: str, local_sr: str) -> None:
-        self._test_firstboot(create_vms, version, machine=machine)
+                       firmware: str, installed_config: str, machine: str, package_source: str,
+                       local_sr: str) -> None:
+        self._test_firstboot(create_vms, installed_config, machine=machine)
 
     @pytest.mark.usefixtures("xcpng_chained")
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
     @pytest.mark.parametrize("machine", ("host1", "host2"))
-    @pytest.mark.parametrize(("orig_version", "iso_version"), [
-        ("83nightly", "83nightly"),
-        ("830", "83nightly"),
-        ("821.1", "83nightly"),
-        ("81", "83nightly"),
-        ("80", "83nightly"),
-        ("xs8", "83nightly"),
-        ("ch821.1", "83nightly"),
-        ("830net", "830net"), # FIXME
-        ("82nightly", "82nightly"),
-        ("821.1", "82nightly"),
-        ("821.1", "821.1"),
-    ])
+    @pytest.mark.parametrize(("installed_config", "iso_version"), (
+        ("83nightly-disk", "83nightly"),
+        ("83nightly-raid1", "83nightly"),
+        ("830-disk", "83nightly"),
+        ("821.1-disk", "83nightly"),
+        ("821.1-raid1", "83nightly"),
+        ("81-disk", "83nightly"),
+        ("80-disk", "83nightly"),
+        ("xs8-disk", "83nightly"),
+        ("ch821.1-disk", "83nightly"),
+        ("830net-disk", "830net"), # FIXME
+        ("82nightly-disk", "82nightly"),
+        ("821.1-disk", "82nightly"),
+        ("821.1-raid1", "82nightly"),
+        ("821.1-disk", "821.1"),
+    ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda firmware, orig_version, machine, package_source, local_sr: [dict(
+        lambda firmware, installed_config, machine, package_source, local_sr: [dict(
             vm="vm1",
-            image_test=f"TestNested::test_boot_inst[{firmware}-{orig_version}-{machine}-{package_source}-{local_sr}]")])
+            image_test=(f"TestNested::test_boot_inst[{firmware}-{installed_config}-{machine}"
+                        f"-{package_source}-{local_sr}]"))])
     @pytest.mark.answerfile.with_args(
-        lambda system_disks_names, package_source, iso_version: AnswerFile("UPGRADE").top_append(
+        lambda system_disks_names, package_source, system_disk_config, iso_version:
+        AnswerFile("UPGRADE").top_append(
             {"iso": {"TAG": "source", "type": "local"},
              "net": {"TAG": "source", "type": "url",
                      "CONTENTS": ISO_IMAGES[iso_version]['net-url']},  # type: ignore
              }[package_source],
             {"TAG": "existing-installation",
-             "CONTENTS": system_disks_names[0]},
+             "CONTENTS": {"disk": system_disks_names[0],
+                          "raid1": "md127",
+                          }[system_disk_config]},
         ))
     def test_upgrade(self, vm_booted_with_installer: VM, system_disks_names: list[str],
-                     firmware: str, orig_version: str, iso_version: str, machine: str,
-                     package_source: str, local_sr: str) -> None:
+                     firmware: str, installed_config: str, iso_version: str, machine: str,
+                     package_source: str, system_disk_config: str, local_sr: str) -> None:
         host_vm = vm_booted_with_installer
         assert host_vm.ip is not None
         installer.monitor_upgrade(ip=host_vm.ip)
@@ -363,56 +424,69 @@ class TestNested:
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
     @pytest.mark.parametrize("machine", ("host1", "host2"))
-    @pytest.mark.parametrize("mode", (
-        "83nightly-83nightly",
-        "830-83nightly",
-        "821.1-83nightly",
-        "81-83nightly",
-        "80-83nightly",
-        "xs8-83nightly",
-        "ch821.1-83nightly",
-        "830net-830net",
-        "82nightly-82nightly",
-        "821.1-82nightly",
-        "821.1-821.1",
+    @pytest.mark.parametrize("installed_config", (
+        ("83nightly-disk-83nightly"),
+        ("83nightly-raid1-83nightly"),
+        ("830-disk-83nightly"),
+        ("821.1-disk-83nightly"),
+        ("821.1-raid1-83nightly"),
+        ("81-disk-83nightly"),
+        ("80-disk-83nightly"),
+        ("xs8-disk-83nightly"),
+        ("ch821.1-disk-83nightly"),
+        ("830net-disk-830net"), # FIXME
+        ("82nightly-disk-82nightly"),
+        ("821.1-disk-82nightly"),
+        ("821.1-raid1-82nightly"),
+        ("821.1-disk-821.1"),
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda firmware, mode, machine, package_source, local_sr: [dict(
+        lambda firmware, installed_config, machine, package_source, local_sr: [dict(
             vm="vm1",
-            image_test=(f"TestNested::test_upgrade[{firmware}-{mode}-{machine}-{package_source}-{local_sr}]"))])
+            image_test=(f"TestNested::test_upgrade[{firmware}-{installed_config}-{machine}"
+                        f"-{package_source}-{local_sr}]"))])
     def test_boot_upg(self, create_vms: list[VM],
-                      firmware: str, mode: str, machine: str, package_source: str, local_sr: str) -> None:
-        self._test_firstboot(create_vms, mode, machine=machine)
+                      firmware: str, installed_config: str, machine: str, package_source: str,
+                      local_sr: str) -> None:
+        self._test_firstboot(create_vms, installed_config, machine=machine)
 
     @pytest.mark.usefixtures("xcpng_chained")
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
-    @pytest.mark.parametrize(("orig_version", "iso_version"), [
-        ("83nightly-83nightly", "83nightly"),
-        ("830-83nightly", "83nightly"),
-        ("821.1-83nightly", "83nightly"),
-        ("81-83nightly", "83nightly"),
-        ("80-83nightly", "83nightly"),
-        ("xs8-83nightly", "83nightly"),
-        ("ch821.1-83nightly", "83nightly"),
-        ("830net-830net", "830net"), # FIXME
-        ("82nightly-82nightly", "82nightly"),
-        ("821.1-82nightly", "82nightly"),
-        ("821.1-821.1", "821.1"),
+    @pytest.mark.parametrize(("installed_config", "iso_version"), [
+        ("83nightly-disk-83nightly", "83nightly"),
+        ("83nightly-raid1-83nightly", "83nightly"),
+        ("830-disk-83nightly", "83nightly"),
+        ("821.1-disk-83nightly", "83nightly"),
+        ("821.1-raid1-83nightly", "83nightly"),
+        ("81-disk-83nightly", "83nightly"),
+        ("80-disk-83nightly", "83nightly"),
+        ("xs8-disk-83nightly", "83nightly"),
+        ("ch821.1-disk-83nightly", "83nightly"),
+        ("830net-disk-830net", "830net"), # FIXME
+        ("82nightly-disk-82nightly", "82nightly"),
+        ("821.1-disk-82nightly", "82nightly"),
+        ("821.1-raid1-82nightly", "82nightly"),
+        ("821.1-disk-821.1", "821.1"),
     ])
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda firmware, orig_version, local_sr, package_source: [dict(
+        lambda firmware, installed_config, local_sr, package_source: [dict(
             vm="vm1",
-            image_test=f"TestNested::test_boot_upg[{firmware}-{orig_version}-host1-{package_source}-{local_sr}]")])
-    @pytest.mark.answerfile(
-        lambda system_disks_names: AnswerFile("RESTORE").top_append(
+            image_test=(f"TestNested::test_boot_upg[{firmware}-{installed_config}-host1"
+                        f"-{package_source}-{local_sr}]"))])
+    @pytest.mark.answerfile.with_args(
+        lambda system_disks_names, system_disk_config: AnswerFile("RESTORE").top_append(
             {"TAG": "backup-disk",
-             "CONTENTS": system_disks_names[0]},
+             "CONTENTS": {"disk": system_disks_names[0],
+                          "raid1": "md127",
+                          }[system_disk_config]},
         ))
     def test_restore(self, vm_booted_with_installer: VM, system_disks_names: list[str],
-                     firmware: str, orig_version: str, iso_version: str, package_source: str, local_sr: str) -> None:
+                     system_disk_config: str,
+                     firmware: str, installed_config: str, iso_version: str, package_source: str,
+                     local_sr: str) -> None:
         host_vm = vm_booted_with_installer
         assert host_vm.ip is not None
         installer.monitor_restore(ip=host_vm.ip)
@@ -420,24 +494,29 @@ class TestNested:
     @pytest.mark.usefixtures("xcpng_chained")
     @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
     @pytest.mark.parametrize("package_source", ("iso", "net"))
-    @pytest.mark.parametrize("mode", (
-        "83nightly-83nightly-83nightly",
-        "830-83nightly-83nightly",
-        "821.1-83nightly-83nightly",
-        "81-83nightly-83nightly",
-        "80-83nightly-83nightly",
-        "xs8-83nightly-83nightly",
-        "ch821.1-83nightly-83nightly",
-        "830net-830net-830net", # FIXME
-        "82nightly-82nightly-82nightly",
-        "821.1-82nightly-82nightly",
-        "821.1-821.1-821.1",
+    @pytest.mark.parametrize("installed_config", (
+        "83nightly-disk-83nightly-83nightly",
+        "83nightly-raid1-83nightly-83nightly",
+        "830-disk-83nightly-83nightly",
+        "821.1-disk-83nightly-83nightly",
+        "821.1-raid1-83nightly-83nightly",
+        "81-disk-83nightly-83nightly",
+        "80-disk-83nightly-83nightly",
+        "xs8-disk-83nightly-83nightly",
+        "ch821.1-disk-83nightly-83nightly",
+        "830net-disk-830net-830net", # FIXME
+        "82nightly-disk-82nightly-82nightly",
+        "821.1-disk-82nightly-82nightly",
+        "821.1-disk-821.1-821.1",
+        "821.1-raid1-821.1-821.1",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda firmware, mode, package_source, local_sr: [dict(
+        lambda firmware, installed_config, package_source, local_sr: [dict(
             vm="vm1",
-            image_test=(f"TestNested::test_restore[{firmware}-{mode}-{package_source}-{local_sr}]"))])
+            image_test=(f"TestNested::test_restore[{firmware}-{installed_config}"
+                        f"-{package_source}-{local_sr}]"))])
     def test_boot_rst(self, create_vms: list[VM],
-                      firmware: str, mode: str, package_source: str, local_sr: str) -> None:
-        self._test_firstboot(create_vms, mode, is_restore=True)
+                      firmware: str, installed_config: str, package_source: str,
+                      local_sr: str) -> None:
+        self._test_firstboot(create_vms, installed_config, is_restore=True)

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -140,13 +140,22 @@ class TestNested:
         "xs8-disk", "xs8-xsraid1",
         "ch821.1-disk",
         "xs70-disk",
+
+        # reinstalls
+        "83nightly-raid1-83nightly-raid1",
+        "83nightly-raid1-83nightly-disk",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
     @pytest.mark.continuation_of.with_args(
-        lambda installed_config, firmware, local_sr, package_source: [dict(
+        lambda installed_config, firmware, local_sr, package_source, machine: [dict(
             vm="vm1",
-            image_test=(f"TestNested::test_install[{firmware}-{installed_config}"
-                        f"-{package_source}-{local_sr}]"))])
+            image_test=(
+                (f"TestNested::test_reinstall[{firmware}-{installed_config}-{machine}"
+                 f"-{package_source}-{local_sr}]")
+                if installed_config.count('-') == 3 else
+                (f"TestNested::test_install[{firmware}-{installed_config}"
+                 f"-{package_source}-{local_sr}]")
+            ))])
     @pytest.mark.small_vm
     def test_tune_firstboot(self, create_vms: list[VM], helper_vm_with_plugged_disk: VM,
                             system_disk_config: str,
@@ -380,6 +389,75 @@ class TestNested:
     def test_boot_inst(self, create_vms: list[VM],
                        firmware: str, installed_config: str, machine: str, package_source: str,
                        local_sr: str) -> None:
+        self._test_firstboot(create_vms, installed_config, machine=machine)
+
+    @pytest.mark.usefixtures("xcpng_chained")
+    @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
+    @pytest.mark.parametrize("package_source", ("iso", "net"))
+    @pytest.mark.parametrize("machine", ("host1",))
+    @pytest.mark.parametrize(("installed_config", "iso_version", "system_disk_config"), [
+        ("83nightly-raid1", "83nightly", "disk"),
+        ("83nightly-raid1", "83nightly", "raid1"),
+    ])
+    @pytest.mark.parametrize("firmware", ("uefi", "bios"))
+    @pytest.mark.continuation_of.with_args(
+        lambda firmware, installed_config, machine, system_disk_config, package_source, local_sr: [dict(
+            vm="vm1",
+            image_test=(f"TestNested::test_boot_inst[{firmware}-{installed_config}-{machine}"
+                        f"-{package_source}-{local_sr}]"))])
+    @pytest.mark.answerfile.with_args(
+        lambda system_disks_names, local_sr, package_source, system_disk_config, iso_version: AnswerFile("INSTALL")
+        .top_setattr({} if local_sr == "nosr" else {"sr-type": local_sr})
+        .top_append(
+            {"iso": {"TAG": "source", "type": "local"},
+             "net": {"TAG": "source", "type": "url",
+                     "CONTENTS": ISO_IMAGES[iso_version]['net-url']},  # type: ignore
+             }[package_source],
+
+            {"raid1": SimpleAnswerfileDict(
+                {"TAG": "raid", "device": "md127",
+                 "CONTENTS": [
+                     {"TAG": "disk", "CONTENTS": diskname} for diskname in system_disks_names
+                 ]}),
+             "disk": None,
+             "xsraid1": None,
+             }[system_disk_config],
+
+            {"TAG": "admin-interface", "name": "eth0", "proto": "dhcp"},
+            {"TAG": "primary-disk",
+             "guest-storage": "no" if local_sr == "nosr" else "yes",
+             "swraid": "yes" if system_disk_config == "xsraid1" else "no",
+             "CONTENTS": {"disk": system_disks_names[0],
+                          "raid1": "md127",
+                          "xsraid1": ','.join(system_disks_names),
+                          }[system_disk_config],
+             },
+        ))
+    def test_reinstall(self, vm_booted_with_installer: VM, system_disks_names: list[str],
+                       firmware: str, installed_config: str, iso_version: str, machine: str,
+                       package_source: str, system_disk_config: str, local_sr: str) -> None:
+        host_vm = vm_booted_with_installer
+        assert host_vm.ip is not None
+        installer.monitor_upgrade(ip=host_vm.ip)
+
+    @pytest.mark.usefixtures("xcpng_chained")
+    @pytest.mark.parametrize("local_sr", ("nosr", "ext", "lvm"))
+    @pytest.mark.parametrize("package_source", ("iso", "net"))
+    @pytest.mark.parametrize("machine", ("host1",))
+    @pytest.mark.parametrize("installed_config", (
+        ("83nightly-raid1-83nightly-disk"),
+        ("83nightly-raid1-83nightly-raid1"),
+    ))
+    @pytest.mark.parametrize("firmware", ("uefi", "bios"))
+    @pytest.mark.continuation_of.with_args(
+        lambda firmware, installed_config, machine, local_sr, package_source: [
+            dict(vm="vm1",
+                 image_test=("TestNested::test_tune_firstboot"
+                             f"[None-{firmware}-{installed_config}-{machine}"
+                             f"-{package_source}-{local_sr}]"))])
+    def test_boot_reinst(self, create_vms: list[VM],
+                         firmware: str, installed_config: str, machine: str, package_source: str,
+                         local_sr: str) -> None:
         self._test_firstboot(create_vms, installed_config, machine=machine)
 
     @pytest.mark.usefixtures("xcpng_chained")

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -55,7 +55,8 @@ class TestNested:
         ("82nightly", "disk"),
         ("821.1", "disk"), ("821.1", "raid1"),
         ("81", "disk"), ("80", "disk"), ("76", "disk"), ("75", "disk"),
-        ("xs8", "disk"), ("ch821.1", "disk"),
+        ("xs8", "disk"), ("xs8", "xsraid1"),
+        ("ch821.1", "disk"),
         ("xs70", "disk"),
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
@@ -82,7 +83,7 @@ class TestNested:
             }[firmware],
             vdis=([dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0")]
                   + ([dict(name="vm1 system disk mirror", size="100GiB", device="xvdb", userdevice="1")]
-                     if system_disk_config == "raid1" else [])
+                     if system_disk_config in ("raid1", "xsraid1") else [])
                   ),
             cd_vbd=dict(device="xvdd", userdevice="3"),
             vifs=[dict(index=0, network_name=NETWORKS["MGMT"])],
@@ -102,13 +103,16 @@ class TestNested:
                      {"TAG": "disk", "CONTENTS": diskname} for diskname in system_disks_names
                  ]}),
              "disk": None,
+             "xsraid1": None,
              }[system_disk_config],
 
             {"TAG": "admin-interface", "name": "eth0", "proto": "dhcp"},
             {"TAG": "primary-disk",
              "guest-storage": "no" if local_sr == "nosr" else "yes",
+             "swraid": "yes" if system_disk_config == "xsraid1" else "no",
              "CONTENTS": {"disk": system_disks_names[0],
                           "raid1": "md127",
+                          "xsraid1": ','.join(system_disks_names),
                           }[system_disk_config],
              },
         ))
@@ -133,7 +137,8 @@ class TestNested:
         "821.1-disk",
         "821.1-raid1",
         "81-disk", "80-disk", "76-disk", "75-disk",
-        "xs8-disk", "ch821.1-disk",
+        "xs8-disk", "xs8-xsraid1",
+        "ch821.1-disk",
         "xs70-disk",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
@@ -152,10 +157,11 @@ class TestNested:
         match system_disk_config:
             case "disk":
                 helper_vm.ssh("mount /dev/xvdb1 /mnt")
-            case "raid1":
+            case "raid1" | "xsraid1":
                 # FIXME helper VM has to be an Alpine, that should not be a random vm_ref
+                logging.info("Assembling RAID (%s)", system_disk_config)
                 helper_vm.ssh("apk add mdadm")
-                helper_vm.ssh("mdadm -A /dev/md/127 -N localhost:127")
+                helper_vm.ssh("mdadm -A --scan")
                 helper_vm.ssh("mount /dev/md127p1 /mnt")
             case _:
                 raise ValueError(f"unhandled system_disk_config {system_disk_config!r}")
@@ -360,7 +366,8 @@ class TestNested:
         "821.1-disk",
         "821.1-raid1",
         "81-disk", "80-disk", "76-disk", "75-disk",
-        "xs8-disk", "ch821.1-disk",
+        "xs8-disk", "xs8-xsraid1",
+        "ch821.1-disk",
         "xs70-disk",
     ))
     @pytest.mark.parametrize("firmware", ("uefi", "bios"))
@@ -388,6 +395,7 @@ class TestNested:
         ("81-disk", "83nightly"),
         ("80-disk", "83nightly"),
         ("xs8-disk", "83nightly"),
+        ("xs8-xsraid1", "83nightly"),
         ("ch821.1-disk", "83nightly"),
         ("830net-disk", "830net"), # FIXME
         ("82nightly-disk", "82nightly"),
@@ -411,6 +419,7 @@ class TestNested:
             {"TAG": "existing-installation",
              "CONTENTS": {"disk": system_disks_names[0],
                           "raid1": "md127",
+                          "xsraid1": "md127",
                           }[system_disk_config]},
         ))
     def test_upgrade(self, vm_booted_with_installer: VM, system_disks_names: list[str],
@@ -433,6 +442,7 @@ class TestNested:
         ("81-disk-83nightly"),
         ("80-disk-83nightly"),
         ("xs8-disk-83nightly"),
+        ("xs8-xsraid1-83nightly"),
         ("ch821.1-disk-83nightly"),
         ("830net-disk-830net"), # FIXME
         ("82nightly-disk-82nightly"),
@@ -463,6 +473,7 @@ class TestNested:
         ("81-disk-83nightly", "83nightly"),
         ("80-disk-83nightly", "83nightly"),
         ("xs8-disk-83nightly", "83nightly"),
+        ("xs8-xsraid1-83nightly", "83nightly"),
         ("ch821.1-disk-83nightly", "83nightly"),
         ("830net-disk-830net", "830net"), # FIXME
         ("82nightly-disk-82nightly", "82nightly"),
@@ -481,6 +492,7 @@ class TestNested:
             {"TAG": "backup-disk",
              "CONTENTS": {"disk": system_disks_names[0],
                           "raid1": "md127",
+                          "xsraid1": "md127",
                           }[system_disk_config]},
         ))
     def test_restore(self, vm_booted_with_installer: VM, system_disks_names: list[str],
@@ -503,6 +515,7 @@ class TestNested:
         "81-disk-83nightly-83nightly",
         "80-disk-83nightly-83nightly",
         "xs8-disk-83nightly-83nightly",
+        "xs8-xsraid1-83nightly-83nightly",
         "ch821.1-disk-83nightly-83nightly",
         "830net-disk-830net-830net", # FIXME
         "82nightly-disk-82nightly-82nightly",

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -97,6 +97,7 @@ class TestNested:
         ))
     def test_install(self, vm_booted_with_installer: VM, system_disks_names: list[str],
                      firmware: str, iso_version: str, package_source: str, local_sr: str) -> None:
+        assert isinstance(system_disks_names, list)
         host_vm = vm_booted_with_installer
         assert host_vm.ip is not None
         installer.monitor_install(ip=host_vm.ip)


### PR DESCRIPTION
XCP-ng adds a few features on top of xenserver's installer, this PR adds some automated testing to the first of those.

This builds on top of:
- #226 
- #319 