### PR TITLE
Add VM cache scanning script

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 
 from lib.commands import ssh
+from lib.typing import VmDef, VMSDef
 
 from typing import NotRequired, TypedDict, cast
 
@@ -590,9 +591,6 @@ BROKEN_TESTS = [
     "tests/storage/zfsvol/test_zfsvol_sr.py::TestZfsvolVm::test_quicktest",
 ]
 
-VmDef = str | tuple[str, str]
-VMSDef = dict[str, dict[str, VmDef | list[VmDef]]]
-
 # Returns the vm filename or None if a host_version is passed and matches the one specified
 # with the vm filename in vm_data.py. ex: ("centos6-32-hvm-created_8.2-zstd.xva", "8\.2\..*")
 def filter_vm(vm: VmDef, host_version: str | None) -> str | None:
@@ -629,14 +627,14 @@ def get_vm_or_vms_refs(handle: str, host_version: str | None = None) -> str | li
 
     VMS = cast(VMSDef, VMS_untyped)
     category, key = handle.split("/")
-    if category not in VMS or key not in VMS[category]:
+    if category not in VMS or key not in VMS[category]:  # type: ignore[literal-required]
         print(f"ERROR: Could not find VMS['{category}']['{key}'] in vm_data.py, or it's empty.")
         print("You need to update your local vm_data.py.")
         print("You may also bypass this error by providing your own --vm parameter(s).")
         sys.exit(1)
 
     vms: str | list[str] | None = []
-    vms_unfiltered = VMS[category][key]
+    vms_unfiltered = VMS[category][key]  # type: ignore[literal-required]
     if isinstance(vms_unfiltered, list):
         # Multi VMs
         vms = [xva for vm in vms_unfiltered if (xva := filter_vm(vm, host_version)) is not None]

--- a/lib/typing.py
+++ b/lib/typing.py
@@ -7,6 +7,15 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import NotRequired
 
