### PR TITLE
Use passlib in place of legacycrypt

### DIFF
--- a/data.py-dist
+++ b/data.py-dist
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-import legacycrypt as crypt  # type: ignore[import-untyped]
+from lib.common import hash_password
 
 from typing import TYPE_CHECKING, Any
 
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 # You need to have an SSH key into the hosts' /root/.ssh/authorized_keys.
 HOST_DEFAULT_USER = "root"
 HOST_DEFAULT_PASSWORD = ""
-
-def hash_password(password):
-    """Hash password for /etc/password."""
-    salt = crypt.mksalt(crypt.METHOD_SHA512)  # type: ignore
-    return crypt.crypt(password, salt)
 
 HOST_DEFAULT_PASSWORD_HASH = hash_password(HOST_DEFAULT_PASSWORD)
 

--- a/lib/common.py
+++ b/lib/common.py
@@ -18,6 +18,7 @@ from functools import lru_cache
 from uuid import UUID
 
 import requests
+from passlib.hash import sha512_crypt
 from pydantic import TypeAdapter
 
 from typing import (
@@ -398,3 +399,8 @@ def _param_clear(host: Host, xe_prefix: str, uuid: str, param_name: str) -> None
     """ Common implementation for param_clear. """
     args: dict[str, str | bool | dict[str, str]] = {'uuid': uuid, 'param-name': param_name}
     host.xe(f'{xe_prefix}-param-clear', args)
+
+def hash_password(password: str) -> str:
+    """Hash password for /etc/shadow."""
+    # XCP-ng uses sha512 with 5000 rounds by default
+    return sha512_crypt.using(rounds=5000).hash(password)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,10 @@ requires-python = ">=3.11"
 dependencies = [
     "cryptography>=3.3.1",
     "gitpython",
+    # TODO: keep legacycrypt to let the user transition to lib.common.hash_password in their data.py
     "legacycrypt",
     "packaging>=20.7",
+    "passlib",
     "pluggy>=1.1.0",
     "pydantic",
     "pytest>=8.0.0",
@@ -34,6 +36,7 @@ dev = [
     "zizmor",
     "prek>=0.4.1",
     "autopep8",
+    "types-passlib",
 ]
 
 [tool.pyright]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ cryptography>=3.3.1
 gitpython
 legacycrypt
 packaging>=20.7
+passlib
 pluggy>=1.1.0
 pydantic
 pytest>=8.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,4 +15,5 @@ types-pexpect
 zizmor
 prek>=0.4.1
 autopep8
+types-passlib
 -r base.txt

--- a/uv.lock
+++ b/uv.lock
@@ -533,6 +533,15 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +877,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-passlib"
+version = "1.7.7.20260211"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/f4/718ff8cbef9366e597aefd58929321702d3e183998cea89949ab5423281f/types_passlib-1.7.7.20260211.tar.gz", hash = "sha256:af73afffe1ce94c95c7f6072bd261572c29845de74fdffa3a265fc7634bca056", size = 25666, upload-time = "2026-02-10T15:11:59.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/6a/e9fc6a5b8f9a380a4a56b9f1e4dba5c6899561868017b17f6de382808b6f/types_passlib-1.7.7.20260211-py3-none-any.whl", hash = "sha256:c0f1ad440c513a6c07f333b28249530686056fd54a7b3ac6128ae31fd46305d3", size = 40457, upload-time = "2026-02-10T15:11:58.647Z" },
+]
+
+[[package]]
 name = "types-pexpect"
 version = "4.9.0.20260518"
 source = { registry = "https://pypi.org/simple" }
@@ -939,6 +957,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "legacycrypt" },
     { name = "packaging" },
+    { name = "passlib" },
     { name = "pluggy" },
     { name = "pydantic" },
     { name = "pytest" },
@@ -959,6 +978,7 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "types-colorama" },
+    { name = "types-passlib" },
     { name = "types-pexpect" },
     { name = "types-pygments" },
     { name = "types-requests" },
@@ -972,6 +992,7 @@ requires-dist = [
     { name = "gitpython" },
     { name = "legacycrypt" },
     { name = "packaging", specifier = ">=20.7" },
+    { name = "passlib" },
     { name = "pluggy", specifier = ">=1.1.0" },
     { name = "pydantic" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -992,6 +1013,7 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "types-colorama" },
+    { name = "types-passlib" },
     { name = "types-pexpect" },
     { name = "types-pygments" },
     { name = "types-requests" },


### PR DESCRIPTION
legacycrypt requires to install libcrypt.so.1 manually

Keep legacycrypt as a dependency for now, to ease the transition to those who already have a custom data.py.

Move hash_password() to lib.common, to make easier to change the implementation in the future.

This is in draft while I test if it actually works with an install test.

<!-- start jj-vine stack -->
This PR is part of a tree containing 3 PRs:

1. `master`
2. **"Use passlib in place of legacycrypt" (this PR) → `master`**
3. #431 → #396
4. #491 → #396
<!-- end jj-vine stack -->