### PR TITLE
tests/storage: add type hints

### DIFF
--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -4,19 +4,26 @@ import logging
 
 from lib import config
 from lib.common import exec_nofail, raise_errors
+from lib.host import Host
+from lib.pool import Pool
+from lib.sr import SR
+from lib.vdi import VDI
+from lib.vm import VM
 
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state
 
+from typing import Generator
+
 @pytest.fixture(scope='package')
-def pool_without_ceph(host):
+def pool_without_ceph(host: Host) -> Generator[Pool, None, None]:
     for h in host.pool.hosts:
         assert not host.file_exists('/usr/sbin/mount.ceph'), \
             "mount.ceph must not be installed on the host at the beginning of the tests"
     yield host.pool
 
 @pytest.fixture(scope='package')
-def pool_with_ceph(pool_without_ceph, pool_with_saved_yum_state):
+def pool_with_ceph(pool_without_ceph: Pool, pool_with_saved_yum_state: Pool) -> Generator[Pool, None, None]:
     pool = pool_with_saved_yum_state
     for h in pool.hosts:
         h.yum_install(['centos-release-ceph-jewel'], enablerepo="base,extras")
@@ -24,11 +31,11 @@ def pool_with_ceph(pool_without_ceph, pool_with_saved_yum_state):
     yield pool
 
 @pytest.fixture(scope='package')
-def cephfs_device_config():
+def cephfs_device_config() -> dict[str, str]:
     return config.sr_device_config("CEPHFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
-def cephfs_sr(host, cephfs_device_config, pool_with_ceph):
+def cephfs_sr(host: Host, cephfs_device_config: dict[str, str], pool_with_ceph: Pool) -> Generator[SR, None, None]:
     """ A CephFS SR on first host. """
     sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)
     yield sr
@@ -36,13 +43,13 @@ def cephfs_sr(host, cephfs_device_config, pool_with_ceph):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_cephfs_sr(cephfs_sr):
+def vdi_on_cephfs_sr(cephfs_sr: SR) -> Generator[VDI, None, None]:
     vdi = cephfs_sr.create_vdi('CephFS-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_cephfs_sr(host, cephfs_sr, vm_ref):
+def vm_on_cephfs_sr(host: Host, cephfs_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=cephfs_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_cephfs_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_cephfs_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,12 +18,16 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_cephfs_sr):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM) -> None:
         sr = vm_on_cephfs_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_cephfs_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_cephfs_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -5,7 +5,9 @@ import pytest
 from lib.vm import VM
 from tests.storage import install_randstream
 
-def pytest_collection_modifyitems(config, items):
+from typing import Any, Generator
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     # modify ordering so that ext is always tested first,
     # before more complex storage drivers
     for item in reversed(list(items)):
@@ -14,6 +16,6 @@ def pytest_collection_modifyitems(config, items):
             items.insert(0, item)
 
 @pytest.fixture(scope='module')
-def storage_test_vm(running_unix_vm: VM):
+def storage_test_vm(running_unix_vm: VM) -> Generator[VM, None, None]:
     install_randstream(running_unix_vm)
     yield running_unix_vm

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -6,15 +6,16 @@ import logging
 
 from lib.host import Host
 from lib.sr import SR
-from lib.vdi import ImageFormat
+from lib.vdi import VDI, ImageFormat
+from lib.vm import VM
 
-from typing import Generator
+from typing import Any, Generator
 
 @pytest.fixture(scope='package')
 def ext_sr(host: Host,
            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
            image_format: ImageFormat
-           ) -> Generator[SR]:
+           ) -> Generator[SR, None, None]:
     """ An EXT SR on first host. """
     sr_disk = unused_512B_disks[host][0]["name"]
     sr = host.sr_create('ext', "EXT-local-SR-test",
@@ -25,13 +26,13 @@ def ext_sr(host: Host,
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_ext_sr(ext_sr: SR):
+def vdi_on_ext_sr(ext_sr: SR) -> Generator[VDI, None, None]:
     vdi = ext_sr.create_vdi('EXT-local-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_ext_sr(host, ext_sr, vm_ref):
+def vm_on_ext_sr(host: Host, ext_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=ext_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -32,7 +32,7 @@ class TestEXTSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_sr_with_missing_device(self, host):
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
         try_to_create_sr_with_missing_device('ext', 'EXT-local-SR-test', host)
 
     def test_create_and_destroy_sr(self, host: Host,
@@ -53,13 +53,13 @@ class TestEXTSRCreateDestroy:
 @pytest.mark.usefixtures("ext_sr")
 class TestEXTSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, ext_sr):
+    def test_quicktest(self, ext_sr: SR) -> None:
         ext_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_ext_sr):
+    def test_vdi_is_not_open(self, vdi_on_ext_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_ext_sr)
 
-    def test_vdi_image_format(self, vdi_on_ext_sr: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, vdi_on_ext_sr: VDI, image_format: ImageFormat) -> None:
         fmt = vdi_on_ext_sr.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -68,7 +68,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_ext_sr):
+    def test_start_and_shutdown_VM(self, vm_on_ext_sr: VM) -> None:
         vm = vm_on_ext_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -76,7 +76,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_ext_sr):
+    def test_snapshot(self, vm_on_ext_sr: VM) -> None:
         vm = vm_on_ext_sr
         vm.start()
         try:
@@ -87,23 +87,23 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
-    def test_coalesce(self, storage_test_vm: VM, vdi_on_ext_sr: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_ext_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_ext_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_ext_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_ext_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_ext_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, ext_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, ext_sr: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, ext_sr, image_format)
 
     # *** tests with reboots (longer tests).
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_blktap_activate_failure(self, vm_on_ext_sr):
+    def test_blktap_activate_failure(self, vm_on_ext_sr: VM) -> None:
         from lib.fistpoint import FistPoint
         vm = vm_on_ext_sr
         with FistPoint(vm.host, "blktap_activate_inject_failure"), pytest.raises(SSHCommandFailed):
@@ -112,7 +112,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_resize(self, vm_on_ext_sr):
+    def test_resize(self, vm_on_ext_sr: VM) -> None:
         vm = vm_on_ext_sr
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
         old_size = vdi.get_virtual_size()
@@ -124,7 +124,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize(self, host, ext_sr, vm_on_ext_sr, exit_on_fistpoint):
+    def test_failing_resize(self, host: Host, ext_sr: SR, vm_on_ext_sr: VM, exit_on_fistpoint: None) -> None:
         vm = vm_on_ext_sr
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
         old_size = vdi.get_virtual_size()
@@ -135,13 +135,13 @@ class TestEXTSR:
                 vdi.resize(new_size)
             except SSHCommandFailed:
                 logging.info(f"Launching SR scan for {ext_sr} after failure")
-                host.xe("sr-scan", {"uuid": ext_sr})
+                host.xe("sr-scan", {"uuid": ext_sr.uuid})
 
         assert vdi.get_virtual_size() == new_size
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, host, ext_sr, vm_on_ext_sr):
+    def test_reboot(self, host: Host, ext_sr: SR, vm_on_ext_sr: VM) -> None:
         sr = ext_sr
         vm = vm_on_ext_sr
         host.reboot(verify=True)

