### PR TITLE
conftest: split vm-type fixtures into require and skip variants

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -123,8 +123,11 @@ def pytest_collection_modifyitems(items, config):
 
     markable_fixtures = [
         'uefi_vm',
+        'skip_if_not_uefi_vm',
         'unix_vm',
+        'skip_if_not_unix_vm',
         'windows_vm',
+        'skip_if_not_windows_vm',
         'hostA2',
         'hostB1',
         'unused_512B_disks',
@@ -660,7 +663,14 @@ def running_vm(started_vm):
 def unix_vm(imported_vm):
     vm = imported_vm
     if vm.is_windows:
-        pytest.skip("This test is only compatible with unix VMs.")
+        pytest.fail("This test requires a unix VM.")
+    yield vm
+
+@pytest.fixture(scope='module')
+def skip_if_not_unix_vm(imported_vm):
+    vm = imported_vm
+    if vm.is_windows:
+        pytest.skip("Skipping: this test is only compatible with unix VMs.")
     yield vm
 
 @pytest.fixture(scope="module")
@@ -672,14 +682,28 @@ def running_unix_vm(unix_vm, running_vm):
 def windows_vm(imported_vm):
     vm = imported_vm
     if not vm.is_windows:
-        pytest.skip("This test is only compatible with Windows VMs.")
+        pytest.fail("This test requires a Windows VM.")
+    yield vm
+
+@pytest.fixture(scope='module')
+def skip_if_not_windows_vm(imported_vm):
+    vm = imported_vm
+    if not vm.is_windows:
+        pytest.skip("Skipping: this test is only compatible with Windows VMs.")
     yield vm
 
 @pytest.fixture(scope='module')
 def uefi_vm(imported_vm):
     vm = imported_vm
     if not vm.is_uefi:
-        pytest.skip('This test requires an UEFI VM')
+        pytest.fail('This test requires a UEFI VM.')
+    yield vm
+
+@pytest.fixture(scope='module')
+def skip_if_not_uefi_vm(imported_vm):
+    vm = imported_vm
+    if not vm.is_uefi:
+        pytest.skip('Skipping: this test requires a UEFI VM.')
     yield vm
 
 @pytest.fixture(scope='session')

--- a/jobs.py
+++ b/jobs.py
@@ -268,7 +268,7 @@ JOBS = {
             "tests/uefi_sb/test_varstored_sb.py",
             "tests/uefi_sb/test_sb_state.py"
         ],
-        "markers": "not windows_vm",
+        "markers": "not windows_vm and not skip_if_not_windows_vm",
     },
     "sb-certificates": {
         "description": "tests certificate propagation to disk by XAPI, and to VMs by uefistored/varstored",
@@ -297,7 +297,7 @@ JOBS = {
             "--vm": "single/small_vm_windows",
         },
         "paths": ["tests/uefi_sb"],
-        "markers": "windows_vm",
+        "markers": "windows_vm or skip_if_not_windows_vm",
     },
     "sb-unix-multi": {
         "description": "checks basic Secure-Boot support on a variety of Unix VMs",
@@ -311,7 +311,7 @@ JOBS = {
             "--vm[]": "multi/uefi_unix",
         },
         "paths": ["tests/uefi_sb"],
-        "markers": "multi_vms and unix_vm",
+        "markers": "multi_vms and skip_if_not_unix_vm",
     },
     "sb-windows-multi": {
         "description": "checks basic Secure-Boot support on a variety of Windows VMs",
@@ -324,7 +324,7 @@ JOBS = {
             "--vm[]": "multi/uefi_windows",
         },
         "paths": ["tests/uefi_sb"],
-        "markers": "multi_vms and windows_vm",
+        "markers": "multi_vms and skip_if_not_windows_vm",
     },
     "tools-unix": {
         "description": "tests our unix guest tools on a single small VM",

--- a/tests/guest_tools/unix/test_guest_tools_unix.py
+++ b/tests/guest_tools/unix/test_guest_tools_unix.py
@@ -19,7 +19,7 @@ class State:
         self.vm_distro = None
 
 @pytest.mark.multi_vms
-@pytest.mark.usefixtures("unix_vm")
+@pytest.mark.usefixtures("skip_if_not_unix_vm")
 class TestGuestToolsUnix:
     @pytest.fixture(scope='class')
     def state(self):

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -66,7 +66,7 @@ from typing import Any, Tuple
 
 
 @pytest.mark.multi_vms
-@pytest.mark.usefixtures("windows_vm")
+@pytest.mark.usefixtures("skip_if_not_windows_vm")
 class TestGuestToolsWindows:
     def test_drivers_detected(self, vm_install_test_tools_per_test_class: VM):
         pass
@@ -96,7 +96,7 @@ class TestGuestToolsWindows:
 
 
 @pytest.mark.multi_vms
-@pytest.mark.usefixtures("windows_vm")
+@pytest.mark.usefixtures("skip_if_not_windows_vm")
 class TestGuestToolsWindowsDestructive:
     def test_uninstall_tools(self, vm_install_test_tools_no_reboot: VM):
         vm = vm_install_test_tools_no_reboot
@@ -130,7 +130,7 @@ class TestGuestToolsWindowsDestructive:
             exitcode = install_guest_tools(vm, guest_tools_iso, PowerAction.Nothing, check=False)
             assert exitcode == ERROR_INSTALL_FAILURE
 
-    @pytest.mark.usefixtures("uefi_vm")
+    @pytest.mark.usefixtures("skip_if_not_uefi_vm")
     def test_uefi_vm_suspend_refused_without_tools(self, running_unsealed_windows_vm: VM):
         vm = running_unsealed_windows_vm
         with pytest.raises(SSHCommandFailed, match="lacks the feature"):

--- a/tests/guest_tools/win/test_xenclean.py
+++ b/tests/guest_tools/win/test_xenclean.py
@@ -37,7 +37,7 @@ def run_xenclean(vm: VM, guest_tools_iso: Dict[str, Any]):
 
 
 @pytest.mark.multi_vms
-@pytest.mark.usefixtures("windows_vm")
+@pytest.mark.usefixtures("skip_if_not_windows_vm")
 class TestXenClean:
     def test_xenclean_without_tools(self, running_unsealed_windows_vm: VM, guest_tools_iso):
         vm = running_unsealed_windows_vm

--- a/tests/uefi_sb/test_uefistored_sb.py
+++ b/tests/uefi_sb/test_uefistored_sb.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.default_vm('mini-linux-x86_64-uefi')
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_less_than_8_3")
-@pytest.mark.usefixtures("pool_without_uefi_certs", "unix_vm")
+@pytest.mark.usefixtures("pool_without_uefi_certs", "skip_if_not_unix_vm")
 class TestGuestLinuxUEFISecureBoot:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):
