### PR TITLE
Update requirements for test_varstored_sb

### DIFF
--- a/tests/uefi_sb/test_varstored_sb.py
+++ b/tests/uefi_sb/test_varstored_sb.py
@@ -26,6 +26,7 @@ from .utils import (
 # From --vm parameter
 # - A UEFI VM to import
 #   Some tests are Linux-only and some tests are Windows-only.
+#   The Windows tests here (e.g. test_key_upgrade_bitlocker) require Windows Server.
 
 pytestmark = pytest.mark.default_vm('mini-linux-x86_64-uefi')
 

--- a/vm_data.py-dist
+++ b/vm_data.py-dist
@@ -34,7 +34,7 @@ VMS = {
         "small_vm_unix_tools": "",
         # small UEFI VM on which efitools is installed, for some uefistored/varstored tests
         "small_vm_efitools": "",
-        # "small" Windows VM (UEFI)
+        # "small" Windows Server VM (UEFI)
         "small_vm_windows": "",
         # Debian VM (UEFI, no GUI)
         "debian_uefi_vm": "",


### PR DESCRIPTION
`test_varstored_sb` and consequently the "small Windows" image requires Windows Server. Describe these requirements in the respective files.