### PR TITLE
xen, guest_tools: add type hints

### DIFF
--- a/tests/guest_tools/win/conftest.py
+++ b/tests/guest_tools/win/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import logging
@@ -18,7 +20,7 @@ from lib.windows import (
 from lib.windows.guest_tools import install_guest_tools
 from lib.windows.other_tools import install_other_drivers
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Generator, Tuple
 
 @pytest.fixture(scope="module")
 def running_windows_vm_without_tools(imported_vm: VM) -> VM:
@@ -36,7 +38,9 @@ def running_windows_vm_without_tools(imported_vm: VM) -> VM:
 
 
 @pytest.fixture(scope="module")
-def unsealed_windows_vm_and_snapshot(running_windows_vm_without_tools: VM):
+def unsealed_windows_vm_and_snapshot(
+    running_windows_vm_without_tools: VM
+) -> Generator[Tuple[VM, Snapshot], None, None]:
     """Unseal VM and get its IP, then shut it down. Cache the unsealed state in a snapshot to save time."""
     vm = running_windows_vm_without_tools
     vm_shutdown_without_tools(vm)
@@ -46,7 +50,7 @@ def unsealed_windows_vm_and_snapshot(running_windows_vm_without_tools: VM):
 
 
 @pytest.fixture
-def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot]):
+def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot]) -> Generator[VM, None, None]:
     vm, snapshot = unsealed_windows_vm_and_snapshot
     vm.start()
     wait_for_vm_running_and_ssh_up_without_tools(vm)