--- a/tests/storage/ext/test_ext_sr_crosspool_migration.py
+++ b/tests/storage/ext/test_ext_sr_crosspool_migration.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +18,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_ext_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_ext_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_ext_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, local_sr_on_hostB1: SR) -> None:
         live_storage_migration_then_come_back(vm_on_ext_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/ext/test_ext_sr_intrapool_migration.py
+++ b/tests/storage/ext/test_ext_sr_intrapool_migration.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +18,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_ext_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_ext_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_ext_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, local_sr_on_hostA2: SR) -> None:
         live_storage_migration_then_come_back(vm_on_ext_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/fsp/conftest.py
+++ b/tests/storage/fsp/conftest.py
@@ -4,7 +4,10 @@ import time
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from lib.host import Host
+from lib.sr import SR
 from pkgfixtures import host_with_saved_yum_state_toolstack_restart
+
+from typing import Generator
 
 FSP_REPO_NAME = 'runx'
 
@@ -13,7 +16,7 @@ FSP_PACKAGES = ['xcp-ng-xapi-storage']
 DIRECTORIES_PATH = 'directories'
 
 @pytest.fixture(scope='package')
-def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart):
+def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state_toolstack_restart
     host.add_xcpng_repo(FSP_REPO_NAME, 'vates')
     yield host
@@ -21,7 +24,7 @@ def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart):
     host.remove_xcpng_repo(FSP_REPO_NAME)
 
 @pytest.fixture(scope='package')
-def host_with_fsp(host_with_runx_repo: Host):
+def host_with_fsp(host_with_runx_repo: Host) -> Generator[Host, None, None]:
     host = host_with_runx_repo
     host.yum_install(FSP_PACKAGES)
     # fsp is not listed by xe sm-list until it's actually used, so just wait a few seconds instead
@@ -31,7 +34,7 @@ def host_with_fsp(host_with_runx_repo: Host):
     # teardown: nothing to do, done by host_with_saved_yum_state.
 
 @pytest.fixture(scope='package')
-def fsp_config(host_with_fsp: Host):
+def fsp_config(host_with_fsp: Host) -> dict[str, str]:
     db_path = host_with_fsp.ssh('mktemp -d')
     shared_dir_path = host_with_fsp.ssh('mktemp -d')
     return {
@@ -40,7 +43,7 @@ def fsp_config(host_with_fsp: Host):
     }
 
 @pytest.fixture(scope='package')
-def fsp_sr(host_with_fsp: Host, fsp_config):
+def fsp_sr(host_with_fsp: Host, fsp_config: dict[str, str]) -> Generator[SR, None, None]:
     """ An FSP SR on first host. """
     db_path = fsp_config['db_path']
     host_with_fsp.ssh(f'mkdir {db_path}/{DIRECTORIES_PATH}')

--- a/tests/storage/fsp/test_fsp_sr.py
+++ b/tests/storage/fsp/test_fsp_sr.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from lib.host import Host
+from lib.sr import SR
 
 from .conftest import DIRECTORIES_PATH
 
@@ -17,14 +18,14 @@ class TestFSPSRCreateDestroy:
     because they precisely need to test SR creation and destruction.
     """
 
-    def test_create_and_destroy_sr(self, host_with_fsp: Host):
+    def test_create_and_destroy_sr(self, host_with_fsp: Host) -> None:
         db_path = host_with_fsp.ssh('mktemp -d')
         host_with_fsp.ssh(f'mkdir {db_path}/{DIRECTORIES_PATH}')
         sr = host_with_fsp.sr_create('fsp', "fsp-local-SR-test", {'file-uri': db_path})
         sr.destroy()
         host_with_fsp.ssh(f'rm -rf {db_path}')
 
-    def test_create_and_destroy_sr_non_existing_path(self, host_with_fsp):
+    def test_create_and_destroy_sr_non_existing_path(self, host_with_fsp: Host) -> None:
         # get an unique non-existing path
         db_path = host_with_fsp.ssh('mktemp -d --dry-run')
         sr = None
@@ -37,7 +38,7 @@ class TestFSPSRCreateDestroy:
             assert False, "SR creation should not have succeeded!"
 
 class TestFSPVDI:
-    def test_create_and_destroy_VDI(self, host_with_fsp: Host, fsp_sr, fsp_config):
+    def test_create_and_destroy_VDI(self, host_with_fsp: Host, fsp_sr: SR, fsp_config: dict[str, str]) -> None:
         linkname = 'vdifor' + os.path.basename(fsp_config['shared_dir_path'])
         source = fsp_config['shared_dir_path']
         destination = fsp_config['db_path'] + '/' + DIRECTORIES_PATH + '/' + linkname

--- a/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_glusterfs_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_glusterfs_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,12 +18,16 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("local_sr_on_hostA2")
 class Test:
-    def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_glusterfs_sr):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM) -> None:
         sr = vm_on_glusterfs_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_glusterfs_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_glusterfs_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/iso/test_cifs_iso_sr.py
+++ b/tests/storage/iso/test_cifs_iso_sr.py
@@ -3,6 +3,10 @@ import pytest
 import logging
 import os
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
+
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
@@ -18,19 +22,19 @@ class TestCIFSISOSRCreateDestroy:
     because they precisely need to test SR creation and destruction
     """
 
-    def test_create_sr_with_bad_location(self, host, cifs_iso_device_config):
+    def test_create_sr_with_bad_location(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
         sr = None
         try:
             wrong_device_config = cifs_iso_device_config.copy()
             wrong_device_config['location'] += r'\wrongpath'
-            host.sr_create('iso', "ISO-CIFS-SR-test", wrong_device_config, verify=True)
+            sr = host.sr_create('iso', "ISO-CIFS-SR-test", wrong_device_config, verify=True)
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:
             sr.forget()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host, cifs_iso_device_config):
+    def test_create_and_destroy_sr(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
         sr = host.sr_create('iso', "ISO-CIFS-SR-test", cifs_iso_device_config, shared=True, verify=True)
         sr.forget()
 
@@ -38,10 +42,10 @@ class TestCIFSISOSRCreateDestroy:
 @pytest.mark.usefixtures("cifs_iso_sr")
 class TestCIFSISOSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, cifs_iso_sr):
+    def test_quicktest(self, cifs_iso_sr: SR) -> None:
         cifs_iso_sr.run_quicktest()
 
-    def test_iso_mount_and_read(self, host, cifs_iso_sr, running_unix_vm):
+    def test_iso_mount_and_read(self, host: Host, cifs_iso_sr: SR, running_unix_vm: VM) -> None:
         # create the ISO SR on CIFS
         sr = cifs_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr)

--- a/tests/storage/iso/test_cifs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_cifs_iso_sr_reboot.py
@@ -3,6 +3,9 @@ import pytest
 import os
 
 from lib.common import wait_for
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
@@ -21,7 +24,7 @@ class TestCIFSISOSRReboot:
     This test is longer because the host reboots between the creation of the SR and the test with the ISO file.
     """
 
-    def test_iso_mount_and_read_after_reboot(self, host, cifs_iso_sr, unix_vm):
+    def test_iso_mount_and_read_after_reboot(self, host: Host, cifs_iso_sr: SR, unix_vm: VM) -> None:
         # create the ISO SR on CIFS
         sr = cifs_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr)

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -3,6 +3,10 @@ import pytest
 import logging
 import os
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
+
 from .conftest import (
     check_iso_mount_and_read_from_vm,
     copy_tools_iso_to_iso_sr,
@@ -24,7 +28,7 @@ class TestLocalISOSRCreateDestroy:
     because they precisely need to test SR creation and destruction
     """
 
