### PR TITLE
tests/storage/linstor: Added `daemon-reload` post package installation

### DIFF
--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -70,6 +70,8 @@ def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state):
         # Needed because the linstor driver is not in the xapi sm-plugins list
         # before installing the LINSTOR packages.
         host.ssh(["systemctl", "restart", "multipathd"])
+        # Needed because sometimes the systemctl may complain about service reload.
+        host.ssh(["systemctl", "daemon-reload"])
         host.restart_toolstack(verify=True)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:


### PR DESCRIPTION
Sometimes the `systemctl` may complain about service reload.

```
SM: [64335] linstor-manager:prepare_sr error: Failed to stop drbd-reactor:  Failed to stop drbd-reactor.service: Unit drbd-reactor.service not loaded.
```