@@ -55,7 +59,9 @@ def running_unsealed_windows_vm(unsealed_windows_vm_and_snapshot: Tuple[VM, Snap
 
 
 @pytest.fixture(scope="class")
-def vm_install_test_tools_per_test_class(unsealed_windows_vm_and_snapshot, guest_tools_iso: Dict[str, Any]):
+def vm_install_test_tools_per_test_class(
+    unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot], guest_tools_iso: Dict[str, Any]
+) -> Generator[VM, None, None]:
     vm, snapshot = unsealed_windows_vm_and_snapshot
     vm.start()
     wait_for_vm_running_and_ssh_up_without_tools(vm)
@@ -66,7 +72,7 @@ def vm_install_test_tools_per_test_class(unsealed_windows_vm_and_snapshot, guest
 
 
 @pytest.fixture
-def vm_install_test_tools_no_reboot(running_unsealed_windows_vm: VM, guest_tools_iso: Dict[str, Any]):
+def vm_install_test_tools_no_reboot(running_unsealed_windows_vm: VM, guest_tools_iso: Dict[str, Any]) -> VM:
     install_guest_tools(running_unsealed_windows_vm, guest_tools_iso, PowerAction.Nothing)
     return running_unsealed_windows_vm
 
@@ -76,12 +82,14 @@ def vm_install_test_tools_no_reboot(running_unsealed_windows_vm: VM, guest_tools
     ids=list(WIN_GUEST_TOOLS_ISOS.keys()),
     params=list(WIN_GUEST_TOOLS_ISOS.values()),
 )
-def guest_tools_iso(host: Host, request: pytest.FixtureRequest, nfs_iso_sr: SR):
+def guest_tools_iso(
+    host: Host, request: pytest.FixtureRequest, nfs_iso_sr: SR
+) -> Generator[Dict[str, Any], None, None]:
     yield from iso_create(host, nfs_iso_sr, request.param)
 
 
 @pytest.fixture(scope="module")
-def other_tools_iso(host: Host, nfs_iso_sr: SR):
+def other_tools_iso(host: Host, nfs_iso_sr: SR) -> Generator[Dict[str, Any], None, None]:
     yield from iso_create(host, nfs_iso_sr, OTHER_GUEST_TOOLS_ISO)
 
 
@@ -90,7 +98,7 @@ def vm_install_other_drivers(
     unsealed_windows_vm_and_snapshot: Tuple[VM, Snapshot],
     other_tools_iso: Dict[str, Any],
     request: pytest.FixtureRequest,
-):
+) -> Generator[Tuple[VM, Dict[str, Any]], None, None]:
     vm, snapshot = unsealed_windows_vm_and_snapshot
     param = request.param
     install_other_drivers(vm, other_tools_iso["name"], param)

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import logging
@@ -70,10 +72,10 @@ from typing import Any, Tuple
 @pytest.mark.multi_vms
 @pytest.mark.usefixtures("windows_vm")
 class TestGuestToolsWindows:
-    def test_drivers_detected(self, vm_install_test_tools_per_test_class: VM):
+    def test_drivers_detected(self, vm_install_test_tools_per_test_class: VM) -> None:
         pass
 
-    def test_vif_replug(self, vm_install_test_tools_per_test_class: VM):
+    def test_vif_replug(self, vm_install_test_tools_per_test_class: VM) -> None:
         vm = vm_install_test_tools_per_test_class
         for _iter in range(3):
             vifs = vm.vifs()
@@ -87,7 +89,7 @@ class TestGuestToolsWindows:
                 vif.plug()
             wait_for(vm.is_ssh_up, "Wait for SSH up")
 
-    def test_rss(self, vm_install_test_tools_per_test_class: VM):
+    def test_rss(self, vm_install_test_tools_per_test_class: VM) -> None:
         """
         Receive-side scaling is known to be broken on some driver versions.
 
@@ -98,7 +100,7 @@ class TestGuestToolsWindows:
         for vif in vifs:
             assert vif_has_rss(vif)
 
-    def test_reporting_after_xeniface_disable(self, vm_install_test_tools_per_test_class: VM):
+    def test_reporting_after_xeniface_disable(self, vm_install_test_tools_per_test_class: VM) -> None:
         vm = vm_install_test_tools_per_test_class
         for _iter in range(3):
             logging.info("Disable Xeniface")
@@ -109,7 +111,7 @@ class TestGuestToolsWindows:
             check_vm_distro(vm)
             check_vm_clipboard(vm)
 
-    def test_reporting_after_suspend(self, vm_install_test_tools_per_test_class: VM):
+    def test_reporting_after_suspend(self, vm_install_test_tools_per_test_class: VM) -> None:
         vm = vm_install_test_tools_per_test_class
         for _iter in range(3):
             vm.suspend(verify=True)
@@ -118,7 +120,7 @@ class TestGuestToolsWindows:
             check_vm_distro(vm)
             check_vm_clipboard(vm)
 
-    def test_xenvbd_unmap(self, vm_install_test_tools_per_test_class: VM):
+    def test_xenvbd_unmap(self, vm_install_test_tools_per_test_class: VM) -> None:
         """Xenvbd must always advertise unmap to allow migration between backends with different discard support."""
         vm = vm_install_test_tools_per_test_class
         trim_supported = strtobool(
@@ -127,7 +129,7 @@ Select-String "Trim Supported")''')
         )
         assert trim_supported
 
-    def test_xenvbd_ssd(self, vm_install_test_tools_per_test_class: VM):
+    def test_xenvbd_ssd(self, vm_install_test_tools_per_test_class: VM) -> None:
         """Xenvbd must always advertise as SSD to avoid unnecessary defragging by Windows."""
         vm = vm_install_test_tools_per_test_class
         is_ssd = strtobool(
@@ -144,7 +146,7 @@ Select-String "Trim Supported")''')
 @pytest.mark.multi_vms
 @pytest.mark.usefixtures("windows_vm")
 class TestGuestToolsWindowsDestructive:
-    def test_uninstall_tools(self, vm_install_test_tools_no_reboot: VM):
+    def test_uninstall_tools(self, vm_install_test_tools_no_reboot: VM) -> None:
         vm = vm_install_test_tools_no_reboot
         vm_shutdown_without_tools(vm)
         vm.start()
@@ -157,7 +159,7 @@ class TestGuestToolsWindowsDestructive:
         assert vm.are_windows_tools_uninstalled()
         check_vm_dns(vm)
 
-    def test_uninstall_tools_early(self, vm_install_test_tools_no_reboot: VM):
+    def test_uninstall_tools_early(self, vm_install_test_tools_no_reboot: VM) -> None:
         vm = vm_install_test_tools_no_reboot
         logging.info("Uninstall Windows PV drivers before rebooting")
         uninstall_guest_tools(vm, action=PowerAction.Reboot)
@@ -165,7 +167,7 @@ class TestGuestToolsWindowsDestructive:
 
     def test_install_with_other_tools(
         self, vm_install_other_drivers: Tuple[VM, dict[str, Any]], guest_tools_iso: dict[str, Any]
-    ):
+    ) -> None:
         vm, param = vm_install_other_drivers
         if param["upgradable"]:
             install_guest_tools(vm, guest_tools_iso, PowerAction.Reboot, check=False)
@@ -175,7 +177,7 @@ class TestGuestToolsWindowsDestructive:
             assert exitcode == ERROR_INSTALL_FAILURE
 
     @pytest.mark.usefixtures("uefi_vm")
-    def test_uefi_vm_suspend_refused_without_tools(self, running_unsealed_windows_vm: VM):
+    def test_uefi_vm_suspend_refused_without_tools(self, running_unsealed_windows_vm: VM) -> None:
         vm = running_unsealed_windows_vm
         with pytest.raises(SSHCommandFailed, match="lacks the feature"):
             vm.suspend()
@@ -183,7 +185,7 @@ class TestGuestToolsWindowsDestructive:
 
     # Test of the unplug rework, where the driver must remain activated even if the device ID changes.
     # Also serves as a "close-enough" test of vendor device toggling.
-    def test_toggle_device_id(self, running_unsealed_windows_vm: VM, guest_tools_iso: dict[str, Any]):
+    def test_toggle_device_id(self, running_unsealed_windows_vm: VM, guest_tools_iso: dict[str, Any]) -> None:
         vm = running_unsealed_windows_vm
         assert vm.param_get("platform", "device_id") == "0002"
         install_guest_tools(vm, guest_tools_iso, PowerAction.Shutdown, check=False)

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import logging
@@ -41,7 +43,7 @@ def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any], onboard: Literal[True]
     ...
 
 
-def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any], onboard: bool = False):
+def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any], onboard: bool = False) -> str | None:
     """
     Run XenClean from the provided guest tools.
 
@@ -80,10 +82,12 @@ def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any], onboard: bool = False)
         onboarding_phase = ONBOARDING_PHASES[int(exitcode)]
         logging.info(f"Onboarding phase: {onboarding_phase}")
         return onboarding_phase
