### PR TITLE
storage: test full device write

### DIFF
--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -4,6 +4,7 @@ from .storage import (
     XVACompression,
     coalesce_integrity,
     cold_migration_then_come_back,
+    full_vdi_write,
     install_randstream,
     live_storage_migration_then_come_back,
     randstream,

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -16,6 +16,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     try_to_create_sr_with_missing_device,
     vdi_export_import,
     vdi_is_open,
@@ -100,6 +101,10 @@ class TestEXTSR:
     def test_vdi_export_import(self, storage_test_vm: VM, ext_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, ext_sr, image_format, temp_large_dir, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_ext_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_ext_sr, defer)
 
     # *** tests with reboots (longer tests).
 

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -16,6 +16,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     try_to_create_sr_with_missing_device,
     vdi_export_import,
     vdi_is_open,
@@ -146,6 +147,10 @@ class TestLVMSR:
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
     def test_coalesce(self, storage_test_vm: VM, vdi_on_lvm_sr: VDI, vdi_op: CoalesceOperation, defer: Defer) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_lvm_sr, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_lvm_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_lvm_sr, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -10,6 +10,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     vdi_export_import,
     vdi_is_open,
     xva_export_import,
@@ -72,6 +73,10 @@ class TestLVMOISCSISR:
     def test_coalesce(self, storage_test_vm: 'VM', vdi_on_lvmoiscsi_sr: 'VDI', vdi_op: CoalesceOperation,
                       defer: Defer) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_lvmoiscsi_sr, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_lvmoiscsi_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_lvmoiscsi_sr, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -13,6 +13,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     vdi_export_import,
     vdi_is_open,
     xva_export_import,
@@ -118,6 +119,10 @@ class TestNFSSR:
     @pytest.mark.parametrize('vdi_op', ['snapshot', 'clone'])
     def test_coalesce(self, storage_test_vm: VM, dispatch_nfs: VDI, vdi_op: CoalesceOperation, defer: Defer) -> None:
         coalesce_integrity(storage_test_vm, dispatch_nfs, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_nfs_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_nfs_sr, defer)
 
     @pytest.mark.small_vm
     # Make sure this fixture is called before the parametrized one

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -335,3 +335,14 @@ def vdi_export_import(vm: VM, sr: SR, image_format: ImageFormat, temp_large_dir:
     dev = f'/dev/{vbd.param_get("device")}'
 
     validate_partially_populated_device(vm, dev, config.volume_size, checksums)
+
+def full_vdi_write(vm: VM, vdi: VDI, defer: Defer):
+    vdi.get_virtual_size()
+    vbd = vm.connect_vdi(vdi)
+    defer(lambda: vm.disconnect_vdi(vdi))
+
+    dev = f'/dev/{vbd.param_get("device")}'
+    install_randstream(vm)
+
+    checksum = randstream(vm, f'generate {dev}')
+    randstream(vm, f'validate --expected-checksum {checksum} {dev}')

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -16,6 +16,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     vdi_export_import,
     vdi_is_open,
     xva_export_import,
@@ -106,6 +107,10 @@ class TestXFSSR:
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
     def test_coalesce(self, storage_test_vm: VM, vdi_on_xfs_sr: VDI, vdi_op: CoalesceOperation, defer: Defer) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_xfs_sr, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_xfs_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_xfs_sr, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -16,6 +16,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     vdi_export_import,
     vdi_is_open,
     xva_export_import,
@@ -103,6 +104,10 @@ class TestZFSSR:
     @pytest.mark.parametrize("vdi_op", ["snapshot", "clone"])
     def test_coalesce(self, storage_test_vm: VM, vdi_on_zfs_sr: VDI, vdi_op: CoalesceOperation, defer: Defer) -> None:
         coalesce_integrity(storage_test_vm, vdi_on_zfs_sr, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_zfs_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_zfs_sr, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -15,6 +15,7 @@ from tests.storage import (
     ImageFormat,
     XVACompression,
     coalesce_integrity,
+    full_vdi_write,
     vdi_export_import,
     xva_export_import,
 )
@@ -77,6 +78,10 @@ class TestZfsvolVm:
     def test_coalesce(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, vdi_op: CoalesceOperation, defer: Defer) \
             -> None:
         coalesce_integrity(storage_test_vm, vdi_on_zfsvol_sr, vdi_op, defer)
+
+    @pytest.mark.small_vm
+    def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, defer: Defer):
+        full_vdi_write(storage_test_vm, vdi_on_zfsvol_sr, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])


### PR DESCRIPTION
With most test now writing only a small amount of data to the devices,
we need these new test to validate that we can write on the whole
device.

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. **"storage: test full device write" (this PR) → #452**
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->