### PR TITLE
xapi,network: add type hints

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -1,7 +1,9 @@
 import pytest
 
+from lib.host import Host
+
 @pytest.fixture(scope='package')
-def host_no_sdn_controller(host):
+def host_no_sdn_controller(host: Host) -> None:
     """ An XCP-ng with no SDN controller. """
     if host.xe('sdn-controller-list', minimal=True):
         pytest.skip("This test requires an XCP-ng with no SDN controller")

--- a/tests/network/test_management_disable_address_type.py
+++ b/tests/network/test_management_disable_address_type.py
@@ -1,7 +1,9 @@
+from lib.host import Host
+
 # Requirements:
 # - one XCP-ng host (--hosts) (>= 8.3 for IPv6 test)
 
-def test_management_disable_address_type(host):
+def test_management_disable_address_type(host: Host) -> None:
     management_pif = host.management_pif()
     type = management_pif.param_get("primary-address-type").lower()
 

--- a/tests/network/test_vif_allowed_ip.py
+++ b/tests/network/test_vif_allowed_ip.py
@@ -9,13 +9,13 @@ from lib.vm import VM
 # - one XCP-ng host (--hosts) >= 8.2 (>= 8.3 for the CIDR tests) with no SDN controller configured
 # - a VM (--vm)
 
-def ip_responsive(ip):
+def ip_responsive(ip: str) -> bool:
     return not os.system(f"ping -c 3 -W 10 {ip} > /dev/null 2>&1")
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_no_sdn_controller")
 class TestAllowedIP:
-    def test_unallowed_ip(self, running_vm: VM):
+    def test_unallowed_ip(self, running_vm: VM) -> None:
         vm = running_vm
         vif = vm.vifs()[0]
         ip = vm.ip
@@ -32,7 +32,7 @@ class TestAllowedIP:
         vif.param_clear(f"ipv{ip_family}-allowed")
         vif.param_set("locking-mode", "unlocked")
 
-    def test_allowed_ip(self, running_vm):
+    def test_allowed_ip(self, running_vm: VM) -> None:
         vm = running_vm
         vif = vm.vifs()[0]
         ip = vm.ip
@@ -55,7 +55,7 @@ class TestAllowedIP:
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_at_least_8_3", "host_no_sdn_controller")
 class TestAllowedCIDR:
-    def test_unallowed_cidr(self, running_vm: VM):
+    def test_unallowed_cidr(self, running_vm: VM) -> None:
         vm = running_vm
         vif = vm.vifs()[0]
         ip = vm.ip
@@ -73,7 +73,7 @@ class TestAllowedCIDR:
         vif.param_clear(f"ipv{ip_family}-allowed")
         vif.param_set("locking-mode", "unlocked")
 
-    def test_allowed_cidr(self, running_vm: VM):
+    def test_allowed_cidr(self, running_vm: VM) -> None:
         vm = running_vm
         vif = vm.vifs()[0]
         ip = vm.ip

--- a/tests/network/test_vif_management.py
+++ b/tests/network/test_vif_management.py
@@ -20,7 +20,7 @@ def count_interfaces(vm: VM) -> int:
 
 @pytest.mark.small_vm
 class TestVIFManagement:
-    def test_vif_management(self, running_unix_vm: VM):
+    def test_vif_management(self, running_unix_vm: VM) -> None:
         vm = running_unix_vm
         host = vm.host
         network_uuid = host.management_network()

--- a/tests/xapi_plugins/plugin_hyperthreading/test_hyperthreading.py
+++ b/tests/xapi_plugins/plugin_hyperthreading/test_hyperthreading.py
@@ -1,6 +1,8 @@
+from lib.host import Host
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host > 8.2.
 
-def test_get_hyperthreading(host):
+def test_get_hyperthreading(host: Host) -> None:
     host.call_plugin('hyperthreading.py', 'get_hyperthreading')

