### PR TITLE
storage: avoid writing the whole device in migration tests

### DIFF
--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -53,7 +53,7 @@ def cold_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Host, dest
     vdi_name: str | None = None
     integrity_check = not vm.is_windows
     dev = ""
-    checksum = ""
+    checksums = ('', '', '')
 
     if integrity_check:
         # the vdi will be destroyed with the vm
@@ -64,10 +64,8 @@ def cold_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Host, dest
         vm.wait_for_vm_running_and_ssh_up()
         install_randstream(vm)
         dev = f'/dev/{vbd.param_get("device")}'
-        logging.info(f"Generate {dev} content")
-        checksum = randstream(vm, f'generate {dev}')
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        checksums = partially_populate_device(vm, dev, config.volume_size)
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
         vm.shutdown(verify=True)
 
     assert vm.is_halted()
@@ -81,8 +79,7 @@ def cold_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Host, dest
     vm.wait_for_os_booted()
     if integrity_check:
         vm.wait_for_vm_running_and_ssh_up()
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
     vm.shutdown(verify=True)
 
     # Migrate it back to the provenance SR
@@ -94,8 +91,7 @@ def cold_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Host, dest
     vm.wait_for_os_booted()
     if integrity_check:
         vm.wait_for_vm_running_and_ssh_up()
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
     vm.shutdown(verify=True)
 
     if vdi_name is not None:

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -102,7 +102,7 @@ def live_storage_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Ho
     vdi_name: str | None = None
     integrity_check = not vm.is_windows
     dev = ""
-    checksum = ""
+    checksums = ('', '', '')
     vbd = None
 
     if integrity_check:
@@ -118,26 +118,22 @@ def live_storage_migration_then_come_back(vm: VM, prov_host: Host, dest_host: Ho
         install_randstream(vm)
         assert vbd is not None
         dev = f'/dev/{vbd.param_get("device")}'
-        logging.info(f"Generate {dev} content")
-        randstream(vm, f'generate {dev}')
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        checksums = partially_populate_device(vm, dev, config.volume_size)
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
 
     # Move the VM to another host of the pool
     vm.migrate(dest_host, dest_sr)
     wait_for(lambda: vm.all_vdis_on_sr(dest_sr), "Wait for all VDIs on destination SR")
     wait_for(lambda: vm.is_running_on_host(dest_host), "Wait for VM to be running on destination host")
     if integrity_check:
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
 
     # Migrate it back to the provenance SR
     vm.migrate(prov_host, prov_sr)
     wait_for(lambda: vm.all_vdis_on_sr(prov_sr), "Wait for all VDIs back on provenance SR")
     wait_for(lambda: vm.is_running_on_host(prov_host), "Wait for VM to be running on provenance host")
     if integrity_check:
-        logging.info(f"Validate {dev}")
-        randstream(vm, f'validate --expected-checksum {checksum} {dev}')
+        validate_partially_populated_device(vm, dev, config.volume_size, checksums)
 
     vm.shutdown(verify=True)
 


### PR DESCRIPTION
<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. **"storage: avoid writing the whole device in migration tests" (this PR) → #449**
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->