### PR TITLE
Robustify LINSTOR `_get_diskful_hosts` test to ignore OLD volumes

### DIFF
--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -186,7 +186,7 @@ class TestLinstorDisklessResource:
         # "xcp/volume/{vdi_uuid}/volume-name": "{volume_name}"
         output = host.ssh([
             "linstor-kv-tool", "--dump-volumes", "-g", sr_group_name,
-            "|", "grep", "volume-name", "|", "grep", vdi_uuid
+            "|", "grep", "volume-name", "|", "grep", f"/{vdi_uuid}/"
         ])
         volume_name = output.split(': ')[1].split('"')[1]
 


### PR DESCRIPTION
Without this change we can have a result like that:
```
linstor-kv-tool --dump-volumes -g xcp-sr-linstor_group_thin_device | grep volume-name | grep fe2bc8da-8bff-4543-bfd9-587b48b5cbe7
"xcp/volume/OLD_fe2bc8da-8bff-4543-bfd9-587b48b5cbe7/volume-name": "xcp-volume-2154355c-2c55-469f-aac2-6c778d6a28b9",
"xcp/volume/fe2bc8da-8bff-4543-bfd9-587b48b5cbe7/volume-name": "xcp-volume-2cb7798f-dfbc-45f1-b9c3-47c6a0b07856"
```

In this situation we use `xcp-volume-2154355c-2c55-469f-aac2-6c778d6a28b9` instead of `xcp-volume-2cb7798f-dfbc-45f1-b9c3-47c6a0b07856`.

As a reminder, the `OLD_` prefix is ​​used by the GC internally and we don't want to expose these volumes. Therefore, it is necessary to use `grep` with slashes to match the exact XAPI/LINSTOR UUIDs of the volume.