--- a/tests/xapi_plugins/plugin_lsblk/test_lsblk.py
+++ b/tests/xapi_plugins/plugin_lsblk/test_lsblk.py
@@ -1,6 +1,8 @@
+from lib.host import Host
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host > 8.2.
 
-def test_list_block_devices(host):
+def test_list_block_devices(host: Host) -> None:
     host.call_plugin('lsblk.py', 'list_block_devices')

--- a/tests/xapi_plugins/plugin_netdata/test_netdata.py
+++ b/tests/xapi_plugins/plugin_netdata/test_netdata.py
@@ -1,6 +1,9 @@
 import pytest
 
 from lib.common import strtobool
+from lib.host import Host
+
+from typing import Generator
 
 # Requirements:
 # From --hosts parameter:
@@ -9,15 +12,15 @@ from lib.common import strtobool
 # - access to XCP-ng RPM repository from hostA1
 
 @pytest.fixture(scope='module')
-def host_without_netdata(host):
+def host_without_netdata(host: Host) -> Generator[Host, None, None]:
     assert not strtobool(host.call_plugin('netdata.py', 'is_netdata_installed'))
     yield host
 
 class TestInstall:
-    def test_is_netdata_installed(self, host):
+    def test_is_netdata_installed(self, host: Host) -> None:
         host.call_plugin('netdata.py', 'is_netdata_installed')
 
