### PR TITLE
tools/update: move update_host into Host class

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -450,6 +450,26 @@ class Host:
 
         return self.ssh(base_command)
 
+    def update(self, enablerepos: list[str] = [], reboot: bool = True):
+        """Updates current host.
+
+        An helper function that wraps update tasks on current host.
+
+        :param list[str] enablerepos:
+            Repositories to enable when updating.
+        :param bool reboot:
+            Choose to reboot or not after update (default: True).
+        """
+        logging.info(f"[{self}] Updating...")
+
+        self.yum_clean_metadata()
+        self.yum_update(enablerepos=enablerepos)
+        if reboot:
+            # Everything's ok, just reboot
+            self.reboot(verify=True)
+
+        logging.info(f"[{self}] Updated successfully!")
+
     def restart_toolstack(self, verify=False):
         logging.info("Restart toolstack on host %s" % self)
         self.ssh(['xe-toolstack-restart'])

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -4,7 +4,6 @@ This module is intended for performing update actions on existing remote targets
 """
 from concurrent.futures import ThreadPoolExecutor
 
-from lib.host import Host
 from lib.pool import Pool
 
 from .. import logger
@@ -25,24 +24,4 @@ def update_all(inventory: dict) -> None:
 
     with ThreadPoolExecutor() as executor:
         for p in pools:
-            executor.submit(update_host, p.master, inventory[p.master.hostname_or_ip]["enablerepos"])
-
-
-def update_host(host: Host, enablerepos: list[str] = []):
-    """Updates the target host.
-
-    An helper function that wraps update tasks on specific host.
-
-    :param :py:class:`lib.host.Host` host:
-        Target host to update.
-    :param list[str] enablerepos:
-        Repositories to enable when updating.
-    """
-    logger.info(f"[{host}] Updating...")
-
-    host.yum_clean_metadata()
-    host.yum_update(enablerepos=enablerepos)
-    # Everything's ok, just reboot
-    host.reboot(verify=True)
-
-    logger.info(f"[{host}] Updated successfully!")
+            executor.submit(p.master.update, inventory[p.master.hostname_or_ip]["enablerepos"])


### PR DESCRIPTION
Instead of an external function, update should live inside Host class.

With this PR, I move function `update_host` from module `lib/tools/update.py` into class `Host`. IMO, this change fits well the existing "object model" in `lib/`.