### PR TITLE
Add toolstack restart after teardown on tests enabling / disabling SRs

### DIFF
--- a/tests/storage/fsp/conftest.py
+++ b/tests/storage/fsp/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state
+from pkgfixtures import host_with_saved_yum_state_toolstack_restart
 
 FSP_REPO_NAME = 'runx'
 
@@ -10,8 +10,8 @@ FSP_PACKAGES = ['xcp-ng-xapi-storage']
 DIRECTORIES_PATH = 'directories'
 
 @pytest.fixture(scope='package')
-def host_with_runx_repo(host_with_saved_yum_state):
-    host = host_with_saved_yum_state
+def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart):
+    host = host_with_saved_yum_state_toolstack_restart
     host.add_xcpng_repo(FSP_REPO_NAME, 'vates')
     yield host
     # teardown

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -110,6 +110,7 @@ def pool_with_linstor(hostA2, lvm_disks, pool_with_saved_yum_state):
     def remove_linstor(host):
         logging.info(f"Cleaning up python-linstor from host {host}...")
         host.yum_remove(["python-linstor"])
+        host.restart_toolstack(verify=True)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         executor.map(remove_linstor, pool.hosts)

--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -3,11 +3,11 @@ import pytest
 import logging
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped
+from pkgfixtures import host_with_saved_yum_state_toolstack_restart, sr_disk_wiped
 
 @pytest.fixture(scope='package')
-def host_with_zfsvol(host_with_saved_yum_state):
-    host = host_with_saved_yum_state
+def host_with_zfsvol(host_with_saved_yum_state_toolstack_restart):
+    host = host_with_saved_yum_state_toolstack_restart
     host.yum_install(['xcp-ng-xapi-storage-volume-zfsvol'])
     host.restart_toolstack(verify=True)
     yield host


### PR DESCRIPTION
This prevents the risk of discrepancy in `sm-list` between multiple hosts 
which can cause a "incompatible set of sm features" error.