### PR TITLE
Add support for VM serial/UART console logging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data.py
 vm_data.py
 /scripts/guests/windows/id_rsa.pub
 .envrc
+pytest-logs/

--- a/jobs.py
+++ b/jobs.py
@@ -454,7 +454,8 @@ JOBS = {
         ],
         "nb_pools": 1,
         "params": {},
-        "paths": ["tests/misc/test_log_collection.py"],
+        "paths": ["tests/misc/test_log_collection.py",
+                  "tests/misc/test_serial_console_logging.py"],
     }
 }
 

--- a/lib/distros/__init__.py
+++ b/lib/distros/__init__.py
@@ -1,0 +1,18 @@
+
+from lib.distros.alma import AlmaVM
+from lib.distros.alpine import AlpineVM
+from lib.distros.centos import CentOSVM
+from lib.distros.debian import DebianVM
+from lib.distros.freebsd import FreeBsdVM
+from lib.distros.opensuse import OpenSuseVM
+from lib.distros.ubuntu import UbuntuVM
+
+__all__ = [
+    'AlpineVM',
+    'AlmaVM',
+    'CentOSVM',
+    'DebianVM',
+    'FreeBsdVM',
+    'OpenSuseVM',
+    'UbuntuVM',
+]

--- a/lib/distros/alma.py
+++ b/lib/distros/alma.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class AlmaVM(UnixVM):
+
+    def __init__(self, uuid: str, host: Host):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        self.ssh('export F=/etc/default/grub ; '
+                 '[ -f ${F} ] && '
+                 ' ( grep -q " console=ttyS" ${F} || '
+                 '   sed -i \'/^GRUB_CMDLINE_LINUX=/ { s/[ ]*quiet[ ]*/ / ; s/"$/ console=ttyS,115200"/ }\' ${F} ) && '
+                 ' grub2-mkconfig -o /boot/grub2/grub.cfg',
+                 check=False)

--- a/lib/distros/alpine.py
+++ b/lib/distros/alpine.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class AlpineVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+
+        # Try extlinux.conf first (common in Alpine)
+        self.ssh('export F=/boot/extlinux.conf ; '
+                 '[ -f ${F} ] && '
+                 ' ( grep -q "APPEND.*console=ttyS" ${F} || '
+                 '   sed -i "/APPEND.*root=/ { s/$/ console=ttyS,115200/; s/ quiet / /}" ${F} )',
+                 check=False)
+
+        # Also try GRUB (Alpine UEFI - alpine-mini)
+        self.ssh(
+            'export F=/etc/default/grub ; '
+            '[ -f ${F} ] && '
+            ' ( grep -q " console=ttyS" ${F} || '
+            '   sed -i \'/^GRUB_CMDLINE_LINUX_DEFAULT/ { s/ quiet / /; '
+            '             s/ *"$/ console=ttyS,115200"/ }\' ${F} ) && '
+            ' grub-mkconfig -o /boot/grub/grub.cfg',
+            check=False
+        )

--- a/lib/distros/centos.py
+++ b/lib/distros/centos.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class CentOSVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        self.ssh('sed -i "/^[[:space:]]*kernel / { s/ *quiet */ /; s/$/ console=ttyS,115200/ }" /boot/grub/grub.conf',
+                 check=False)

--- a/lib/distros/debian.py
+++ b/lib/distros/debian.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class DebianVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        self.ssh('echo GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS,115200" > /etc/default/grub.d/console.cfg &&'
+                 ' grub-mkconfig -o /boot/grub/grub.cfg',
+                 check=False)

--- a/lib/distros/freebsd.py
+++ b/lib/distros/freebsd.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class FreeBsdVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        """ TODO: Implement FreeBSD serial console configuration. """
+        logging.warning("Serial console configuration for FreeBSD not yet implemented")