-    def test_create_sr_with_bad_location(self, host):
+    def test_create_sr_with_bad_location(self, host: Host) -> None:
         sr = None
         try:
             device_config = {
@@ -38,7 +42,7 @@ class TestLocalISOSRCreateDestroy:
             sr.destroy()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host, formatted_and_mounted_ext4_disk):
+    def test_create_and_destroy_sr(self, host: Host, formatted_and_mounted_ext4_disk: str) -> None:
         location = formatted_and_mounted_ext4_disk + '/iso_sr'
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = create_local_iso_sr(host, location)
@@ -48,11 +52,11 @@ class TestLocalISOSRCreateDestroy:
 @pytest.mark.usefixtures("local_iso_sr")
 class TestLocalISOSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, local_iso_sr):
+    def test_quicktest(self, local_iso_sr: tuple[SR, str]) -> None:
         sr, _ = local_iso_sr
         sr.run_quicktest()
 
-    def test_iso_mount_and_read(self, host, local_iso_sr, unix_vm):
+    def test_iso_mount_and_read(self, host: Host, local_iso_sr: tuple[SR, str], unix_vm: VM) -> None:
         sr, location = local_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr, location)
         unix_vm.start(on=host.uuid)

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -31,7 +31,7 @@ class TestLocalISOSRCreateDestroy:
                 'location': '/this/does/not/exist',
                 'legacy_mode': 'true'
             }
-            host.sr_create('iso', "ISO-local-SR-test", device_config, verify=True)
+            sr = host.sr_create('iso', "ISO-local-SR-test", device_config, verify=True)
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:

--- a/tests/storage/iso/test_local_iso_sr_reboot.py
+++ b/tests/storage/iso/test_local_iso_sr_reboot.py
@@ -3,6 +3,9 @@ import pytest
 import os
 
 from lib.common import wait_for
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
@@ -22,7 +25,7 @@ class TestLocalISOSRReboot:
     This test is longer because the host reboots between the creation of the SR and the test with the ISO file.
     """
 
-    def test_iso_mount_and_read_after_reboot(self, host, local_iso_sr, unix_vm):
+    def test_iso_mount_and_read_after_reboot(self, host: Host, local_iso_sr: tuple[SR, str], unix_vm: VM) -> None:
         sr, location = local_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr, location)
         host.reboot(verify=True)

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -3,6 +3,10 @@ import pytest
 import logging
 import os
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
+
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
 # Requirements:
@@ -18,7 +22,7 @@ class TestNFSISOSRCreateDestroy:
     because they precisely need to test SR creation and destruction
     """
 
-    def test_create_sr_with_bad_location(self, host, nfs_iso_device_config):
+    def test_create_sr_with_bad_location(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
         sr = None
         try:
             wrong_device_config = nfs_iso_device_config.copy()
@@ -30,7 +34,7 @@ class TestNFSISOSRCreateDestroy:
             sr.forget()
             assert False, "SR creation should not have succeeded!"
 
-    def test_create_and_destroy_sr(self, host, nfs_iso_device_config):
+    def test_create_and_destroy_sr(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('iso', "ISO-NFS-SR-test", nfs_iso_device_config, shared=True, verify=True)
         sr.forget()
@@ -40,10 +44,10 @@ class TestNFSISOSRCreateDestroy:
 @pytest.mark.usefixtures("nfs_iso_sr")
 class TestNFSISOSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, nfs_iso_sr):
+    def test_quicktest(self, nfs_iso_sr: SR) -> None:
         nfs_iso_sr.run_quicktest()
 
-    def test_iso_mount_and_read(self, host, nfs_iso_sr, running_unix_vm):
+    def test_iso_mount_and_read(self, host: Host, nfs_iso_sr: SR, running_unix_vm: VM) -> None:
         # create the ISO SR on NFS
         sr = nfs_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr)

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -23,7 +23,7 @@ class TestNFSISOSRCreateDestroy:
         try:
             wrong_device_config = nfs_iso_device_config.copy()
             wrong_device_config['location'] += '/wrongpath'
-            host.sr_create('iso', "ISO-NFS-SR-test", wrong_device_config, verify=True)
+            sr = host.sr_create('iso', "ISO-NFS-SR-test", wrong_device_config, verify=True)
         except Exception:
             logging.info("SR creation failed, as expected.")
         if sr is not None:

--- a/tests/storage/iso/test_nfs_iso_sr_reboot.py
+++ b/tests/storage/iso/test_nfs_iso_sr_reboot.py
@@ -3,6 +3,9 @@ import pytest
 import os
 
 from lib.common import wait_for
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 
 from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr, remove_iso_from_sr
 