+    else:
+        return None
 
 
 @pytest.fixture(scope="module")
-def onboarding_guest_tools_iso(guest_tools_iso):
+def onboarding_guest_tools_iso(guest_tools_iso: Dict[str, Any]) -> Dict[str, Any]:
     if not guest_tools_iso.get("onboard_family"):
         pytest.skip("Onboarding info not declared in data.py")
     return guest_tools_iso
@@ -92,24 +96,30 @@ def onboarding_guest_tools_iso(guest_tools_iso):
 @pytest.mark.multi_vms
 @pytest.mark.usefixtures("windows_vm")
 class TestXenClean:
-    def test_xenclean_without_tools(self, running_unsealed_windows_vm: VM, guest_tools_iso):
+    def test_xenclean_without_tools(
+        self, running_unsealed_windows_vm: VM, guest_tools_iso: Dict[str, Any]
+    ) -> None:
         vm = running_unsealed_windows_vm
         logging.info("XenClean with empty VM")
         run_xenclean(vm, guest_tools_iso)
         assert vm.are_windows_tools_uninstalled()
 
-    def test_xenclean_onboard_without_tools(self, running_unsealed_windows_vm: VM, onboarding_guest_tools_iso):
+    def test_xenclean_onboard_without_tools(self, running_unsealed_windows_vm: VM,
+                                            onboarding_guest_tools_iso: Dict[str, Any]) -> None:
         vm = running_unsealed_windows_vm
         logging.info("XenClean onboard with empty VM")
         assert run_xenclean(vm, onboarding_guest_tools_iso, onboard=True) == "ReadyForOnboard"
 
-    def test_xenclean_with_test_tools_early(self, vm_install_test_tools_no_reboot: VM, guest_tools_iso):
+    def test_xenclean_with_test_tools_early(
+        self, vm_install_test_tools_no_reboot: VM, guest_tools_iso: Dict[str, Any]
+    ) -> None:
         vm = vm_install_test_tools_no_reboot
         logging.info("XenClean with test tools (without reboot)")
         run_xenclean(vm, guest_tools_iso)
         assert vm.are_windows_tools_uninstalled()
 
