### PR TITLE
storage: Snapshot the VM multiple times before exporting/importing

### DIFF
--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -92,8 +92,9 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_ext_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_ext_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_ext_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_ext_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, ext_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -74,6 +74,10 @@ class TestEXTSR:
         xva_export_import(vm_on_ext_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_ext_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        xva_export_import(vm_on_ext_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, ext_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, ext_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -149,8 +149,9 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_lvm_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_lvm_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_lvm_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_lvm_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, lvm_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -142,6 +142,10 @@ class TestLVMSR:
         xva_export_import(vm_on_lvm_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_lvm_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        xva_export_import(vm_on_lvm_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, lvm_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, lvm_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/lvmohba/test_lvmohba_sr.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr.py
@@ -74,6 +74,10 @@ class TestLVMOHBASR:
         xva_export_import(vm_on_lvmohba_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_lvmohba_sr: VM, temp_large_dir: str, defer: Defer):
+        xva_export_import(vm_on_lvmohba_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, lvmohba_sr: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer):
         vdi_export_import(storage_test_vm, lvmohba_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -74,8 +74,9 @@ class TestLVMOISCSISR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_lvmoiscsi_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_lvmoiscsi_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_lvmoiscsi_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_lvmoiscsi_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, lvmoiscsi_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -76,6 +76,10 @@ class TestLVMOISCSISR:
         xva_export_import(vm_on_lvmoiscsi_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_lvmoiscsi_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        xva_export_import(vm_on_lvmoiscsi_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, lvmoiscsi_sr: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer) -> None:
         vdi_export_import(storage_test_vm, lvmoiscsi_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -124,8 +124,9 @@ class TestNFSSR:
     @pytest.mark.usefixtures('vm_ref')
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, dispatch_nfs: VM, compression: XVACompression) -> None:
-        xva_export_import(dispatch_nfs, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, dispatch_nfs: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(dispatch_nfs, compression, with_snapshot)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -135,6 +135,14 @@ class TestNFSSR:
         xva_export_import(dispatch_nfs, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.usefixtures('vm_ref')
+    @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
+    def test_xva_export_import_with_snapshot(self, dispatch_nfs: VM, temp_large_dir: str, defer: Defer) -> None:
+        if "NFS4" in dispatch_nfs.vdis[0].sr.get_name_label() and config.write_volume_cap > 20 * GiB:
+            pytest.skip("Skipping NFSv4 large VDI test (known performance issue)")
+        xva_export_import(dispatch_nfs, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)
     def test_vdi_export_import(self, storage_test_vm: VM, dispatch_nfs: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer) -> None:

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -211,6 +211,7 @@ def xva_export_import(vm: VM, compression: XVACompression, with_snapshot: bool) 
     vm.ssh("randstream generate -v --size 500MiB /root/data")
     vm.ssh("randstream validate -v --expected-checksum 24e905d6 /root/data")
 
+    snap1, snap2 = None, None
     if with_snapshot:
         snap1 = vm.snapshot()
         # Write new data to a particular sector after taking a snapshot
@@ -238,8 +239,9 @@ def xva_export_import(vm: VM, compression: XVACompression, with_snapshot: bool) 
         if imported_vm is not None:
             imported_vm.destroy()
         vm.host.ssh(f'rm -f {xva_path}')
-        if with_snapshot:
+        if snap1:
             snap1.destroy()
+        if snap2:
             snap2.destroy()
 
 def vdi_export_import(vm: VM, sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -201,7 +201,7 @@ def coalesce_integrity(vm: VM, vdi: VDI, vdi_op: CoalesceOperation) -> None:
 
 XVACompression = Literal['none', 'gzip', 'zstd']
 
-def xva_export_import(vm: VM, compression: XVACompression) -> None:
+def xva_export_import(vm: VM, compression: XVACompression, with_snapshot: bool) -> None:
     # The tests using this function are using specific fixtures to create the VM on the expected SR
     # In consequence, we can't use the storage_test_vm, so we have to start the VM explicitly and install randstream
     vm.start()
@@ -210,6 +210,16 @@ def xva_export_import(vm: VM, compression: XVACompression) -> None:
     # 500MiB, so we have some data to check and some empty spaces in the exported image
     vm.ssh("randstream generate -v --size 500MiB /root/data")
     vm.ssh("randstream validate -v --expected-checksum 24e905d6 /root/data")
+
+    if with_snapshot:
+        snap1 = vm.snapshot()
+        # Write new data to a particular sector after taking a snapshot
+        vm.ssh("randstream generate --seed 1 -v --position 300MiB --size 100MiB /root/data")
+        vm.ssh("randstream validate -v --expected-checksum 67ee1057 /root/data")
+        snap2 = vm.snapshot()
+        vm.ssh("randstream generate --seed 2 -v --position 100MiB --size 100MiB /root/data")
+        vm.ssh("randstream validate -v --expected-checksum f6c6abc1 /root/data")
+
     vm.shutdown(verify=True)
     xva_path = f'/tmp/{vm.uuid}.xva'
     imported_vm = None
@@ -222,11 +232,15 @@ def xva_export_import(vm: VM, compression: XVACompression) -> None:
         imported_vm = vm.host.import_vm(xva_path, vm.vdis[0].sr.uuid)
         imported_vm.start()
         imported_vm.wait_for_vm_running_and_ssh_up()
-        imported_vm.ssh("randstream validate -v --expected-checksum 24e905d6 /root/data")
+        expected_checksum = 'f6c6abc1' if with_snapshot else '24e905d6'
+        imported_vm.ssh(f"randstream validate -v --expected-checksum {expected_checksum} /root/data")
     finally:
         if imported_vm is not None:
             imported_vm.destroy()
         vm.host.ssh(f'rm -f {xva_path}')
+        if with_snapshot:
+            snap1.destroy()
+            snap2.destroy()
 
 def vdi_export_import(vm: VM, sr: SR, image_format: ImageFormat) -> None:
     vdi: VDI | None = sr.create_vdi(image_format=image_format)

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -7,6 +7,7 @@ from lib import config
 from lib.commands import SSHCommandFailed
 from lib.common import QCOW2_MAX, VHD_MAX, Defer, MiB, PackageManagerEnum, strtobool, wait_for
 from lib.host import Host
+from lib.snapshot import Snapshot
 from lib.sr import SR
 from lib.vdi import VDI, ImageFormat
 from lib.vm import VM
@@ -225,10 +226,15 @@ def coalesce_integrity(vm: VM, vdi: VDI, vdi_op: CoalesceOperation, defer: Defer
 
 XVACompression = Literal['none', 'gzip', 'zstd']
 
-def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir: str, defer: Defer) -> None:
+def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir: str,
+                      defer: Defer, *, with_snapshot=False) -> None:
     # clone the vm, so we can resize the disk without affecting the vm from the fixture
     vm: VM | None = source_vm.clone()
+    snap1: Snapshot | None = None
+    snap2: Snapshot | None = None
     defer(lambda: vm.destroy() if vm is not None else None)
+    defer(lambda: snap1.destroy() if snap1 is not None else None)
+    defer(lambda: snap2.destroy() if snap2 is not None else None)
     assert vm is not None
     host = vm.host
     sr = vm.vdis[0].sr
@@ -260,6 +266,17 @@ def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir
 
     checksum = randstream(vm, f'generate --size {stream_size} /root/data')
     randstream(vm, f'validate --expected-checksum {checksum} /root/data')
+
+    if with_snapshot:
+        snap1 = vm.snapshot()
+        # Write new data to a particular sector after taking a snapshot
+        vm.ssh("randstream generate --seed 1 -v --position 300MiB --size 100MiB /root/data")
+        vm.ssh("randstream validate -v --expected-checksum f797ab33 /root/data")
+        snap2 = vm.snapshot()
+        vm.ssh("randstream generate --seed 2 -v --position 100MiB --size 100MiB /root/data")
+        vm.ssh("randstream validate -v --expected-checksum 60db5b9f /root/data")
+        checksum = '60db5b9f'
+
     vm.shutdown(verify=True)
 
     xva_path = f'{temp_large_dir}/{vm.uuid}.xva'

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -264,18 +264,21 @@ def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir
     else:
         stream_size = 500 * MiB
 
-    checksum = randstream(vm, f'generate --size {stream_size} /root/data')
-    randstream(vm, f'validate --expected-checksum {checksum} /root/data')
+    file_size = (stream_size // 3) // 32768 * 32768
+    checksum1 = randstream(vm, f'generate --size {file_size} /root/data1')
+    randstream(vm, f'validate --expected-checksum {checksum1} /root/data1')
 
     if with_snapshot:
         snap1 = vm.snapshot()
-        # Write new data to a particular sector after taking a snapshot
-        vm.ssh("randstream generate --seed 1 -v --position 300MiB --size 100MiB /root/data")
-        vm.ssh("randstream validate -v --expected-checksum f797ab33 /root/data")
+
+    checksum2 = randstream(vm, f'generate --size {file_size} /root/data2')
+    randstream(vm, f'validate --expected-checksum {checksum2} /root/data2')
+
+    if with_snapshot:
         snap2 = vm.snapshot()
-        vm.ssh("randstream generate --seed 2 -v --position 100MiB --size 100MiB /root/data")
-        vm.ssh("randstream validate -v --expected-checksum 60db5b9f /root/data")
-        checksum = '60db5b9f'
+
+    checksum3 = randstream(vm, f'generate --size {file_size} /root/data3')
+    randstream(vm, f'validate --expected-checksum {checksum3} /root/data3')
 
     vm.shutdown(verify=True)
 
@@ -301,7 +304,9 @@ def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir
 
     imported_vm.start()
     imported_vm.wait_for_vm_running_and_ssh_up()
-    randstream(imported_vm, f'validate --expected-checksum {checksum} /root/data')
+    randstream(imported_vm, f'validate --expected-checksum {checksum1} /root/data1')
+    randstream(imported_vm, f'validate --expected-checksum {checksum2} /root/data2')
+    randstream(imported_vm, f'validate --expected-checksum {checksum3} /root/data3')
 
 def vdi_export_import(vm: VM, sr: SR, image_format: ImageFormat, temp_large_dir: str, defer: Defer) -> None:
     vdi_src: VDI | None = sr.create_vdi(image_format=image_format, virtual_size=config.volume_size)

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -109,8 +109,9 @@ class TestXFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_xfs_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_xfs_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_xfs_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_xfs_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, xfs_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -85,6 +85,10 @@ class TestXFSSR:
         xva_export_import(vm_on_xfs_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_xfs_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        xva_export_import(vm_on_xfs_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, xfs_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, xfs_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -106,8 +106,9 @@ class TestZFSSR:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_zfs_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_zfs_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_zfs_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_zfs_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, zfs_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -87,6 +87,10 @@ class TestZFSSR:
         xva_export_import(vm_on_zfs_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_zfs_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        xva_export_import(vm_on_zfs_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
+    @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, zfs_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, zfs_sr, image_format, temp_large_dir, defer)

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -71,8 +71,9 @@ class TestZfsvolVm:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
-    def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression) -> None:
-        xva_export_import(vm_on_zfsvol_sr, compression)
+    @pytest.mark.parametrize("with_snapshot", [True, False])
+    def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression, with_snapshot: bool) -> None:
+        xva_export_import(vm_on_zfsvol_sr, compression, with_snapshot)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, zfsvol_sr: SR, image_format: ImageFormat) -> None:

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -85,6 +85,13 @@ class TestZfsvolVm:
             pytest.skip("Skipping large VDI test (known performance issue)")
         xva_export_import(vm_on_zfsvol_sr, compression, temp_large_dir, defer)
 
+    @pytest.mark.xfail # Failing on Exception "Only snapshots can be cloned!"
+    @pytest.mark.small_vm
+    def test_xva_export_import_with_snapshot(self, vm_on_zfsvol_sr: VM, temp_large_dir: str, defer: Defer) -> None:
+        if config.write_volume_cap > 20 * GiB:
+            pytest.skip("Skipping large VDI test (known performance issue)")
+        xva_export_import(vm_on_zfsvol_sr, 'zstd', temp_large_dir, defer, with_snapshot=True)
+
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, zfsvol_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:


### PR DESCRIPTION
Adds a new with_snapshot parameter which, if enabled, snapshots the VM
twice before the export/import cycle.

This tests for the bug we are seeing now with QCOW2, where the full
chain of snapshots is not considered.

Leave holes in each snapshot by writing to independent sections to verify
all the snapshot's bitmaps are consulted.

---

This test passes with the current pre-build of xapi: [xapi-26.1.3-1.6~fixsnapexport.6.xcpng8.3](https://koji.xcp-ng.org/buildinfo?buildID=5455)