@@ -21,7 +24,7 @@ class TestNFSISOSRReboot:
     This test is longer because the host reboots between the creation of the SR and the test with the ISO file.
     """
 
-    def test_iso_mount_and_read_after_reboot(self, host, nfs_iso_sr, unix_vm):
+    def test_iso_mount_and_read_after_reboot(self, host: Host, nfs_iso_sr: SR, unix_vm: VM) -> None:
         # create the ISO SR on nfs
         sr = nfs_iso_sr
         iso_path = copy_tools_iso_to_iso_sr(host, sr)

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -11,11 +11,13 @@ from typing import TYPE_CHECKING, Generator
 if TYPE_CHECKING:
     from lib.host import Host
     from lib.sr import SR
+    from lib.vdi import VDI
+    from lib.vm import VM
 
 @pytest.fixture(scope='package')
 def largeblock_sr(host: Host,
                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                  image_format: ImageFormat) -> Generator[SR]:
+                  image_format: ImageFormat) -> Generator[SR, None, None]:
     """ A LARGEBLOCK SR on first host. """
     sr_disk = unused_4k_disks[host][0]["name"]
     sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
@@ -26,13 +28,13 @@ def largeblock_sr(host: Host,
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_largeblock_sr(largeblock_sr):
+def vdi_on_largeblock_sr(largeblock_sr: SR) -> Generator[VDI, None, None]:
     vdi = largeblock_sr.create_vdi('LARGEBLOCK-local-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_largeblock_sr(host, largeblock_sr, vm_ref):
+def vm_on_largeblock_sr(host: Host, largeblock_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=largeblock_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/largeblock/test_largeblock_sr.py
+++ b/tests/storage/largeblock/test_largeblock_sr.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lib.host import Host
+    from lib.sr import SR
     from lib.vdi import VDI
+    from lib.vm import VM
 
 # Requirements:
 # - one XCP-ng host with an additional unused 4KiB disk for the SR
@@ -22,7 +24,7 @@ class TestLARGEBLOCKSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_sr_with_missing_device(self, host):
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
         try_to_create_sr_with_missing_device('largeblock', 'LARGEBLOCK-local-SR-test', host)
 
     def test_create_and_destroy_sr(self, host: Host,
@@ -42,13 +44,13 @@ class TestLARGEBLOCKSRCreateDestroy:
 @pytest.mark.usefixtures("largeblock_sr")
 class TestLARGEBLOCKSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, largeblock_sr):
+    def test_quicktest(self, largeblock_sr: SR) -> None:
         largeblock_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_largeblock_sr):
+    def test_vdi_is_not_open(self, vdi_on_largeblock_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_largeblock_sr)
 
-    def test_vdi_image_format(self, vdi_on_largeblock_sr: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, vdi_on_largeblock_sr: VDI, image_format: ImageFormat) -> None:
         fmt = vdi_on_largeblock_sr.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -57,7 +59,7 @@ class TestLARGEBLOCKSR:
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_largeblock_sr):
+    def test_start_and_shutdown_VM(self, vm_on_largeblock_sr: VM) -> None:
         vm = vm_on_largeblock_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -65,7 +67,7 @@ class TestLARGEBLOCKSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_largeblock_sr):
+    def test_snapshot(self, vm_on_largeblock_sr: VM) -> None:
         vm = vm_on_largeblock_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -76,7 +78,7 @@ class TestLARGEBLOCKSR:
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, host, largeblock_sr, vm_on_largeblock_sr):
+    def test_reboot(self, host: Host, largeblock_sr: SR, vm_on_largeblock_sr: VM) -> None:
         sr = largeblock_sr
         vm = vm_on_largeblock_sr
         host.reboot(verify=True)

--- a/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +16,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_largeblock_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_largeblock_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +16,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_largeblock_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_largeblock_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_linstor_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_linstor_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_linstor_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,12 +18,16 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_linstor_sr):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_linstor_sr: VM) -> None:
         sr = vm_on_linstor_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_linstor_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_linstor_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_linstor_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -6,7 +6,8 @@ import logging
 
 from lib.host import Host
 from lib.sr import SR
-from lib.vdi import ImageFormat
+from lib.vdi import VDI, ImageFormat
+from lib.vm import VM
 
 from typing import Generator
 
@@ -14,7 +15,7 @@ from typing import Generator
 def lvm_sr(host: Host,
            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
            image_format: ImageFormat
-           ) -> Generator[SR]:
+           ) -> Generator[SR, None, None]:
     """ An LVM SR on first host. """
     sr_disk = unused_512B_disks[host][0]["name"]
     sr = host.sr_create('lvm', "LVM-local-SR-test",
@@ -25,13 +26,13 @@ def lvm_sr(host: Host,
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_lvm_sr(lvm_sr: SR):
+def vdi_on_lvm_sr(lvm_sr: SR) -> Generator[VDI, None, None]:
     vdi = lvm_sr.create_vdi('LVM-local-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_lvm_sr(host, lvm_sr, vm_ref):
+def vm_on_lvm_sr(host: Host, lvm_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=lvm_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -32,7 +32,7 @@ class TestLVMSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_sr_with_missing_device(self, host):
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
         try_to_create_sr_with_missing_device('lvm', 'LVM-local-SR-test', host)
 
     def test_create_and_destroy_sr(self, host: Host,
@@ -54,13 +54,13 @@ class TestLVMSRCreateDestroy:
 @pytest.mark.usefixtures("lvm_sr")
 class TestLVMSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, lvm_sr):
+    def test_quicktest(self, lvm_sr: SR) -> None:
         lvm_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_lvm_sr):
+    def test_vdi_is_not_open(self, vdi_on_lvm_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_lvm_sr)
 
-    def test_vdi_image_format(self, vdi_on_lvm_sr: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, vdi_on_lvm_sr: VDI, image_format: ImageFormat) -> None:
         fmt = vdi_on_lvm_sr.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -69,7 +69,7 @@ class TestLVMSR:
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_lvm_sr):
+    def test_start_and_shutdown_VM(self, vm_on_lvm_sr: VM) -> None:
         vm = vm_on_lvm_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -77,7 +77,7 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_lvm_sr):
+    def test_snapshot(self, vm_on_lvm_sr: VM) -> None:
         vm = vm_on_lvm_sr
         vm.start()
         try:
@@ -88,7 +88,9 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize_on_inflate_after_setSize(self, host, lvm_sr, vm_on_lvm_sr, exit_on_fistpoint):
+    def test_failing_resize_on_inflate_after_setSize(
+        self, host: Host, lvm_sr: SR, vm_on_lvm_sr: VM, exit_on_fistpoint: None
+    ) -> None:
         vm = vm_on_lvm_sr
         lvinflate = ""
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
@@ -114,7 +116,9 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize_on_inflate_after_setSizePhys(self, host, lvm_sr, vm_on_lvm_sr, exit_on_fistpoint):
+    def test_failing_resize_on_inflate_after_setSizePhys(
+        self, host: Host, lvm_sr: SR, vm_on_lvm_sr: VM, exit_on_fistpoint: None
+    ) -> None:
         vm = vm_on_lvm_sr
         lvinflate = ""
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
@@ -140,23 +144,23 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
-    def test_coalesce(self, storage_test_vm: VM, vdi_on_lvm_sr: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_lvm_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_lvm_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_lvm_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_lvm_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_lvm_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, lvm_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, lvm_sr: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, lvm_sr, image_format)
 
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, host, lvm_sr, vm_on_lvm_sr):
+    def test_reboot(self, host: Host, lvm_sr: SR, vm_on_lvm_sr: VM) -> None:
         sr = lvm_sr
         vm = vm_on_lvm_sr
         host.reboot(verify=True)

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +16,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvm_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_lvm_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_lvm_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, local_sr_on_hostB1: SR) -> None:
         live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +16,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_lvm_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_lvm_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_lvm_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, local_sr_on_hostA2: SR) -> None:
         live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -3,15 +3,20 @@ import pytest
 import logging
 
 from lib import config
+from lib.host import Host
 from lib.sr import SR
-from lib.vdi import ImageFormat
+from lib.vdi import VDI, ImageFormat
+from lib.vm import VM
+
+from typing import Generator
 
 @pytest.fixture(scope='package')
-def lvmoiscsi_device_config():
+def lvmoiscsi_device_config() -> dict[str, str]:
     return config.sr_device_config("LVMOISCSI_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
-def lvmoiscsi_sr(host, lvmoiscsi_device_config, image_format: ImageFormat):
+def lvmoiscsi_sr(host: Host, lvmoiscsi_device_config: dict[str, str], image_format: ImageFormat) \
+        -> Generator[SR, None, None]:
     """ A lvmoiscsi SR on first host. """
     sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test",
                         lvmoiscsi_device_config | {'preferred-image-formats': image_format}, shared=True)
@@ -20,13 +25,13 @@ def lvmoiscsi_sr(host, lvmoiscsi_device_config, image_format: ImageFormat):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_lvmoiscsi_sr(lvmoiscsi_sr: SR):
+def vdi_on_lvmoiscsi_sr(lvmoiscsi_sr: SR) -> Generator[VDI, None, None]:
     vdi = lvmoiscsi_sr.create_vdi('lvmoiscsi-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_lvmoiscsi_sr(host, lvmoiscsi_sr, vm_ref):
+def vm_on_lvmoiscsi_sr(host: Host, lvmoiscsi_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=lvmoiscsi_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -1,6 +1,7 @@
 import pytest
 
 from lib.common import vm_image, wait_for
+from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI, ImageFormat
 from lib.vm import VM
@@ -25,7 +26,8 @@ class TestLVMOISCSISRCreateDestroy:
     and VM import.
     """
 