-    def test_xenclean_with_test_tools(self, vm_install_test_tools_no_reboot: VM, guest_tools_iso):
+    def test_xenclean_with_test_tools(self, vm_install_test_tools_no_reboot: VM,
+                                      guest_tools_iso: Dict[str, Any]) -> None:
         vm = vm_install_test_tools_no_reboot
         vm.reboot()
         # HACK: In some cases, vm.reboot(verify=False) followed by vm.insert_cd() (as called by run_xenclean)
@@ -123,7 +133,8 @@ class TestXenClean:
         assert vm.are_windows_tools_uninstalled()
         check_vm_dns(vm)
 
-    def test_xenclean_onboard_with_test_tools(self, vm_install_test_tools_no_reboot: VM, onboarding_guest_tools_iso):
+    def test_xenclean_onboard_with_test_tools(self, vm_install_test_tools_no_reboot: VM,
+                                              onboarding_guest_tools_iso: Dict[str, Any]) -> None:
         vm = vm_install_test_tools_no_reboot
         vm.reboot()
         wait_for_vm_running_and_ssh_up_without_tools(vm)
@@ -133,7 +144,9 @@ class TestXenClean:
         logging.info("Check tools still working")
         assert vm.are_windows_tools_working()
 
-    def test_xenclean_with_other_tools(self, vm_install_other_drivers: Tuple[VM, Dict], guest_tools_iso):
+    def test_xenclean_with_other_tools(
+        self, vm_install_other_drivers: Tuple[VM, Dict[str, Any]], guest_tools_iso: Dict[str, Any]
+    ) -> None:
         vm, param = vm_install_other_drivers
         if param.get("vendor_device"):
             pytest.skip("Skipping XenClean with vendor device present")
@@ -146,8 +159,8 @@ class TestXenClean:
         check_vm_dns(vm)
 
     def test_xenclean_onboard_with_other_tools(
-        self, vm_install_other_drivers: Tuple[VM, Dict], onboarding_guest_tools_iso
-    ):
+        self, vm_install_other_drivers: Tuple[VM, Dict[str, Any]], onboarding_guest_tools_iso: Dict[str, Any]
+    ) -> None:
         vm, param = vm_install_other_drivers
         onboarding_phase = param.get("onboarding_phase")
         if not param.get("onboarding_phase"):

--- a/tests/xen/conftest.py
+++ b/tests/xen/conftest.py
@@ -8,8 +8,10 @@ from packaging import version
 from lib.host import Host
 from pkgfixtures import host_with_saved_yum_state
 
+from typing import Generator
+
 @pytest.fixture(scope="package")
-def host_with_hvm_fep(host: Host):
+def host_with_hvm_fep(host: Host) -> Generator[Host, None, None]:
     logging.info("Checking for HVM FEP support")
     xen_args = host.ssh('xl info xen_commandline').split()
     if 'hvm_fep' not in xen_args and 'hvm_fep=1' not in xen_args:
@@ -17,7 +19,7 @@ def host_with_hvm_fep(host: Host):
     yield host
 
 @pytest.fixture(scope="package")
