### PR TITLE
Add TLS_Test & XOA deployment

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -23,6 +23,7 @@ JOBS = {
         },
         "paths": [
             "tests/misc",
+            "tests/security",
             "tests/migration",
             "tests/network",
             "tests/snapshot",

--- a/tests/misc/test_access_links.py
+++ b/tests/misc/test_access_links.py
@@ -1,0 +1,47 @@
+import pytest
+import subprocess
+import hashlib
+
+# This test is designed to verify the accessibility of the XOA deployment script
+#
+# Requirements:
+# - an XCP-ng host with xcp-ng-release >= 8.3.0.29
+
+@pytest.mark.parametrize("command_id", ["curl", "wget"])
+@pytest.mark.parametrize("url_id", [
+    "xoa",
+    "xcp-ng",
+    "vates"
+])
+def test_access_links(host, command_id, url_id):
+    """
+    Verifies that the specified URL responds correctly via the specified command
+    and compares the checksum of the downloaded content between local and remote.
+    """
+    command = {"curl": "curl -fsSL",
+               "wget": "wget -qO-"}[command_id]
+    url = {
+        "xoa": "https://xoa.io/deploy",
+        "xcpng": "https://updates.xcp-ng.org/trace",
+        "vates": "https://repo.vates.tech/README.txt"
+    }[url_id]
+    COMMAND = f"{command} '{url}'"
+
+    # Download from remote host
+    remote_result = host.ssh(COMMAND)
+
+    # Verify the download worked by comparing with local download
+    # This ensures the content is accessible and identical from both locations
+    local_result = host.local_cmd(COMMAND)
+
+    assert local_result.returncode == 0, (
+        f"Failed to fetch URL locally: {local_result.stderr}"
+    )
+
+    # Extract checksums
+    local_checksum = hashlib.sha256(local_result.stdout.split()[0].encode('utf-8')).hexdigest()
+    remote_checksum = hashlib.sha256(remote_result.split()[0].encode('utf-8')).hexdigest()
+
+    assert local_checksum == remote_checksum, (
+        f"Checksum mismatch: local ({local_checksum}) != remote ({remote_checksum})"
+    )

--- a/tests/security/test_tls.py
+++ b/tests/security/test_tls.py
@@ -1,0 +1,55 @@
+import pytest
+import ssl
+import socket
+import logging
+
+# This test is designed to verify that TLS connections is secured
+#
+# Requirements:
+# - An XCP-ng host
+
+@pytest.mark.parametrize("protocol_name", ["TLSv1", "TLSv1.1"])
+def test_tls_disabled(host: str, protocol_name: str):
+    """
+    Verifies that specified TLS protocols are disabled on the XCP-ng host.
+    Uses the ssl library directly. Should raise SSLError.
+    """
+    PORT = 443
+
+    protocol = {
+        "TLSv1": ssl.PROTOCOL_TLSv1,
+        "TLSv1.1": ssl.PROTOCOL_TLSv1_1
+    }[protocol_name]
+
+    logging.info(f"Testing if protocol {protocol_name} is disabled on host {host}")
+
+    with pytest.raises(ssl.SSLError):
+        context = ssl.SSLContext(protocol)
+        with socket.create_connection((str(host), PORT), timeout=10) as sock:
+            with context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+                ssock.do_handshake()
+                # If we reach this point, the protocol is enabled (test should fail)
+                pytest.fail(f"Protocol {protocol} should be disabled but connection succeeded")
+
+@pytest.mark.parametrize("protocol_name", ["TLSv1.2"])
+def test_enabled(host: str, protocol_name: str):
+    """
+    Verifies that TLSv1.2 is enabled on the XCP-ng host.
+    Uses the ssl library directly.
+    """
+    PORT = 443
+
+    protocol = {
+        "TLSv1.2": ssl.PROTOCOL_TLSv1_2
+    }[protocol_name]
+
+    logging.info(f"Testing if protocol {protocol_name} is enabled on host {host}")
+
+    try:
+        context = ssl.SSLContext(protocol)
+        with socket.create_connection((str(host), PORT), timeout=10) as sock:
+            with context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+                ssock.do_handshake()
+                assert ssock.version()
+    except ssl.SSLError as e:
+        pytest.fail(f"{protocol_name} should be enabled, but got SSLError: {e}")


### PR DESCRIPTION
This pull request introduces two new test suites for verifying the functionality and security of the XCP-ng environment, along with a minor update to the test paths in `jobs.py`. The most important changes include adding tests to access on some website, ensuring TLS protocol configurations are correct.

### New Test Suites

* [`tests/misc/test_access_links.py`]: Added tests to verify the accessibility of some website (Especially the XOA deployment script) using both `curl` and `wget`. These tests ensure the script responds correctly by comparing the checksum between the local & remote

* [`tests/security/test_tls.py`]: Added tests to validate TLS protocol configurations on the XCP-ng host. Tests ensure that insecure protocols (`tls1` and `tls1_1`) are disabled and that `tls1_2` is enabled.