### PR TITLE
Update randstream to 0.5.0

### DIFF
--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -155,10 +155,10 @@ print(sr_ref)
 
 def install_randstream(vm: VM) -> None:
     BASE_URL = 'https://github.com/xcp-ng/randstream/releases/download'
-    VERSION = '0.4.1'
+    VERSION = '0.5.0'
     CHECKSUM = {
-        'Linux': '2a49ec6492a826cc9d4a69556041dad6dbea0051039f41f8de765bd4fb560e54',
-        'FreeBSD': '07362e6ced58f3dcf0676500775df401ed475b2e594a75a7949e4b2c1ca4775c',
+        'Linux': '31ece6ea8f605aa3046609b37c72bdc11b39ee5942e8a0a8e2a052c50df00026',
+        'FreeBSD': '12fcaad99d892963af84f2a3861a7b38a14e96cc6b3a3e45d78fb76a69b421f5',
     }
     TARGET_TRIPLE = {
         'Linux': 'x86_64-unknown-linux-musl',


### PR DESCRIPTION
This version adds progress report even when the standard error is not a tty, which is convenient when working with large volumes.

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. **"Update randstream to 0.5.0" (this PR) → #447**
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->