-    def test_create_and_destroy_sr(self, host, lvmoiscsi_device_config, image_format: ImageFormat):
+    def test_create_and_destroy_sr(self, host: Host, lvmoiscsi_device_config: dict[str, str],
+                                   image_format: ImageFormat) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test",
                             lvmoiscsi_device_config | {'preferred-image-formats': image_format},
@@ -40,15 +42,15 @@ class TestLVMOISCSISRCreateDestroy:
 @pytest.mark.usefixtures("lvmoiscsi_sr")
 class TestLVMOISCSISR:
     @pytest.mark.quicktest
-    def test_quicktest(self, lvmoiscsi_sr):
+    def test_quicktest(self, lvmoiscsi_sr: SR) -> None:
         lvmoiscsi_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_lvmoiscsi_sr):
+    def test_vdi_is_not_open(self, vdi_on_lvmoiscsi_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_lvmoiscsi_sr)
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_lvmoiscsi_sr):
+    def test_start_and_shutdown_VM(self, vm_on_lvmoiscsi_sr: VM) -> None:
         vm = vm_on_lvmoiscsi_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -56,7 +58,7 @@ class TestLVMOISCSISR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_lvmoiscsi_sr):
+    def test_snapshot(self, vm_on_lvmoiscsi_sr: VM) -> None:
         vm = vm_on_lvmoiscsi_sr
         vm.start()
         try:
@@ -67,23 +69,23 @@ class TestLVMOISCSISR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
-    def test_coalesce(self, storage_test_vm: 'VM', vdi_on_lvmoiscsi_sr: 'VDI', vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_lvmoiscsi_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_lvmoiscsi_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_lvmoiscsi_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_lvmoiscsi_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_lvmoiscsi_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, lvmoiscsi_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, lvmoiscsi_sr: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, lvmoiscsi_sr, image_format)
 
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, host, lvmoiscsi_sr, vm_on_lvmoiscsi_sr):
+    def test_reboot(self, host: Host, lvmoiscsi_sr: SR, vm_on_lvmoiscsi_sr: VM) -> None:
         sr = lvmoiscsi_sr
         vm = vm_on_lvmoiscsi_sr
         host.reboot(verify=True)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,8 +16,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvmoiscsi_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_lvmoiscsi_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -13,12 +16,16 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_lvmoiscsi_sr):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM) -> None:
         sr = vm_on_lvmoiscsi_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_lvmoiscsi_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_lvmoiscsi_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import logging
@@ -6,44 +8,50 @@ from lib import config
 
 # explicit import for package-scope fixtures
 from lib.host import Host
+from lib.pool import Pool
+from lib.sr import SR
+from lib.vdi import VDI
+from lib.vm import VM
 from pkgfixtures import pool_with_saved_yum_state
 
-def install_moosefs(host: Host):
+from typing import Generator
+
+def install_moosefs(host: Host) -> None:
     assert not host.file_exists('/usr/sbin/mount.moosefs'), \
         "MooseFS client should not be installed on the host before all tests"
     host.ssh('curl https://repository.moosefs.com/RPM-GPG-KEY-MooseFS > /etc/pki/rpm-gpg/RPM-GPG-KEY-MooseFS')
     host.ssh('curl http://repository.moosefs.com/MooseFS-3-el7.repo > /etc/yum.repos.d/MooseFS.repo')
     host.yum_install(['fuse', 'moosefs-client'])
 
-def uninstall_moosefs_repo(host: Host):
+def uninstall_moosefs_repo(host: Host) -> None:
     host.ssh('rm -f /etc/pki/rpm-gpg/RPM-GPG-KEY-MooseFS /etc/yum.repos.d/MooseFS.repo')
 
-def enable_moosefs(host: Host):
+def enable_moosefs(host: Host) -> None:
     host.activate_smapi_driver('moosefs')
 
-def disable_moosefs(host: Host):
+def disable_moosefs(host: Host) -> None:
     host.deactivate_smapi_driver('moosefs')
 
 @pytest.fixture(scope='package')
-def pool_with_moosefs_installed(pool_with_saved_yum_state):
+def pool_with_moosefs_installed(pool_with_saved_yum_state: Pool) -> Generator[Pool, None, None]:
     pool = pool_with_saved_yum_state
     pool.exec_on_hosts_on_error_rollback(install_moosefs, uninstall_moosefs_repo)
     yield pool
     pool.exec_on_hosts_on_error_continue(uninstall_moosefs_repo)
 
 @pytest.fixture(scope='package')
-def pool_with_moosefs_enabled(pool_with_moosefs_installed):
+def pool_with_moosefs_enabled(pool_with_moosefs_installed: Pool) -> Generator[Pool, None, None]:
     pool = pool_with_moosefs_installed
     pool.exec_on_hosts_on_error_rollback(enable_moosefs, disable_moosefs)
     yield pool
     pool.exec_on_hosts_on_error_continue(disable_moosefs)
 
 @pytest.fixture(scope='package')