@@ -125,7 +125,7 @@ class TestGuestLinuxUEFISecureBoot:
 
 
 @pytest.mark.usefixtures("host_less_than_8_3")
-@pytest.mark.usefixtures("pool_without_uefi_certs", "windows_vm")
+@pytest.mark.usefixtures("pool_without_uefi_certs", "skip_if_not_windows_vm")
 class TestGuestWindowsUEFISecureBoot:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):

--- a/tests/uefi_sb/test_varstored_sb.py
+++ b/tests/uefi_sb/test_varstored_sb.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.default_vm('mini-linux-x86_64-uefi')
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_at_least_8_3")
-@pytest.mark.usefixtures("unix_vm")
+@pytest.mark.usefixtures("skip_if_not_unix_vm")
 class TestGuestLinuxUEFISecureBoot:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):
@@ -129,7 +129,7 @@ class TestGuestLinuxUEFISecureBoot:
 
 
 @pytest.mark.usefixtures("host_at_least_8_3")
-@pytest.mark.usefixtures("windows_vm")
+@pytest.mark.usefixtures("skip_if_not_windows_vm")
 class TestGuestWindowsUEFISecureBoot:
     @pytest.fixture(autouse=True)
     def setup_and_cleanup(self, uefi_vm_and_snapshot):


### PR DESCRIPTION
unix_vm, windows_vm, and uefi_vm now call pytest.fail() if the VM is the wrong type, matching the expectation that these fixtures enforce a requirement. The new skip_if_not_unix_vm, skip_if_not_windows_vm, and skip_if_not_uefi_vm fixtures call pytest.skip() instead, for use in multi-VM jobs where different VMs types are expected and non-matching ones should be silently skipped rather than failed. So, updated all multi_vms-annotated classes to use the skip variants. The markable_fixtures list and jobs.py marker expressions are updated accordingly.