### PR TITLE
Stop pytest from always stopping at first error.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --maxfail=1
+addopts = -ra
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.


### PR DESCRIPTION
It is very annoying to get a single failed test stop the whole run by default: it requires rerunning the whole run (or spending time forging a filter to exclude exactly those we don't want to rerun), whereas when a test has failed and the user wants to stop the run because of that, Ctrl-C is our friend.

It is also very easy to just add `-x` to a pytest command to stop on first error when really needed, much less obvious to dig for `--maxfail=0` when we want to have a view of all errors.  Even in CI it is not obvious that we always want this anyway, likely only for the very long jobs.  Those CI jobs can be modified even before this PR gets merged, to add `-x` where we want it.

And it is the standard behaviour, and will be the default expectation of any newcomer with previous knowledge of pytest.