-def moosefs_device_config():
+def moosefs_device_config() -> dict[str, str]:
     return config.sr_device_config("MOOSEFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
-def moosefs_sr(moosefs_device_config, pool_with_moosefs_enabled):
+def moosefs_sr(moosefs_device_config: dict[str, str], pool_with_moosefs_enabled: Pool) -> Generator[SR, None, None]:
     """ MooseFS SR on a specific host. """
     sr = pool_with_moosefs_enabled.master.sr_create('moosefs', "MooseFS-SR-test", moosefs_device_config, shared=True)
     yield sr
@@ -51,13 +59,13 @@ def moosefs_sr(moosefs_device_config, pool_with_moosefs_enabled):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_moosefs_sr(moosefs_sr):
+def vdi_on_moosefs_sr(moosefs_sr: SR) -> Generator[VDI, None, None]:
     vdi = moosefs_sr.create_vdi('MooseFS-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_moosefs_sr(host, moosefs_sr, vm_ref):
+def vm_on_moosefs_sr(host: Host, moosefs_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=moosefs_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_moosefs_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_moosefs_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,12 +18,16 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
-    def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_moosefs_sr):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM) -> None:
         sr = vm_on_moosefs_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_moosefs_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_moosefs_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -5,23 +5,27 @@ import pytest
 import logging
 
 from lib import config
+from lib.host import Host
 from lib.sr import SR
-from lib.vdi import ImageFormat
+from lib.vdi import VDI, ImageFormat
+from lib.vm import VM
+
+from typing import Generator
 
 # --- Dispatch fixture for NFS versions ----------------------------------------
 
 @pytest.fixture
-def dispatch_nfs(request):
+def dispatch_nfs(request: pytest.FixtureRequest) -> Generator[SR | VDI | VM, None, None]:
     yield request.getfixturevalue(request.param)
 
 # --- NFS3 fixtures ------------------------------------------------------------
 
 @pytest.fixture(scope='package')
-def nfs_device_config():
+def nfs_device_config() -> dict[str, str]:
     return config.sr_device_config("NFS_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
-def nfs_sr(host, image_format: ImageFormat, nfs_device_config):
+def nfs_sr(host: Host, image_format: ImageFormat, nfs_device_config: dict[str, str]) -> Generator[SR, None, None]:
     """ A NFS SR on first host. """
     sr = host.sr_create(
         'nfs', "NFS-SR-test", nfs_device_config | {'preferred-image-formats': image_format}, shared=True
@@ -31,13 +35,13 @@ def nfs_sr(host, image_format: ImageFormat, nfs_device_config):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_nfs_sr(nfs_sr: SR):
+def vdi_on_nfs_sr(nfs_sr: SR) -> Generator[VDI, None, None]:
     vdi = nfs_sr.create_vdi('NFS-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_nfs_sr(host, nfs_sr, vm_ref):
+def vm_on_nfs_sr(host: Host, nfs_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=nfs_sr.uuid)
     yield vm
     # teardown
@@ -47,11 +51,11 @@ def vm_on_nfs_sr(host, nfs_sr, vm_ref):
 # --- NFS4+ only fixtures ------------------------------------------------------
 
 @pytest.fixture(scope='package')
-def nfs4_device_config():
+def nfs4_device_config() -> dict[str, str]:
     return config.sr_device_config("NFS4_DEVICE_CONFIG")
 
 @pytest.fixture(scope='package')
-def nfs4_sr(host, image_format: ImageFormat, nfs4_device_config):
+def nfs4_sr(host: Host, image_format: ImageFormat, nfs4_device_config: dict[str, str]) -> Generator[SR, None, None]:
     """ A NFS4+ SR on first host. """
     sr = host.sr_create(
         'nfs', "NFS4-SR-test", nfs4_device_config | {'preferred-image-formats': image_format}, shared=True
@@ -61,13 +65,13 @@ def nfs4_sr(host, image_format: ImageFormat, nfs4_device_config):
     sr.destroy()
 
 @pytest.fixture(scope='module')
-def vdi_on_nfs4_sr(nfs4_sr: SR):
+def vdi_on_nfs4_sr(nfs4_sr: SR) -> Generator[VDI, None, None]:
     vdi = nfs4_sr.create_vdi('NFS4-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_nfs4_sr(host, nfs4_sr, vm_ref):
+def vm_on_nfs4_sr(host: Host, nfs4_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=nfs4_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -4,6 +4,7 @@ import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for
+from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
@@ -22,7 +23,7 @@ from tests.storage import (
 
 class TestNFSSRCreateDestroy:
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_device_config', 'nfs4_device_config'], indirect=True)
-    def test_create_and_destroy_sr(self, host, dispatch_nfs):
+    def test_create_and_destroy_sr(self, host: Host, dispatch_nfs: dict[str, str]) -> None:
         device_config = dispatch_nfs
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('nfs', "NFS-SR-test", device_config, shared=True, verify=True)
@@ -37,12 +38,12 @@ class TestNFSSRCreateDestroy:
 class TestNFSSR:
     @pytest.mark.quicktest
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)
-    def test_quicktest(self, dispatch_nfs):
+    def test_quicktest(self, dispatch_nfs: SR) -> None:
         sr = dispatch_nfs
         sr.run_quicktest()
 
     @pytest.mark.parametrize('dispatch_nfs', ['vdi_on_nfs_sr', 'vdi_on_nfs4_sr'], indirect=True)
-    def test_vdi_is_not_open(self, dispatch_nfs):
+    def test_vdi_is_not_open(self, dispatch_nfs: VDI) -> None:
         vdi = dispatch_nfs
         assert not vdi_is_open(vdi)
 
@@ -51,7 +52,7 @@ class TestNFSSR:
     # Make sure this fixture is called before the parametrized one
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_plugin_nfs_on_on_slave(self, dispatch_nfs: VM):
+    def test_plugin_nfs_on_on_slave(self, dispatch_nfs: VM) -> None:
         vm = dispatch_nfs
         vm.start()
         vm.wait_for_os_booted()
@@ -80,7 +81,7 @@ class TestNFSSR:
         vm.shutdown(verify=True)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vdi_on_nfs_sr', 'vdi_on_nfs4_sr'], indirect=True)
-    def test_vdi_image_format(self, dispatch_nfs: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, dispatch_nfs: VDI, image_format: ImageFormat) -> None:
         fmt = dispatch_nfs.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -92,7 +93,7 @@ class TestNFSSR:
     # Make sure this fixture is called before the parametrized one
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_start_and_shutdown_VM(self, dispatch_nfs):
+    def test_start_and_shutdown_VM(self, dispatch_nfs: VM) -> None:
         vm = dispatch_nfs
         vm.start()
         vm.wait_for_os_booted()
@@ -103,7 +104,7 @@ class TestNFSSR:
     # Make sure this fixture is called before the parametrized one
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_snapshot(self, dispatch_nfs):
+    def test_snapshot(self, dispatch_nfs: VM) -> None:
         vm = dispatch_nfs
         vm.start()
         try:
@@ -115,7 +116,7 @@ class TestNFSSR:
     @pytest.mark.small_vm
     @pytest.mark.parametrize('dispatch_nfs', ['vdi_on_nfs_sr', 'vdi_on_nfs4_sr'], indirect=True)
     @pytest.mark.parametrize('vdi_op', ['snapshot', 'clone'])
-    def test_coalesce(self, storage_test_vm: VM, dispatch_nfs: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, dispatch_nfs: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, dispatch_nfs, vdi_op)
 
     @pytest.mark.small_vm
@@ -123,12 +124,12 @@ class TestNFSSR:
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, dispatch_nfs: VM, compression: XVACompression):
+    def test_xva_export_import(self, dispatch_nfs: VM, compression: XVACompression) -> None:
         xva_export_import(dispatch_nfs, compression)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)
-    def test_vdi_export_import(self, storage_test_vm: VM, dispatch_nfs: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, dispatch_nfs: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, dispatch_nfs, image_format)
 
     # *** tests with reboots (longer tests).
@@ -138,7 +139,7 @@ class TestNFSSR:
     # Make sure this fixture is called before the parametrized one
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_reboot(self, host, dispatch_nfs):
+    def test_reboot(self, host: Host, dispatch_nfs: VM) -> None:
         vm = dispatch_nfs
         sr = vm.get_sr()
         host.reboot(verify=True)

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -17,9 +20,9 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.usefixtures('image_format')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_cold_crosspool_migration(self, host, hostB1, dispatch_nfs, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(dispatch_nfs, host, hostB1, local_sr_on_hostB1)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_live_crosspool_migration(self, host, hostB1, dispatch_nfs, local_sr_on_hostB1):
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, local_sr_on_hostB1: SR) -> None:
         live_storage_migration_then_come_back(dispatch_nfs, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -17,14 +20,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.usefixtures('image_format')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_live_intrapool_shared_migration(self, host, hostA2, dispatch_nfs):
+    def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM) -> None:
         sr = dispatch_nfs.get_sr()
         live_storage_migration_then_come_back(dispatch_nfs, host, hostA2, sr)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_cold_intrapool_migration(self, host, hostA2, dispatch_nfs, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(dispatch_nfs, host, hostA2, local_sr_on_hostA2)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_live_intrapool_migration(self, host, hostA2, dispatch_nfs, local_sr_on_hostA2):
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, local_sr_on_hostA2: SR) -> None:
         live_storage_migration_then_come_back(dispatch_nfs, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -25,7 +25,7 @@ def _xfs_config() -> XfsConfig:
 # image_format in the fixture arguments.
 # ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
 @pytest.fixture(scope='package')
-def host_with_xfsprogs(host: Host, image_format: ImageFormat, _xfs_config: XfsConfig) -> Generator[Host]:
+def host_with_xfsprogs(host: Host, image_format: ImageFormat, _xfs_config: XfsConfig) -> Generator[Host, None, None]:
     assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
         "xfsprogs must not be installed on the host at the beginning of the tests"
     host.yum_save_state()
@@ -41,7 +41,7 @@ def xfs_sr(
     host_with_xfsprogs: Host,
     image_format: ImageFormat,
     _xfs_config: XfsConfig,
-) -> Generator[SR]:
+) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
     sr_disk = unused_512B_disks[host_with_xfsprogs][0]["name"]
     sr = host_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
@@ -56,13 +56,13 @@ def xfs_sr(
         raise pytest.fail("Could not destroy xfs SR, leaving packages in place for manual cleanup") from e
 
 @pytest.fixture(scope='module')
-def vdi_on_xfs_sr(xfs_sr: SR) -> Generator[VDI]:
+def vdi_on_xfs_sr(xfs_sr: SR) -> Generator[VDI, None, None]:
     vdi = xfs_sr.create_vdi('XFS-local-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_xfs_sr(host: Host, xfs_sr: SR, vm_ref: str) -> Generator[VM]:
+def vm_on_xfs_sr(host: Host, xfs_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=xfs_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -41,7 +41,7 @@ class TestXFSSRCreateDestroy:
         assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
             "xfsprogs must not be installed on the host at the beginning of the tests"
         sr_disk = unused_512B_disks[host][0]["name"]
-        sr = None
+        sr: SR | None = None
         try:
             sr = host.sr_create('xfs', "XFS-local-SR-test", {
                 'device': '/dev/' + sr_disk,
@@ -70,13 +70,13 @@ class TestXFSSRCreateDestroy:
 @pytest.mark.usefixtures("xfs_sr")
 class TestXFSSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, xfs_sr):
+    def test_quicktest(self, xfs_sr: SR) -> None:
         xfs_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_xfs_sr):
+    def test_vdi_is_not_open(self, vdi_on_xfs_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_xfs_sr)
 
-    def test_vdi_image_format(self, vdi_on_xfs_sr: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, vdi_on_xfs_sr: VDI, image_format: ImageFormat) -> None:
         fmt = vdi_on_xfs_sr.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -85,7 +85,7 @@ class TestXFSSR:
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_xfs_sr):
+    def test_start_and_shutdown_VM(self, vm_on_xfs_sr: VM) -> None:
         vm = vm_on_xfs_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -93,7 +93,7 @@ class TestXFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_xfs_sr):
+    def test_snapshot(self, vm_on_xfs_sr: VM) -> None:
         vm = vm_on_xfs_sr
         vm.start()
         try:
@@ -104,23 +104,23 @@ class TestXFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
-    def test_coalesce(self, storage_test_vm: VM, vdi_on_xfs_sr: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_xfs_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_xfs_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_xfs_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_xfs_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_xfs_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, xfs_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, xfs_sr: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, xfs_sr, image_format)
 
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, vm_on_xfs_sr, host, xfs_sr):
+    def test_reboot(self, vm_on_xfs_sr: VM, host: Host, xfs_sr: SR) -> None:
         sr = xfs_sr
         vm = vm_on_xfs_sr
         host.reboot(verify=True)
@@ -131,7 +131,7 @@ class TestXFSSR:
         vm.shutdown(verify=True)
 
     @pytest.mark.reboot
-    def test_xfsprogs_missing(self, host, xfs_sr):
+    def test_xfsprogs_missing(self, host: Host, xfs_sr: SR) -> None:
         sr = xfs_sr
         xfsprogs_installed = True
         try:

--- a/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +20,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_xfs_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_xfs_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_xfs_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, local_sr_on_hostB1: SR) -> None:
         live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +20,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_xfs_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_xfs_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_xfs_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, local_sr_on_hostA2: SR) -> None:
         live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -7,6 +7,7 @@ import time
 
 from lib.commands import SSHCommandFailed
 from lib.common import vm_image, wait_for
+from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
@@ -19,12 +20,6 @@ from tests.storage import (
     vdi_is_open,
     xva_export_import,
 )
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from lib.host import Host
-    from lib.vdi import VDI
 
 from .conftest import POOL_NAME, POOL_PATH
 
@@ -72,13 +67,13 @@ class TestZFSSRCreateDestroy:
 @pytest.mark.usefixtures("zpool_vol0")
 class TestZFSSR:
     @pytest.mark.quicktest
-    def test_quicktest(self, zfs_sr):
+    def test_quicktest(self, zfs_sr: SR) -> None:
         zfs_sr.run_quicktest()
 
-    def test_vdi_is_not_open(self, vdi_on_zfs_sr):
+    def test_vdi_is_not_open(self, vdi_on_zfs_sr: VDI) -> None:
         assert not vdi_is_open(vdi_on_zfs_sr)
 
-    def test_vdi_image_format(self, vdi_on_zfs_sr: VDI, image_format: ImageFormat):
+    def test_vdi_image_format(self, vdi_on_zfs_sr: VDI, image_format: ImageFormat) -> None:
         fmt = vdi_on_zfs_sr.get_image_format()
         # feature-detect: if the SM doesn't report image-format, skip this check
         if not fmt:
@@ -87,7 +82,7 @@ class TestZFSSR:
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_zfs_sr):
+    def test_start_and_shutdown_VM(self, vm_on_zfs_sr: VM) -> None:
         vm = vm_on_zfs_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -95,7 +90,7 @@ class TestZFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_zfs_sr):
+    def test_snapshot(self, vm_on_zfs_sr: VM) -> None:
         vm = vm_on_zfs_sr
         vm.start()
         try:
@@ -106,23 +101,23 @@ class TestZFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
-    def test_coalesce(self, storage_test_vm: VM, vdi_on_zfs_sr: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_zfs_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_zfs_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_zfs_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_zfs_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_zfs_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, zfs_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, zfs_sr: SR, image_format: ImageFormat) -> None:
         vdi_export_import(storage_test_vm, zfs_sr, image_format)
 
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, vm_on_zfs_sr, host, zfs_sr):
+    def test_reboot(self, vm_on_zfs_sr: VM, host: Host, zfs_sr: SR) -> None:
         sr = zfs_sr
         vm = vm_on_zfs_sr
         host.reboot(verify=True)
