### PR TITLE
host: include mdadm RAID devices in disk detection

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -688,9 +688,17 @@ class Host:
 
     def disks(self) -> list[Host.BlockDeviceInfo]:
         """ List of BlockDeviceInfo for all disks. """
+        # store the names of the parent devices to filter out the devices with children
+        pknames = set(disk['pkname'] for disk in self.block_devices_info if disk['pkname'])
         # filter out partitions from block_devices
-        return sorted((disk for disk in self.block_devices_info if not disk["pkname"]),
-                      key=lambda disk: disk["name"])
+        return sorted(
+            (
+                disk
+                for disk in self.block_devices_info
+                if (not disk["pkname"] or disk['type'] == 'raid0') and disk['kname'] not in pknames
+            ),
+            key=lambda disk: disk["name"],
+        )
 
     def disk_is_available(self, disk: DiskDevName) -> bool:
         """


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. **"host: include mdadm RAID devices in disk detection" (this PR) → #437**
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->