-def host_with_dynamically_disabled_ept_sp(host: Host):
+def host_with_dynamically_disabled_ept_sp(host: Host) -> Generator[Host, None, None]:
     """
     Disable EPT superpages before running XTF.
 
@@ -30,7 +32,7 @@ def host_with_dynamically_disabled_ept_sp(host: Host):
     host.ssh('xl set-parameters ept=exec-sp')
 
 @pytest.fixture(scope="package")
-def host_with_git_and_gcc_and_py3(host_with_saved_yum_state: Host):
+def host_with_git_and_gcc_and_py3(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host_less_8_3 = host.xcp_version < version.parse("8.3")
     if host_less_8_3:
@@ -43,7 +45,7 @@ def host_with_git_and_gcc_and_py3(host_with_saved_yum_state: Host):
         host.ssh('rm /usr/bin/python3')
 
 @pytest.fixture(scope="package")
-def xtf_runner(host_with_git_and_gcc_and_py3: Host):
+def xtf_runner(host_with_git_and_gcc_and_py3: Host) -> Generator[str, None, None]:
     host = host_with_git_and_gcc_and_py3
     logging.info("Download and build XTF")
     tmp_dir = host.ssh('mktemp -d')
@@ -64,7 +66,7 @@ make -j$(nproc)
     host.ssh(f'rm -rf {tmp_dir}')
 
 @pytest.fixture(scope="package")
-def host_with_dom0_tests(host_with_saved_yum_state):
+def host_with_dom0_tests(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host.yum_install(['xen-dom0-tests'])
     yield host

--- a/tests/xen/test_misc.py
+++ b/tests/xen/test_misc.py
@@ -11,7 +11,7 @@ from lib.host import Host
 # - XCP-ng host
 
 # Check for a valid "Latest ChangeSet" trace in 'xl dmesg'
-def test_xen_changeset(host: Host):
+def test_xen_changeset(host: Host) -> None:
     changeset = host.ssh('xl dmesg | grep "Latest ChangeSet"')
     regexp = r'.*Latest ChangeSet:\s*(([^,]+),.*)'
 

--- a/tests/xen/test_ring0.py
+++ b/tests/xen/test_ring0.py
@@ -49,42 +49,42 @@ def do_execute_xst(host: Host, modname: str, testname: str | None = None) -> Non
 @pytest.mark.reboot  # host_with_ring0_tests
 @pytest.mark.usefixtures("host_with_ring0_tests")
 class TestRing0Tests:
-    def test_privcmd_restrict(self, host: Host):
+    def test_privcmd_restrict(self, host: Host) -> None:
         host.ssh("/usr/bin/privcmd-restrict_test")
 
-    def test_xst_alloc_balloon(self, host: Host):
+    def test_xst_alloc_balloon(self, host: Host) -> None:
         do_execute_xst(host, "alloc_balloon")
 
-    def test_xst_big_module(self, host: Host):
+    def test_xst_big_module(self, host: Host) -> None:
         do_execute_xst(host, "big_module")
 
     @pytest.mark.skip("may hang system with fifo evtchn")
-    def test_xst_evtchn_latency(self, host: Host):
+    def test_xst_evtchn_latency(self, host: Host) -> None:
         do_execute_xst(host, "evtchn_latency", "evtchn_lat")
 
     @pytest.mark.skip("only makes sense for 2l evtchn")
-    def test_xst_evtchn_limit(self, host: Host):
+    def test_xst_evtchn_limit(self, host: Host) -> None:
         do_execute_xst(host, "evtchn_limit")
 
-    def test_xst_evtchn_stress(self, host: Host):
+    def test_xst_evtchn_stress(self, host: Host) -> None:
         do_execute_xst(host, "evtchn_stress")
 
     @pytest.mark.skip("leaks event channels infinitely")
-    def test_xst_evtchn_unbind(self, host: Host):
+    def test_xst_evtchn_unbind(self, host: Host) -> None:
         do_execute_xst(host, "evtchn_unbind")
 
-    def test_xst_get_user_pages(self, host: Host):
+    def test_xst_get_user_pages(self, host: Host) -> None:
         host.ssh("modprobe xst_get_user_pages")
         try:
             host.ssh("/usr/bin/gup_test")
         finally:
             host.ssh("modprobe -r xst_get_user_pages", check=False)
 
-    def test_xst_grant_copy_perf(self, host: Host):
+    def test_xst_grant_copy_perf(self, host: Host) -> None:
         do_execute_xst(host, "grant_copy_perf", "gntcpy_perf")
 
     @pytest.mark.small_vm
-    def test_xst_ioemu_msi(self, host: Host, running_unix_vm: VM):
+    def test_xst_ioemu_msi(self, host: Host, running_unix_vm: VM) -> None:
         # TODO: validate MSI reception in guest
         vm = running_unix_vm
         domid = vm.param_get("dom-id")
@@ -98,7 +98,7 @@ class TestRing0Tests:
             host.ssh("modprobe -r xst_ioemu_msi", check=False)
 
     @pytest.mark.usefixtures("host_at_least_8_3")
-    def test_xst_livepatch(self, host_without_livepatch_loaded: Host):
+    def test_xst_livepatch(self, host_without_livepatch_loaded: Host) -> None:
         """
         This test loads a `livepatch_testee` module, and triggers the test
         function `test_function_default` by writing to