@@ -133,7 +128,7 @@ class TestZFSSR:
         vm.shutdown(verify=True)
 
     @pytest.mark.reboot
-    def test_zfs_missing(self, host: Host, zfs_sr):
+    def test_zfs_missing(self, host: Host, zfs_sr: SR) -> None:
         sr = zfs_sr
         zfs_installed = True
         try:
@@ -161,7 +156,7 @@ class TestZFSSR:
                 host.ssh('modprobe zfs')
 
     @pytest.mark.reboot
-    def test_zfs_unmounted(self, host: Host, zfs_sr):
+    def test_zfs_unmounted(self, host: Host, zfs_sr: SR) -> None:
         sr = zfs_sr
         zpool_imported = True
         try:

--- a/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_zfs_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_zfs_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_zfs_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, local_sr_on_hostB1: SR) -> None:
         live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -15,8 +18,8 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_zfs_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_zfs_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_zfs_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, local_sr_on_hostA2: SR) -> None:
         live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -6,19 +6,23 @@ import logging
 
 from lib.host import Host
 from lib.sr import SR
+from lib.vdi import VDI
+from lib.vm import VM
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state_toolstack_restart, sr_disk_wiped
 
+from typing import Generator
+
 @pytest.fixture(scope='package')
-def host_with_zfsvol(host_with_saved_yum_state_toolstack_restart):
+def host_with_zfsvol(host_with_saved_yum_state_toolstack_restart: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state_toolstack_restart
     host.yum_install(['xcp-ng-xapi-storage-volume-zfsvol'])
     host.restart_toolstack(verify=True)
     yield host
 
 @pytest.fixture(scope='package')
-def zfsvol_sr(host: Host, sr_disk_wiped, host_with_zfsvol):
+def zfsvol_sr(host: Host, sr_disk_wiped: str, host_with_zfsvol: Host) -> Generator[SR, None, None]:
     """ A ZFS Volume SR on first host. """
     device = '/dev/' + sr_disk_wiped
     sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': device})
@@ -28,13 +32,13 @@ def zfsvol_sr(host: Host, sr_disk_wiped, host_with_zfsvol):
     host.ssh(f'wipefs -a {device}')
 
 @pytest.fixture(scope='module')
-def vdi_on_zfsvol_sr(zfsvol_sr: SR):
+def vdi_on_zfsvol_sr(zfsvol_sr: SR) -> Generator[VDI, None, None]:
     vdi = zfsvol_sr.create_vdi('ZFS-local-VDI-test')
     yield vdi
     vdi.destroy()
 
 @pytest.fixture(scope='module')
-def vm_on_zfsvol_sr(host, zfsvol_sr, vm_ref):
+def vm_on_zfsvol_sr(host: Host, zfsvol_sr: SR, vm_ref: str) -> Generator[VM, None, None]:
     vm = host.import_vm(vm_ref, sr_uuid=zfsvol_sr.uuid)
     yield vm
     # teardown

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -5,6 +5,7 @@ import pytest
 import logging
 
 from lib.common import vm_image, wait_for
+from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
@@ -16,6 +17,7 @@ from tests.storage import CoalesceOperation, ImageFormat, XVACompression, coales
 
 pytestmark = pytest.mark.usefixtures("host_at_least_8_3")
 
+
 class TestZfsvolSRCreateDestroy:
     """
     Tests that do not use fixtures that setup the SR or import VMs,
@@ -23,7 +25,7 @@ class TestZfsvolSRCreateDestroy:
     and VM import.
     """
 
-    def test_create_and_destroy_sr(self, sr_disk_wiped, host_with_zfsvol):
+    def test_create_and_destroy_sr(self, sr_disk_wiped: str, host_with_zfsvol: Host) -> None:
         host = host_with_zfsvol
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': '/dev/' + sr_disk_wiped}, verify=True)
@@ -38,12 +40,12 @@ class TestZfsvolVm:
 
     @pytest.mark.xfail
     @pytest.mark.quicktest
-    def test_quicktest(self, zfsvol_sr):
+    def test_quicktest(self, zfsvol_sr: SR) -> None:
         zfsvol_sr.run_quicktest()
 
     @pytest.mark.small_vm # run with a small VM to test the features
     @pytest.mark.big_vm # and ideally with a big VM to test it scales
-    def test_start_and_shutdown_VM(self, vm_on_zfsvol_sr):
+    def test_start_and_shutdown_VM(self, vm_on_zfsvol_sr: VM) -> None:
         vm = vm_on_zfsvol_sr
         vm.start()
         vm.wait_for_os_booted()
@@ -52,7 +54,7 @@ class TestZfsvolVm:
     @pytest.mark.xfail # needs support for destroying snapshots
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_snapshot(self, vm_on_zfsvol_sr):
+    def test_snapshot(self, vm_on_zfsvol_sr: VM) -> None:
         vm = vm_on_zfsvol_sr
         vm.start()
         try:
@@ -64,16 +66,16 @@ class TestZfsvolVm:
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot"])  # "clone" requires a snapshot
     @pytest.mark.skip("zfsvol doesn't provide vhd-parent")
-    def test_coalesce(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, vdi_op: CoalesceOperation):
+    def test_coalesce(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, vdi_op: CoalesceOperation) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_zfsvol_sr, vdi_op)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression):
+    def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression) -> None:
         xva_export_import(vm_on_zfsvol_sr, compression)
 
     @pytest.mark.small_vm
