### PR TITLE
a-posteriori review and fixes of Linstor tests

### DIFF
--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -77,15 +77,6 @@ def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state):
 
     yield pool
 
-    # Need to remove this package as we have separate run of `test_create_sr_without_linstor`
-    # for `thin` and `thick` `provisioning_type`.
-    def remove_linstor(host):
-        logging.info(f"Cleaning up python-linstor from host {host}...")
-        host.yum_remove(["python-linstor"])
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(remove_linstor, pool.hosts)
-
 @pytest.fixture(scope='package')
 def linstor_sr(pool_with_linstor, provisioning_type, storage_pool_name):
     sr = pool_with_linstor.master.sr_create('linstor', 'LINSTOR-SR-test', {

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -99,3 +99,9 @@ def vm_on_linstor_sr(host, linstor_sr, vm_ref):
     yield vm
     logging.info("<< Destroy VM")
     vm.destroy(verify=True)
+
+@pytest.fixture(scope='module')
+def host_without_linstor(host):
+    # FIXME: is that really the package to test?
+    assert not host.is_package_installed('python-linstor'), \
+        "linstor must not be installed on the host at the beginning of the tests"

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -8,7 +8,7 @@ from lib.common import wait_for, vm_image
 from tests.storage import vdi_is_open
 
 # Requirements:
-# - two or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR
+# - one pool of 3 or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR
 # - access to XCP-ng RPM repository from the host
 
 class TestLinstorSRCreateDestroy:

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -22,19 +22,16 @@ class TestLinstorSRCreateDestroy:
         # This test must be the first in the series in this module
         assert not host.is_package_installed('python-linstor'), \
             "linstor must not be installed on the host at the beginning of the tests"
-        try:
+        with pytest.raises(SSHCommandFailed):
             sr = host.sr_create('linstor', 'LINSTOR-SR-test', {
                 'group-name': storage_pool_name,
                 'redundancy': '1',
                 'provisioning': provisioning_type
             }, shared=True)
-            try:
+            # if exception was not raised, cleanup
+            # FIXME: ignoring all exceptions looks like a problem here?
+            with contextlib.suppress(Exception):
                 sr.destroy()
-            except Exception:
-                pass
-            assert False, "SR creation should not have succeeded!"
-        except SSHCommandFailed as e:
-            logging.info("SR creation failed, as expected: {}".format(e))
 
     def test_create_and_destroy_sr(self, pool_with_linstor, provisioning_type, storage_pool_name):
         # Create and destroy tested in the same test to leave the host as unchanged as possible

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -18,10 +18,9 @@ class TestLinstorSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_sr_without_linstor(self, host, lvm_disks, provisioning_type, storage_pool_name):
+    def test_create_sr_without_linstor(self, host_without_linstor, lvm_disks, provisioning_type, storage_pool_name):
         # This test must be the first in the series in this module
-        assert not host.is_package_installed('python-linstor'), \
-            "linstor must not be installed on the host at the beginning of the tests"
+        host = host_without_linstor
         with pytest.raises(SSHCommandFailed):
             sr = host.sr_create('linstor', 'LINSTOR-SR-test', {
                 'group-name': storage_pool_name,

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -20,6 +20,7 @@ class TestLinstorSRCreateDestroy:
 
     def test_create_sr_without_linstor(self, host_without_linstor, lvm_disks, provisioning_type, storage_pool_name):
         # This test must be the first in the series in this module
+        # FIXME: why would it be?
         host = host_without_linstor
         with pytest.raises(SSHCommandFailed):
             sr = host.sr_create('linstor', 'LINSTOR-SR-test', {


### PR DESCRIPTION
First version is only driven by the `TestLinstorSRCreateDestroy` class of tests.  I propose fixes for the problems I see with obvious solutions (and some changes that are merely improvements), and insert FIXME's in the places I see as potentially problematic.