### PR TITLE
Tools/update - Also update secondary hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,12 +575,14 @@ This command performs an update operation on remote targets.
 uv run scripts/tools.py update -H primary1 primary2
 ```
 
-For each primary target :
+For each pool target :
 
-1. Clean cached metadata
-2. Update with repository manager (yum): Optionally enables repositories
-3. Reboot
-4. Get attached secondary hosts and repeats three previous steps for each secondary
+1. Update master (primary) host of the pool:
+  * Clean cached metadata
+  * Update with repository manager (yum): Optionally enables repositories
+  * Reboot
+2. Get attached secondary hosts of the pool
+  * Repeat step `1.` for each secondary
 
 **Inventory file**
 

--- a/lib/tools/cli.py
+++ b/lib/tools/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from lib.common import HostAddress
 from lib.tools import logger
 from lib.tools.inventory import into_inventory, load_inventory
-from lib.tools.tasks.update import update_all
+from lib.tools.tasks.update import update_pools
 
 def _command_update(args: argparse.Namespace) -> None:
     if args.inventory:
@@ -19,7 +19,7 @@ def _command_update(args: argparse.Namespace) -> None:
     else:
         inventory = into_inventory(args.hosts, args.repos)
 
-    update_all(inventory)
+    update_pools(inventory)
 
 
 def cli() -> None:
@@ -33,12 +33,17 @@ def cli() -> None:
     # subparser - command: update
     subparser_cmd_update = subparsers.add_parser(
         name="update",
-        description="Run update tasks on target(s)",
-        help="Run update tasks on target(s)",
+        description="Run update tasks on target pools",
+        help="Run update tasks on target pools",
     )
     cmd_update_excl_grp = subparser_cmd_update.add_mutually_exclusive_group(required=True)
     cmd_update_excl_grp.add_argument(
-        "-H", "--hosts", type=HostAddress, metavar="HOST", nargs="+", help="Hostname(s) or ip address(es) of target(s)"
+        "-H",
+        "--hosts",
+        type=HostAddress,
+        metavar="HOST",
+        nargs="+",
+        help="Address (hostname|ip) of the master host in pool",
     )
     cmd_update_excl_grp.add_argument("-i", "--inventory", type=Path, help="Use an hosts inventory file")
     subparser_cmd_update.add_argument(

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 
-from lib.pool import Pool
+from lib.pool import NotAMasterHostError, Pool
 
 from .. import logger
 
@@ -15,14 +15,20 @@ def update_pools(inventory: dict) -> None:
 
     .. note:: Host must be a master
 
-        Throws error if hosts are not master (primary).
+        Every non-master hosts will be ignored
 
     :param dict inventory:
         Each host (key) holds its own config data (values, eg: `enablerepos`).
     """
     logger.debug(f"Inventory: {inventory}")
     # init related pools
-    pools = [Pool(h) for h in inventory]
+    pools = []
+    for h in inventory:
+        try:
+            p = Pool(h)
+            pools.append(p)
+        except NotAMasterHostError:
+            logger.warning(f"[{h}] Skipping: not a master host")
 
     with ThreadPoolExecutor() as executor:
         for p in pools:

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -10,15 +10,15 @@ from lib.pool import Pool
 
 from .. import logger
 
-def update_all(inventory: dict[str, dict[str, list[str]]]) -> None:
-    """Updates all master (primary) hosts.
+def update_pools(inventory: dict) -> None:
+    """Updates hosts in pool(s).
 
     .. note:: Host must be a master
 
         Throws error if hosts are not master (primary).
 
     :param dict inventory:
-        Each host (key) holds its own config data (values).
+        Each host (key) holds its own config data (values, eg: `enablerepos`).
     """
     logger.debug(f"Inventory: {inventory}")
     # init related pools

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -13,9 +13,11 @@ from .. import logger
 def update_pools(inventory: dict) -> None:
     """Updates hosts in pool(s).
 
-    .. note:: Host must be a master
+    .. note::
 
-        Every non-master hosts will be ignored
+        Every non-master hosts in inventory will be ignored
+
+    *Update master hosts declared in inventory first, then, update secondary hosts attached to each master.*
 
     :param dict inventory:
         Each host (key) holds its own config data (values, eg: `enablerepos`).
@@ -33,3 +35,12 @@ def update_pools(inventory: dict) -> None:
     with ThreadPoolExecutor() as executor:
         for p in pools:
             executor.submit(p.master.update, inventory[p.master.hostname_or_ip]["enablerepos"])
+
+    # secondary hosts
+    with ThreadPoolExecutor() as executor:
+        for p in pools:
+            # omit first item because it is a primary (master)
+            for h in p.hosts[1:]:
+                # repos are the same as the primary (master)
+                repos = inventory[p.master.hostname_or_ip]["enablerepos"]
+                executor.submit(h.update, repos)


### PR DESCRIPTION
With this PR the script `tools/update` can now update secondary hosts too.

Previously, only master (primary) hosts were updated.

In this PR, we keep the same way to run multiprocessing (like primary hosts).