-    def test_vdi_export_import(self, storage_test_vm: VM, zfsvol_sr: SR, image_format: ImageFormat):
+    def test_vdi_export_import(self, storage_test_vm: VM, zfsvol_sr: SR, image_format: ImageFormat) -> None:
         vm = storage_test_vm
         sr = zfsvol_sr
         vdi: VDI | None = sr.create_vdi(image_format=image_format)
@@ -112,7 +114,7 @@ class TestZfsvolVm:
 
     @pytest.mark.reboot
     @pytest.mark.small_vm
-    def test_reboot(self, vm_on_zfsvol_sr, host, zfsvol_sr):
+    def test_reboot(self, vm_on_zfsvol_sr: VM, host: Host, zfsvol_sr: SR) -> None:
         sr = zfsvol_sr
         vm = vm_on_zfsvol_sr
         host.reboot(verify=True)

--- a/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -16,8 +19,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_zfsvol_sr, local_sr_on_hostB1):
+    def test_cold_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, local_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_zfsvol_sr, local_sr_on_hostB1):
+    def test_live_crosspool_migration(
+        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostB1: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
@@ -1,5 +1,8 @@
 import pytest
 
+from lib.host import Host
+from lib.sr import SR
+from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
 
 # Requirements:
@@ -16,8 +19,12 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_zfsvol_sr, local_sr_on_hostA2):
+    def test_cold_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, local_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_zfsvol_sr, local_sr_on_hostA2):
+    def test_live_intrapool_migration(
+        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostA2: SR
+    ) -> None:
         live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, local_sr_on_hostA2)


### PR DESCRIPTION
This allows more validation both in the CI and when writing the tests in our IDEs.

This work was mostly done with AI, validated by the code checkers, and manually cleaned up by me.

<!-- start jj-vine stack -->
This PR is part of a stack containing 9 PRs:

1. `master`
2. #387
3. #398
4. #399
5. **"tests/storage: add type hints" (this PR)**
6. #401
7. #402
8. #403
9. #460
10. #476
<!-- end jj-vine stack -->