@@ -130,7 +130,7 @@ class TestRing0Tests:
         finally:
             host.ssh("modprobe -r livepatch_testee", check=False)
 
-    def test_xst_memory_leak(self, host: Host):
+    def test_xst_memory_leak(self, host: Host) -> None:
         if not host.file_exists("/sys/kernel/debug/kmemleak"):
             pytest.skip("CONFIG_DEBUG_KMEMLEAK is not set")
 
@@ -148,15 +148,15 @@ class TestRing0Tests:
         finally:
             host.ssh("modprobe -r xst_memory_leak", check=False)
 
-    def test_xst_pte_set_clear_flags(self, host: Host):
+    def test_xst_pte_set_clear_flags(self, host: Host) -> None:
         do_execute_xst(host, "pte_set_clear_flags")
 
-    def test_xst_ptwr_xchg(self, host: Host):
+    def test_xst_ptwr_xchg(self, host: Host) -> None:
         do_execute_xst(host, "ptwr_xchg")
 
-    def test_xst_set_memory_uc(self, host: Host):
+    def test_xst_set_memory_uc(self, host: Host) -> None:
         do_execute_xst(host, "set_memory_uc")
 
     @pytest.mark.skip("crashes the host, disabled by default")
-    def test_xst_soft_lockup(self, host: Host):
+    def test_xst_soft_lockup(self, host: Host) -> None:
         do_execute_xst(host, "soft_lockup")

--- a/tests/xen/test_xen_dom0_tests.py
+++ b/tests/xen/test_xen_dom0_tests.py
@@ -11,7 +11,7 @@ from lib.host import Host
 
 @pytest.mark.usefixtures("host_with_dom0_tests")
 class TestXenDom0Tests:
-    def test_dom0(self, host: Host):
+    def test_dom0(self, host: Host) -> None:
         metadata = host.ssh('cat /usr/share/xen-dom0-tests-metadata.json')
         tests = json.loads(metadata)["tests"]
         assert tests, "Test list must not be empty"

--- a/tests/xen/test_xtf.py
+++ b/tests/xen/test_xtf.py
@@ -3,6 +3,9 @@ import pytest
 import logging
 
 from lib.commands import SSHCommandFailed
+from lib.host import Host
+
+from typing import List
 
 # Requirements:
 # From --hosts parameter:
@@ -11,7 +14,7 @@ from lib.commands import SSHCommandFailed
 
 @pytest.mark.usefixtures("host_with_hvm_fep", "host_with_dynamically_disabled_ept_sp")
 class TestXtf:
-    _common_skips = [
+    _common_skips: List[str] = [
         # UMIP requires hardware support, that is a recent enough CPU
         'test-hvm32-umip',
         'test-hvm64-umip',
@@ -24,18 +27,18 @@ class TestXtf:
         'test-pv64-xsa-444',
     ]
 
-    def _extract_skipped_tests(self, output):
+    def _extract_skipped_tests(self, output: str) -> List[str]:
         skipped_tests = []
         for line in output.splitlines():
             if line.endswith(' SKIP'):
                 skipped_tests.append(line.split()[0])
         return skipped_tests
 
-    def test_self(self, host, xtf_runner):
+    def test_self(self, host: Host, xtf_runner: str) -> None:
         logging.info("Running selftest...")
         host.ssh(f'{xtf_runner} selftest -q --host')
 
-    def test_all(self, host, xtf_runner):
+    def test_all(self, host: Host, xtf_runner: str) -> None:
         logging.info("Running tests...")
         try:
             host.ssh(f'{xtf_runner} -aqq --host')


### PR DESCRIPTION
This allows more validation both in the CI and when writing the tests in our IDEs.

This work was mostly done with AI, validated by the code checkers, and manually cleaned up by me.

<!-- start jj-vine stack -->
This PR is part of a stack containing 9 PRs:

1. `master`
2. #387
3. #398
4. #399
5. #400
6. #401
7. #402
8. **"xen, guest_tools: add type hints" (this PR)**
9. #460
10. #476
<!-- end jj-vine stack -->