-    def test_install_netdata(self, host_without_netdata):
+    def test_install_netdata(self, host_without_netdata: Host) -> None:
         host = host_without_netdata
         host.yum_save_state()
         host.call_plugin('netdata.py', 'install_netdata', {
@@ -29,7 +32,7 @@ class TestInstall:
         host.yum_restore_saved_state()
 
 class TestApiKey:
-    def test_get_netdata_api_key(self, host_without_netdata):
+    def test_get_netdata_api_key(self, host_without_netdata: Host) -> None:
         host = host_without_netdata
         host.yum_save_state()
         host.call_plugin('netdata.py', 'install_netdata', {

--- a/tests/xapi_plugins/plugin_raid/test_raid.py
+++ b/tests/xapi_plugins/plugin_raid/test_raid.py
@@ -4,12 +4,14 @@ import logging
 
 from lib.host import Host
 
+from typing import Generator
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host > 8.2.
 
 @pytest.fixture(scope='module')
-def host_with_raid(host: Host):
+def host_with_raid(host: Host) -> Generator[Host, None, None]:
     dummy_raid = False
     if not host.file_exists('/dev/md127', regular_file=False):
         logging.info("> Host has no raids, creating one for tests")
@@ -29,6 +31,6 @@ def host_with_raid(host: Host):
         host.ssh('losetup -d /dev/loop1')
         host.ssh('rm -rf raid-1 raid-0')
 
-def test_check_raid_pool(host_with_raid):
+def test_check_raid_pool(host_with_raid: Host) -> None:
     host = host_with_raid
     host.call_plugin('raid.py', 'check_raid_pool')

--- a/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
+++ b/tests/xapi_plugins/plugin_smartctl/test_smartctl.py
@@ -2,11 +2,13 @@ import pytest
 
 import json
 
+from lib.host import Host
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host >= 8.3.
 
-def _call_plugin(host, fn):
+def _call_plugin(host: Host, fn: str) -> None:
     ret = host.call_plugin("smartctl.py", fn)
     try:
         json.loads(ret)
@@ -14,9 +16,9 @@ def _call_plugin(host, fn):
         pytest.fail("JSON string was expected but ValueError was raised")
 
 @pytest.mark.usefixtures("host_at_least_8_3")
-def test_smartctl_information(host):
+def test_smartctl_information(host: Host) -> None:
     _call_plugin(host, "information")
 
 @pytest.mark.usefixtures("host_at_least_8_3")
-def test_smartctl_health(host):
+def test_smartctl_health(host: Host) -> None:
     _call_plugin(host, "health")

--- a/tests/xapi_plugins/plugin_updater/test_updater.py
+++ b/tests/xapi_plugins/plugin_updater/test_updater.py
@@ -1,5 +1,7 @@
 import json
 
+from lib.host import Host
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host > 8.2.
@@ -7,10 +9,10 @@ import json
 # - access to XCP-ng RPM repository from hostA1
 
 class TestUpdate:
-    def test_check_update(self, host):
+    def test_check_update(self, host: Host) -> None:
         host.call_plugin('updater.py', 'check_update')
 
-    def test_update(self, host):
+    def test_update(self, host: Host) -> None:
         host.yum_save_state()
         host.call_plugin('updater.py', 'update')
 
@@ -19,7 +21,7 @@ class TestUpdate:
 
         host.yum_restore_saved_state()
 
-    def test_package_update(self, host_with_saved_yum_state):
+    def test_package_update(self, host_with_saved_yum_state: Host) -> None:
         host = host_with_saved_yum_state
         packages = host.get_available_package_versions('dummypkg')
         assert len(packages) == 2
@@ -34,7 +36,7 @@ class TestUpdate:
         assert host.is_package_installed(packages[1])
 
 class TestProxies:
-    def test_get_proxies(self, host):
+    def test_get_proxies(self, host: Host) -> None:
         proxies = json.loads(host.call_plugin('updater.py', 'get_proxies'))
         for repo in 'xcp-ng-base', 'xcp-ng-testing', 'xcp-ng-updates':
             assert repo in proxies

--- a/tests/xapi_plugins/plugin_zfs/conftest.py
+++ b/tests/xapi_plugins/plugin_zfs/conftest.py
@@ -1,23 +1,27 @@
 import pytest
 
-# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from lib.host import Host
+
+# Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
 from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped
 
-@pytest.fixture(scope='package')
-def host_without_zfs(host):
-    assert not host.file_exists('/usr/sbin/zpool'), \
-        "zfs must not be installed on the host at the beginning of the tests"
+from typing import Generator
 
 @pytest.fixture(scope='package')
-def host_with_zfs(host_without_zfs: Host, host_with_saved_yum_state: Host):
+def host_without_zfs(host: Host) -> Generator[None, None, None]:
+    assert not host.file_exists('/usr/sbin/zpool'), \
+        "zfs must not be installed on the host at the beginning of the tests"
+    yield
+
+@pytest.fixture(scope='package')
+def host_with_zfs(host_without_zfs: Host, host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host.yum_install(['zfs'])
     host.ssh('modprobe zfs')
     yield host
 
 @pytest.fixture(scope='package')
-def zpool_vol0(sr_disk_wiped, host_with_zfs: Host):
+def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None, None]:
     host_with_zfs.ssh(f'zpool create -f vol0 /dev/{sr_disk_wiped}')
     yield
     # teardown

--- a/tests/xapi_plugins/plugin_zfs/test_zfs.py
+++ b/tests/xapi_plugins/plugin_zfs/test_zfs.py
@@ -3,6 +3,8 @@ import pytest
 import json
 import logging
 
+from lib.host import Host
+
 # Requirements:
 # From --hosts parameter:
 # - host(A1): first XCP-ng host > 8.2 with an additional unused disk for the SR.
@@ -10,7 +12,7 @@ import logging
 # - access to XCP-ng RPM repository from hostA1
 
 @pytest.mark.usefixtures("zpool_vol0")
-def test_list_zfs_pools(host):
+def test_list_zfs_pools(host: Host) -> None:
     logging.info("List ZFS pools on host")
     res = host.call_plugin('zfs.py', 'list_zfs_pools')
     assert json.loads(res).get("vol0") is not None


### PR DESCRIPTION
This allows more validation both in the CI and when writing the tests in our IDEs.

This work was mostly done with AI, validated by the code checkers, and manually cleaned up by me.

<!-- start jj-vine stack -->
This PR is part of a stack containing 9 PRs:

1. `master`
2. #387
3. #398
4. #399
5. #400
6. #401
7. **"xapi,network: add type hints" (this PR)**
8. #403
9. #460
10. #476
<!-- end jj-vine stack -->