### PR TITLE
Tools/update - add nested mark in inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ For each pool target :
 2. Get attached secondary hosts of the pool
   * Repeat step `1.` for each secondary
 
+It is possible to mark target as *"nested"* (XCP-ng inside VM). *See inventory example below*
+
 **Inventory file**
 
 `update` command can read an inventory file in [TOML v1.0.0](https://toml.io/en/v1.0.0) format:
@@ -603,6 +605,7 @@ Take a look at an example inventory file:
 # my_inventory.toml
 
 [all]
+nested = true
 enablerepos = ["xcp-ng-base"]
 
 [servers]

--- a/lib/tools/cli.py
+++ b/lib/tools/cli.py
@@ -17,7 +17,7 @@ def _command_update(args: argparse.Namespace) -> None:
     if args.inventory:
         inventory = load_inventory(args.inventory)
     else:
-        inventory = into_inventory(args.hosts, args.repos)
+        inventory = into_inventory(args.hosts, args.repos, args.nested)
 
     update_pools(inventory)
 
@@ -52,6 +52,9 @@ def cli() -> None:
         action="append",
         dest="repos",
         help="repositories to enable when updating",
+    )
+    subparser_cmd_update.add_argument(
+        "--nested", action="store_true", default=False, help="Indicate whether hosts are nested or not"
     )
     subparser_cmd_update.set_defaults(func=_command_update)
 

--- a/lib/tools/inventory.py
+++ b/lib/tools/inventory.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 from lib.common import HostAddress
 
-def load_inventory(inventory_path: Path) -> dict[str, dict[str, list[str]]]:
+def load_inventory(inventory_path: Path) -> dict[str, dict[str, list[str] | bool]]:
     """Create an inventory object from loaded inventory file."""
-    inventory: dict[str, dict[str, list[str]]] = {}
+    inventory: dict[str, dict[str, list[str] | bool]] = {}
 
     with open(inventory_path, "rb") as f:
         data = tomllib.load(f)
@@ -18,23 +18,31 @@ def load_inventory(inventory_path: Path) -> dict[str, dict[str, list[str]]]:
     servers = data.get("servers", [])
 
     for server, config in servers.items():
+        nested = config.get("nested", None)
+        # We can't use 'False' as fallback value here, because 'False' is falsy...
+        if nested is None:
+            nested = all.get("nested", False)
         repos = config.get("enablerepos", [])
         host = {
+            "nested": nested,
             "enablerepos": repos or all.get("enablerepos", [])
         }
         inventory[server] = host
 
     return inventory
 
-def into_inventory(hosts: list[HostAddress], enablerepos: list[str]) -> dict[HostAddress, dict[str, list[str]]]:
+def into_inventory(
+    hosts: list[HostAddress], enablerepos: list[str], nested: bool
+) -> dict[HostAddress, dict[str, list[str] | bool]]:
     """Create an inventory object from arguments.
 
     Basically, it is used as compatibility when we don't want inventory from file.
     """
-    inventory: dict[HostAddress, dict[str, list[str]]] = {}
+    inventory: dict[HostAddress, dict[str, list[str] | bool]] = {}
 
     for h in hosts:
-        host = {
+        host: dict[str, list[str] | bool] = {
+            "nested": nested or False,
             "enablerepos": enablerepos or [],
         }
         inventory[h] = host


### PR DESCRIPTION
Add `nested = true|false` in inventory to prepare snapshot creation.

This new "nested" mark in inventory allow me to differentiate physical hosts from nested hosts to perform snapshot creation accordingly.