--- a/lib/distros/opensuse.py
+++ b/lib/distros/opensuse.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class OpenSuseVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        self.ssh('export F=/etc/default/grub ; '
+                 '[ -f ${F} ] && '
+                 ' ( grep -q " console=ttyS" ${F} || '
+                 '   sed -i \'/^GRUB_CMDLINE_LINUX_DEFAULT/ { '
+                 '         s/ *quiet */ /; s/ *splash=silent */ /; s/ *"$/ console=ttyS,115200"/ }\' ${F} ) && '
+                 ' grub2-mkconfig -o /boot/grub2/grub.cfg',
+                 check=False)

--- a/lib/distros/ubuntu.py
+++ b/lib/distros/ubuntu.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from lib.unixvm import UnixVM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class UbuntuVM(UnixVM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    def configure_serial_console(self):
+        self.ssh('echo GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS,115200" > /etc/default/grub.d/console.cfg &&'
+                 ' update-grub',
+                 check=False)

--- a/lib/serial_console_logger.py
+++ b/lib/serial_console_logger.py
@@ -1,0 +1,311 @@
+"""
+Serial Console Logger - Background logging of VM serial console output
+
+This module provides facilities to automatically log VM serial console output
+during test execution via SSH subprocesses running `xl console`.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import subprocess
+import threading
+
+from typing import TYPE_CHECKING, Dict, Optional, Set
+
+if TYPE_CHECKING:
+    from lib.host import Host
+    from lib.vm import VM
+
+
+class SerialConsoleLogger:
+    """
+    Manages background SSH processes that log VMs serial console output.
+    Can log and monitor multiple VMs at a time.
+
+    This class handles:
+    - Starting SSH subprocesses with `xl console` for each VM
+    - Tracking VM domids and detecting changes
+    - Background monitoring to detect domid changes during tests
+    - Writing console output to log files
+    """
+
+    def __init__(self, log_dir: str, scope: str = "session",
+                 enable_monitoring: bool = True, monitor_interval: float = 5.0,
+                 keep_log: bool = True):
+
+        self.log_dir = log_dir
+        self.scope = scope
+        self.keep_log = keep_log
+        self.processes: Dict[str, subprocess.Popen | None] = {}  # vm_uuid -> Popen
+        self.vm_domids: Dict[str, str] = {}  # vm_uuid -> domid
+        self.vm_hosts: Dict[str, Host] = {}  # vm_uuid -> Host
+        self.log_files: Dict[str, str] = {}  # vm_uuid -> log_file_path
+
+        # Background monitoring
+        self.enable_monitoring = enable_monitoring
+        self.monitor_interval = monitor_interval
+        self.monitor_thread: Optional[threading.Thread] = None
+        self.monitor_stop_event = threading.Event()
+
+        logging.debug(
+            f"SerialConsoleLogger initialized (scope={scope}, log_dir={log_dir}, "
+            f"monitoring={enable_monitoring}, interval={monitor_interval}s)"
+        )
+
+        # Start monitoring if enabled
+        if self.enable_monitoring:
+            self.start_monitoring()
+
+    def _get_log_filename(self, vm_uuid: str, host: Host) -> str:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        host_ip_safe = host.hostname_or_ip.replace(':', '_').replace('.', '_')
+        vm_uuid_short = vm_uuid[:8]
+
+        filename = f"{host_ip_safe}_vm_{vm_uuid_short}_serial_{timestamp}.log"
+        return os.path.join(self.log_dir, filename)
+
+    def _vm_param_get(self, vm_uuid: str, param: str):
+        host = self.vm_hosts.get(vm_uuid)
+        assert host
+        return host.xe(
+            'vm-param-get',
+            {'uuid': vm_uuid, 'param-name': param},
+            minimal=True
+        )
+
+    def add_vm(self, vm: VM, host: Optional[Host] = None) -> bool:
+        if vm.uuid in self.processes:
+            return True
+
+        if host is None:
+            host = vm.host
+
+        assert host is not None, "Host must be provided or VM must have a host"
+
+        if not vm.is_running():
+            return False
+
+        domid = vm.param_get("dom-id")
+        if not domid or domid == '-1':
+            return False
+
+        return self._start_logging(vm.uuid, host, domid)
+
+    def remove_vm(self, vm: VM) -> None:
+        self._remove_vm_by_uuid(vm.uuid)
+
+    # Background monitoring methods
+
+    def start_monitoring(self) -> None:
+        if self.monitor_thread is not None:
+            return
+
+        logging.debug(f"Starting background monitoring thread (interval={self.monitor_interval}s)")
+        self.monitor_thread = threading.Thread(
+            target=self._monitor_loop,
+            daemon=True,
+            name=f"SerialConsoleMonitor-{self.scope}"
+        )
+        self.monitor_thread.start()
+
+    def _monitor_loop(self) -> None:
+        while not self.monitor_stop_event.wait(self.monitor_interval):
+            # Get snapshot of current VMs being logged
+            vm_uuids = list(self.processes.keys())
+
+            for vm_uuid in vm_uuids:
+                try:
+                    self._check_vm_state_by_uuid(vm_uuid)
+                except Exception as e:
+                    # Ignore monitoring errors for individual VMs
+                    logging.warning(f"something went wrong: {e}")
+                    pass
+
+    def _check_vm_state_by_uuid(self, vm_uuid: str):
+        host = self.vm_hosts.get(vm_uuid)
+        process = self.processes.get(vm_uuid)
+        tracked_domid = self.vm_domids.get(vm_uuid)
+
+        logging.warning(f"check VM state: {host} {process} {tracked_domid}")
+        assert host
+
+        # Check VM power state
+        power_state = self._vm_param_get(vm_uuid, 'power-state')
+        if power_state != 'running':
+            # VM not running, stop logging
+            logging.warning(f"stopping: state={power_state}")
+            self._remove_vm_by_uuid(vm_uuid)
+            return
+
+        # If we don't have process here
+        if not process:
+            try:
+                current_domid = self._vm_param_get(vm_uuid, 'dom-id')
+                if current_domid and current_domid != '-1':
+                    # VM is running, try to start logging
+                    self._restart_logging_by_uuid(vm_uuid)
+                return
+            except Exception:
+                logging.warning("restart failed, retry later")
+                return
+
+        try:
+            try:
+                process.poll()
+            except Exception:
+                logging.debug(
+                    f"[monitor] Serial console process for VM {vm_uuid[:8]} "
+                    f"terminated (exit code {process.returncode}), restarting"
+                )
+                self._restart_logging_by_uuid(vm_uuid)
+                return True
+
+            current_domid = self._vm_param_get(vm_uuid, 'dom-id')
+
+            # Check if domid is -1 (VM doesn't exist or was destroyed)
+            if not current_domid:
+                # VM destroyed or halted (domid=-1), stop logging
+                self._remove_vm_by_uuid(vm_uuid)
+                return False
+
+            # Both domid can be -1, if VM is not started yet
+            if current_domid != -1 and current_domid != tracked_domid:
+                logging.debug(
+                    f"[monitor] VM {vm_uuid[:8]} domid changed from {tracked_domid} "
+                    f"to {current_domid}, restarting serial console logging"
+                )
+                return self._restart_logging_by_uuid(vm_uuid)
+
+            return True
+
+        except Exception:
+            return False
+
+    def _restart_logging_by_uuid(self, vm_uuid: str) -> bool:
+        host = self.vm_hosts.get(vm_uuid)
+        if not host:
+            return False
+
+        self._stop_logging(vm_uuid)
+
+        try:
+            domid = self._vm_param_get(vm_uuid, 'dom-id')
+        except Exception:
+            return False
+        if domid == '-1' or not domid:
+            return False
+
+        success = self._start_logging(vm_uuid, host, domid)
+        return success
+
+    def _start_logging(self, vm_uuid: str, host: Host, domid: str) -> bool:
+        try:
+            os.makedirs(self.log_dir, exist_ok=True)
+
+            ssh_cmd = [
+                "ssh", "-t",
+                "-o", "StrictHostKeyChecking=no",
+                "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "LogLevel=ERROR",
+                f"{host.user}@{host.hostname_or_ip}",
+                f"xl console -t serial {domid} 2> /dev/null"
+            ]
+
+            # Fill dictionnaries before running command in case VM is not
+            # started yet
+            self.processes[vm_uuid] = None
+            self.vm_domids[vm_uuid] = domid
+            self.vm_hosts[vm_uuid] = host
+
+            if self.keep_log and self.log_files.get(vm_uuid):
+                log_file = self.log_files[vm_uuid]
+            else:
+                log_file = self._get_log_filename(vm_uuid, self.vm_hosts[vm_uuid])
+            self.log_files[vm_uuid] = log_file
+
+            logging.debug(f"Starting serial console logging for VM {vm_uuid[:8]} (domid={domid}) -> {log_file}")
+
+            with open(log_file, 'a') as log_fh:
+                process = subprocess.Popen(
+                    ssh_cmd,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL
+                )
+            self.processes[vm_uuid] = process
+            return True
+
+        except Exception as e:
+            logging.warning(f"Failed to start process: {e}")
+            return False
+
+    def _stop_logging(self, vm_uuid: str) -> bool:
+        if vm_uuid not in self.processes:
+            return True
+
+        process = self.processes[vm_uuid]
+        log_file = self.log_files[vm_uuid]
+
+        try:
+            assert process
+
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logging.warning(f"Process {process.pid} didn't terminate, force killing")
+                process.kill()
+                process.wait()
+
+            logging.debug(f"Stopped serial console logging for VM {vm_uuid[:8]}, log: {log_file}")
+            self.processes[vm_uuid] = None
+
+            if os.stat(log_file).st_size == 0:
+                os.unlink(log_file)
+
+            return True
+        except Exception:
+            logging.warning("Exception received will stopping logging")
+            return False
+
+    def _remove_vm_by_uuid(self, vm_uuid: str) -> None:
+        logging.warning(f"Remove VM: {vm_uuid}")
+        if self._stop_logging(vm_uuid):
+
+            if vm_uuid in self.processes:
+                del self.processes[vm_uuid]
+            if vm_uuid in self.vm_domids:
+                del self.vm_domids[vm_uuid]
+            if vm_uuid in self.vm_hosts:
+                del self.vm_hosts[vm_uuid]
+            if vm_uuid in self.log_files:
+                del self.log_files[vm_uuid]
+
+    def cleanup(self) -> None:
+        """Stop monitoring thread and all logging processes."""
+        logging.warning("Monitor cleanup called")
+
+        # Stop monitoring thread first
+        if self.monitor_thread is not None:
+            self.monitor_stop_event.set()
+
+            # Wait for thread to finish (max 2 seconds)
+            self.monitor_thread.join(timeout=2.0)
+
+            if self.monitor_thread.is_alive():
+                logging.warning("Monitoring thread did not stop cleanly")
+
+            self.monitor_thread = None
+
+        # Make a copy of the list since we'll be modifying it
+        vm_uuids = list(self.processes.keys())
+
+        for vm_uuid in vm_uuids:
+            self._remove_vm_by_uuid(vm_uuid)
+
+    def get_logged_vms(self) -> Set[str]:
+        """Return set of VM UUIDs currently being logged."""
+        return set(self.processes.keys())

--- a/lib/unixvm.py
+++ b/lib/unixvm.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import logging
+
+from lib.vm import VM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class UnixVM(VM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)
+
+    @classmethod
+    def detect_distro(cls, vm: VM) -> str:
+        # Try VM's built-in distro() method first
+        distro = vm.distro()
+        if distro:
+            return str(distro).strip()
+
+        # Fallback: read /etc/os-release or check for centos-release
+        result = vm.ssh(
+            '([ -e /etc/os-release ] && . /etc/os-release && echo $ID) ||'
+            ' ([ -e /etc/centos-release ] && echo centos)',
+            check=False
+        )
+        if isinstance(result, bytes):
+            return result.decode('utf-8').strip()
+        return str(result).strip()
+
+    @classmethod
+    def get_distro_class(cls, distro: str) -> type['UnixVM']:
+        # Import here to avoid circular dependencies
+        from lib.distros import (
+            AlmaVM,
+            AlpineVM,
+            CentOSVM,
+            DebianVM,
+            FreeBsdVM,
+            OpenSuseVM,
+            UbuntuVM,
+        )
+
+        distro_map = {
+            'alpine': AlpineVM,
+            'almalinux': AlmaVM,
+            'centos': CentOSVM,
+            'debian': DebianVM,
+            'freebsd': FreeBsdVM,
+            'opensuse-leap': OpenSuseVM,
+            'ubuntu': UbuntuVM,
+        }
+
+        if distro not in distro_map:
+            raise ValueError(f"Unknown distro: {distro}")
+
+        return distro_map[distro]
+
+    @classmethod
+    def from_vm(cls, vm: VM) -> 'UnixVM':
+        instance = cls(vm.uuid, vm.host)
+        # Copy runtime state from the original VM
+        instance.ip = vm.ip
+        instance.previous_host = vm.previous_host
+        instance.is_windows = vm.is_windows
+        instance.is_uefi = vm.is_uefi
+        if hasattr(vm, 'vdis'):
+            instance.vdis = vm.vdis
+        return instance
+
+    @classmethod
+    def from_vm_auto_detect(cls, vm: VM) -> 'UnixVM':
+        distro = cls.detect_distro(vm)
+        logging.debug(f"Detected distro: {distro}")
+        distro_class = cls.get_distro_class(distro)
+        return distro_class.from_vm(vm)
+
+    def configure_serial_console(self) -> None:
+        raise NotImplementedError(
+            f"Serial console configuration not implemented for {self.__class__.__name__}"
+        )

--- a/lib/windowsvm.py
+++ b/lib/windowsvm.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from lib.vm import VM
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+
+class WindowsVM(VM):
+
+    def __init__(self, uuid: str, host: 'Host'):
+        super().__init__(uuid, host)

--- a/tests/misc/test_serial_console_logging.py
+++ b/tests/misc/test_serial_console_logging.py
@@ -1,0 +1,49 @@
+"""
+Tests demonstrating serial console logging for VMs.
+"""
+
+import pytest
+
+from lib.vm import VM
+
+@pytest.mark.small_vm
+@pytest.mark.usefixtures("serial_console_logger_session")
+class TestWithSessionLogging:
+    def test_vm_start_stop(self, unix_vm_with_serial_console: VM):
+        vm = unix_vm_with_serial_console
+
+        if not vm.is_running():
+            vm.start()
+        else:
+            vm.reboot()
+
+        vm.wait_for_os_booted()
+        vm.shutdown(verify=True)
+
+    def test_vm_reboots(self, unix_vm_with_serial_console: VM):
+        """ test domid tracking in case of reboot """
+        vm = unix_vm_with_serial_console
+
+        if not vm.is_running():
+            vm.start()
+
+        vm.wait_for_os_booted()
+
+        # First reboot
+        vm.reboot(verify=True)
+        vm.wait_for_os_booted()
+
+        # Second reboot
+        vm.reboot(verify=True)
+        vm.wait_for_os_booted()
+
+        vm.shutdown(verify=True)
+
+
+@pytest.mark.small_vm
+@pytest.mark.usefixtures("serial_console_logger_class")
+class TestWithClassLogging:
+    def test_suspend_resume(self, running_vm: VM):
+        running_vm.suspend(verify=True)
+        running_vm.resume()
+        running_vm.wait_for_os_booted()

--- a/tests/misc/test_serial_console_logging.py
+++ b/tests/misc/test_serial_console_logging.py
@@ -4,12 +4,12 @@ Tests demonstrating serial console logging for VMs.
 
 import pytest
 
-from lib.vm import VM
+from lib.unixvm import UnixVM
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("serial_console_logger_session")
 class TestWithSessionLogging:
-    def test_vm_start_stop(self, unix_vm_with_serial_console: VM):
+    def test_vm_start_stop(self, unix_vm_with_serial_console: UnixVM):
         vm = unix_vm_with_serial_console
 
         if not vm.is_running():
@@ -20,7 +20,7 @@ class TestWithSessionLogging:
         vm.wait_for_os_booted()
         vm.shutdown(verify=True)
 
-    def test_vm_reboots(self, unix_vm_with_serial_console: VM):
+    def test_vm_reboots(self, unix_vm_with_serial_console: UnixVM):
         """ test domid tracking in case of reboot """
         vm = unix_vm_with_serial_console
 
@@ -43,7 +43,7 @@ class TestWithSessionLogging:
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("serial_console_logger_class")
 class TestWithClassLogging:
-    def test_suspend_resume(self, running_vm: VM):
+    def test_suspend_resume(self, running_vm: UnixVM):
         running_vm.suspend(verify=True)
         running_vm.resume()
         running_vm.wait_for_os_booted()


### PR DESCRIPTION
This is a duplicate of https://github.com/xcp-ng/xcp-ng-tests/pull/364 witch was accidentally closed; marked as merged by Github because of a force push.

<hr>

To debug or just understand why a test failed it could be interesting to have more logs from the VM.
For instance, sometimes tests failed because a VM isn't able to get an IP in the time limit of test.

Using unix_vm_with_serial_console fixture, a test can ask to log serial output for a VM (Unix in this case, or could be Linux instead).
The fixture also ensure that the serial output is enabled by modifying the kernel command-line, because for the moment images we are importing for the tests don't have the console enabled.
This is debatable, but at least for now we try this patch set without modifying any of the current images.

<hr>

The branch is on top `eva/log-test-failure` (https://github.com/xcp-ng/xcp-ng-tests/pull/362) and ideally would also require that branch `eva/local-cmd-generalize` (https://github.com/xcp-ng/xcp-ng-tests/pull/359) be merged also.
That's why the PR is not on top `master`.

Windows not supported (yet?). VM type (Unix or Windows) depends on test.
Distro classes only implement the console configuration and is specific to bootloader, but should move more methods from VM to UnixVM or WindowsVM.

Tested with:
```
uv run pytest \
    tests/misc/test_serial_console_logging.py::TestWithSessionLogging::test_vm_reboots \
    --hosts=10.1.30.2 --log-cli-level=debug --no-collect-logs-on-failure
```

With the following VMs on a XCP-ng 8.3 :
```
  almalinux-8.5-uefi-created_8.2-zstd.xva
  almalinux-9-05082022-uefi-created_8.2-zstd.xva
  alpine-minimal-uefi-3.21.3-created-8.2.zstd.xva
  centos-stream-9-04082022-uefi-created_8.2-zstd.xva
  centos6-32-PVINPVH-created_8.2-zstd.xva
  centos6-32-hvm-created_8.2-zstd.xva
  centos6-64-PVINPVH-created_8.2-zstd.xva
  debian-11.1-gui-created_8.2-zstd.xva
  debian-12-created_8.2-zstd.xva
  openSUSE-Leap-15-4-uefi-created_8.2-zstd.xva
  ubuntu-22.04-server-uefi-created_8.2.xva
  ubuntu-24.04-server-uefi-created_8.2.xva
```
Not tested:
```
 debian-12.1-uefi-created_8.2-zstd.xva
 debian-uefi-10.4.0-created_8.2-zstd-efitools.xva
 freebsd-13.2-uefi-created_8.2-zstd.xva
 freebsd-14-uefi-created_8.2-zstd.xva
```
