### PR TITLE
Fix systemd test with xostor

### DIFF
--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -28,7 +28,7 @@ def test_verify_default_target(host: Host) -> None:
     polkit_msg = "Cannot add dependency job for unit polkit.service, ignoring: Unit not found."
     for line in analyse.splitlines():
         if line == polkit_msg:
-            pytest.xfail(f"drbd-reactor package should be fix to remove dep to polkit: {polkit_msg}")
+            pytest.xfail(f"drbd-reactor package must be fixed to remove dep to polkit: {polkit_msg}")
         if line not in white_list_issues:
             logging.error(f"{line}")
             err = True

--- a/tests/system/test_systemd.py
+++ b/tests/system/test_systemd.py
@@ -25,7 +25,10 @@ pytest.fixture(scope='module')
 def test_verify_default_target(host: Host) -> None:
     analyse = host.ssh('systemd-analyze verify default.target')
     err = False
+    polkit_msg = "Cannot add dependency job for unit polkit.service, ignoring: Unit not found."
     for line in analyse.splitlines():
+        if line == polkit_msg:
+            pytest.xfail(f"drbd-reactor package should be fix to remove dep to polkit: {polkit_msg}")
         if line not in white_list_issues:
             logging.error(f"{line}")
             err = True


### PR DESCRIPTION
When xostor is activated, drbd-reactor.service pulls polkit dependency.
As polkit.service doesn't exist, the command `systemd-analyze verify default.target` prints the message:
`Cannot add dependency job for unit polkit.service, ignoring: Unit not found.`
and `test_systemd.py` fails.

Whitelist polkit message to allow `test_systemd.py` to pass.