+
+VmDef = str | tuple[str, str]
+
+
+class VMSDef(TypedDict):
+    single: dict[str, VmDef]
+    multi: dict[str, list[VmDef]]
+
+
 IsoImageDef = TypedDict('IsoImageDef',
                         {'path': str,
                          'net-url': NotRequired[str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "types-requests",
     "typing-extensions",
     "libarchive-c==5.3",
+    "XenAPI",
     "zizmor",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "types-pygments",
     "types-colorama",
     "types-pexpect",
+    "XenAPI",
     "zizmor",
     "prek>=0.4.4",
     "autopep8",
@@ -83,7 +84,7 @@ ignore = [
 pydocstyle.convention = "pep257"
 
 [tool.ruff.lint.extend-per-file-ignores]
-# Pytest fixtures are often flagged as unused imports (F401) or 
+# Pytest fixtures are often flagged as unused imports (F401) or
 # redefined variables (F811) because they are injected by name.
 "tests/**/*.py" = [
   "F401",  # F401 unused-import

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,5 +10,6 @@ ruff
 types-requests
 typing-extensions
 libarchive-c==5.3
+XenAPI
 zizmor
 -r base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,6 +12,7 @@ libarchive-c==5.3
 types-pygments
 types-colorama
 types-pexpect
+XenAPI
 zizmor
 prek>=0.4.4
 autopep8

--- a/scripts/scan_cache.py
+++ b/scripts/scan_cache.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import argparse
+import contextlib
+import getpass
+import itertools
+import pathlib
+import re
+import sys
+
+import XenAPI
+
+# Scan the current pool for test images that are not described in vm_data.py.
+# Deleting them is up to the user.
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+
+@contextlib.contextmanager
+def xapi_session(uname="root", pwd="", url=None, ignore_ssl=False):
+    if url is None:
+        session = XenAPI.xapi_local()
+    else:
+        session = XenAPI.Session(url, ignore_ssl=ignore_ssl)
+    session.xenapi.login_with_password(uname, pwd, XenAPI.API_VERSION_1_2, "scan_cache.py")
+    try:
+        yield session
+    finally:
+        session.xenapi.logout()
+
+
+def strip_suffix(string, suffix):
+    if string.endswith(suffix):
+        return string[: -len(suffix)]
+    return string
+
+
+def get_cache_url(vm):
+    if type(vm) is tuple:
+        url = vm[1]
+    else:
+        url = vm
+    return strip_suffix(url, '.xva')
+
+
+def get_image_urls():
+    from vm_data import VMS
+
+    image_urls = set()
+    for vm in dict(VMS["single"]).values():
+        image_urls.add(get_cache_url(vm))
+    for vms in dict(VMS["multi"]).values():
+        for vm in vms:
+            image_urls.add(get_cache_url(vm))
+    return image_urls
+
+
+def get_vm_type(session, vm_ref):
+    vm_type = "VM"
+    if session.xenapi.VM.get_is_control_domain(vm_ref):
+        vm_type = "control domain"
+    elif session.xenapi.VM.get_is_default_template(vm_ref):
+        vm_type = "default template"
+    elif session.xenapi.VM.get_is_a_snapshot(vm_ref):
+        vm_type = "snapshot"
+    elif session.xenapi.VM.get_is_a_template(vm_ref):
+        vm_type = "template"
+    return vm_type
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--hosts",
+        action="append",
+        required=True,
+        help="list of hosts to scan (comma-separated)",
+    )
+    parser.add_argument(
+        "--uname",
+        default="root",
+        help="user name for connecting to XAPI",
+    )
+    parser.add_argument(
+        "--pwd",
+        action="store_true",
+        help="prompt for password",
+    )
+    args = parser.parse_args()
+
+    pwd = ""
+    if args.pwd:
+        pwd = getpass.getpass()
+
+    # a list of master hosts, each from a different pool
+    hosts_args = args.hosts
+    hosts_split = [hostlist.split(',') for hostlist in hosts_args]
+    hostname_list = list(itertools.chain(*hosts_split))
+
+    image_urls = get_image_urls()
+
+    for host in hostname_list:
+        with xapi_session(args.uname, pwd, url=f"https://{host}", ignore_ssl=True) as session:
+            for vm_ref in session.xenapi.VM.get_all():
+                if get_vm_type(session, vm_ref) != "VM":
+                    continue
+                description = session.xenapi.VM.get_name_description(vm_ref)
+                m = re.match(r'\[Cache for (.*)\]', description)
+                if not m:
+                    continue
+                current_url = m.group(1)
+                if current_url in image_urls:
+                    continue
+                uuid = session.xenapi.VM.get_uuid(vm_ref)
+                label = session.xenapi.VM.get_name_label(vm_ref)
+                print(f"{uuid} {label} {description}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scan_cache.py
+++ b/scripts/scan_cache.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import argparse
+import contextlib
+import getpass
+import itertools
+import pathlib
+import re
+import sys
+
+import XenAPI  # type: ignore[import-untyped]
+
+from typing import Any, cast
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+# flake8: noqa: E402 module level import not at top of file
+from lib.typing import VmDef, VMSDef
+
+# Scan the current pool for test images that are not described in vm_data.py.
+# Deleting them is up to the user.
+
+
+@contextlib.contextmanager
+def xapi_session(uname="root", pwd="", url=None, ignore_ssl=False) -> Any:
+    if url is None:
+        session: Any = XenAPI.xapi_local()
+    else:
+        session = XenAPI.Session(url, ignore_ssl=ignore_ssl)
+    session.xenapi.login_with_password(uname, pwd, XenAPI.API_VERSION_1_2, "scan_cache.py")
+    try:
+        yield session
+    finally:
+        session.xenapi.logout()
+
+
+def strip_suffix(string: str, suffix: str) -> str:
+    if string.endswith(suffix):
+        return string[: -len(suffix)]
+    return string
+
+
+def get_cache_url(vm: VmDef) -> str:
+    if isinstance(vm, tuple):
+        url = vm[1]
+    else:
+        url = vm
+    return strip_suffix(url, '.xva')
+
+
+def get_image_urls() -> set[Any]:
+    from vm_data import VMS as VMS_untyped
+
+    VMS = cast(VMSDef, VMS_untyped)
+    image_urls = set()
+    for vm in dict(VMS["single"]).values():
+        image_urls.add(get_cache_url(vm))
+    for vms in dict(VMS["multi"]).values():
+        for vm in vms:
+            image_urls.add(get_cache_url(vm))
+    return image_urls
+
+
+def get_vm_type(session: Any, vm_ref: str) -> str:
+    vm_type = "VM"
+    if session.xenapi.VM.get_is_control_domain(vm_ref):
+        vm_type = "control domain"
+    elif session.xenapi.VM.get_is_default_template(vm_ref):
+        vm_type = "default template"
+    elif session.xenapi.VM.get_is_a_snapshot(vm_ref):
+        vm_type = "snapshot"
+    elif session.xenapi.VM.get_is_a_template(vm_ref):
+        vm_type = "template"
+    return vm_type
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--hosts",
+        action="append",
+        required=True,
+        help="list of hosts to scan (comma-separated)",
+    )
+    parser.add_argument(
+        "--uname",
+        default="root",
+        help="user name for connecting to XAPI",
+    )
+    parser.add_argument(
+        "--pwd",
+        action="store_true",
+        help="prompt for password",
+    )
+    args = parser.parse_args()
+
+    pwd = ""
+    if args.pwd:
+        pwd = getpass.getpass()
+
+    # a list of master hosts, each from a different pool
+    hosts_args = args.hosts
+    hosts_split = [hostlist.split(',') for hostlist in hosts_args]
+    hostname_list = list(itertools.chain(*hosts_split))
+
+    image_urls = get_image_urls()
+
+    for host in hostname_list:
+        with xapi_session(args.uname, pwd, url=f"https://{host}", ignore_ssl=True) as session:
+            for vm_ref in session.xenapi.VM.get_all():
+                if get_vm_type(session, vm_ref) != "VM":
+                    continue
+                description = session.xenapi.VM.get_name_description(vm_ref)
+                m = re.match(r'\[Cache for (.*)\]', description)
+                if not m:
+                    continue
+                current_url = m.group(1)
+                if current_url in image_urls:
+                    continue
+                uuid = session.xenapi.VM.get_uuid(vm_ref)
+                label = session.xenapi.VM.get_name_label(vm_ref)
+                print(f"{uuid} {label} {description}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -783,6 +783,7 @@ dev = [
     { name = "ruff" },
     { name = "types-requests" },
     { name = "typing-extensions" },
+    { name = "xenapi" },
     { name = "zizmor" },
 ]
 
@@ -812,7 +813,17 @@ dev = [
     { name = "ruff" },
     { name = "types-requests" },
     { name = "typing-extensions" },
+    { name = "xenapi" },
     { name = "zizmor" },
+]
+
+[[package]]
+name = "xenapi"
+version = "26.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/31/35a2304f30f7fc92a4a054d3f45a358f73daa68856779cede1a9240bc39b/xenapi-26.8.0.tar.gz", hash = "sha256:3c66a149a3bf4a234db04e4cd223138e004c029bacbae83fab0fc4d3282bb3fb", size = 6737, upload-time = "2026-03-31T02:49:25.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/3f/b00f171eee096a4cbeeb70d7f7b30904f282a9173b88cc01846c87202b6a/xenapi-26.8.0-py3-none-any.whl", hash = "sha256:5eab8d396e0696a31b494b25fe3d2eb64630c5b111f25f14d869c1d8d2a2132a", size = 5947, upload-time = "2026-03-31T02:49:24.398Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -963,6 +963,7 @@ dev = [
     { name = "types-pygments" },
     { name = "types-requests" },
     { name = "typing-extensions" },
+    { name = "xenapi" },
     { name = "zizmor" },
 ]
 
@@ -996,7 +997,17 @@ dev = [
     { name = "types-pygments" },
     { name = "types-requests" },
     { name = "typing-extensions" },
+    { name = "xenapi" },
     { name = "zizmor" },
+]
+
+[[package]]
+name = "xenapi"
+version = "26.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/94/1a7ebf2d0551ee3705de78d03a49ad249a0cfbc0903b3e8f99d6717c3865/xenapi-26.15.0.tar.gz", hash = "sha256:d97a01cecf930df62f136985635c4cc91ab3f76c1009794f56f2eeae963a6bc7", size = 6747, upload-time = "2026-06-03T01:40:41.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/5c/4c278231b073a61b2d3860c068703a66dd20ee09e3fa08d0e238603d06a6/xenapi-26.15.0-py3-none-any.whl", hash = "sha256:d008fd5445ddb2e34d9efbfad55c569af529e23961ffc0910e4f89ed2dae1d0e", size = 5958, upload-time = "2026-06-03T01:40:40.678Z" },
 ]
 
 [[package]]

--- a/vm_data.py-dist
+++ b/vm_data.py-dist
@@ -26,7 +26,9 @@
 #         ("alpine-uefi-minimal-efitools-3.12.0.xva", r"8\.2\."),
 #         ...],
 
-VMS: dict[str, dict[str, str | list]] = {
+from lib.typing import VMSDef
+
+VMS: VMSDef = {
     "single": {
         # basic small VM
         "small_vm": "",


### PR DESCRIPTION
Stale cached VMs will fill up the SR and cause test failures when importing new images.

This script helps detect those. It's non-destructive; deleting the VMs is left to the user.