### PR TITLE
tools/update - add a new arg to handle hosting pool (physical)

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,7 @@ Take a look at an example inventory file:
 
 [all]
 repositories = ["xcp-ng-base"]
+hosting_pool = "A"
 
 [hosts]
 
@@ -681,12 +682,13 @@ repositories = ["xcp-ng-base"]
 [hosts."ip_or_hostname-2"]
 
 repositories = ["xcp-ng-updates"]
+hosting_pool = "B"
 ```
 
 > [!IMPORTANT]
-> Config values under `servers` override values under `all`. For instance, the above inventory would produce
+> Config values under `hosts` override values under `all`. For instance, the above inventory would produce
 > the following python dict:
 >
-> `{'ip_or_hostname-1': {'repositories': ['xcp-ng-base']}, 'ip_or_hostname-2': {'repositories': ['xcp-ng-updates']}}`
+> `{'ip_or_hostname-1': {'repositories': ['xcp-ng-base'], 'hosting_pool': 'A'}, 'ip_or_hostname-2': {'repositories': ['xcp-ng-updates'], 'hosting_pool': 'B'}}`
 >
 > Using *enablerepo flag* `-e` with inventory is still possible, it won't be used though.

--- a/README.md
+++ b/README.md
@@ -671,7 +671,7 @@ Take a look at an example inventory file:
 ```toml
 # my_inventory.toml
 
-[all]
+[default]
 repositories = ["xcp-ng-base"]
 hosting_pool = "A"
 
@@ -686,9 +686,10 @@ hosting_pool = "B"
 ```
 
 > [!IMPORTANT]
-> Config values under `hosts` override values under `all`. For instance, the above inventory would produce
+> * `default` is applied to all hosts
+> * Config values under `hosts` override values under `default`. For instance, the above inventory would produce
 > the following python dict:
 >
 > `{'ip_or_hostname-1': {'repositories': ['xcp-ng-base'], 'hosting_pool': 'A'}, 'ip_or_hostname-2': {'repositories': ['xcp-ng-updates'], 'hosting_pool': 'B'}}`
 >
-> Using *enablerepo flag* `-e` with inventory is still possible, it won't be used though.
+> * Using *enablerepo flag* `-e` with inventory is still possible, it won't be used though.

--- a/README.md
+++ b/README.md
@@ -641,17 +641,17 @@ uv run scripts/tools.py -h
 This command performs an update operation on remote targets.
 
 ```bash
-uv run scripts/tools.py update -H primary1 primary2
+uv run scripts/tools.py update -H master1 master2
 ```
 
 For each pool target :
 
-1. Update master (primary) host of the pool:
+1. Update master host of the pool:
   * Clean cached metadata
   * Update with repository manager (yum): Optionally enables repositories
   * Reboot
-2. Get attached secondary hosts of the pool
-  * Repeat step `1.` for each secondary
+2. Get other hosts of the pool
+  * Repeat step `1.` for each host
 
 **Inventory file**
 
@@ -692,4 +692,4 @@ hosting_pool = "B"
 >
 > `{'ip_or_hostname-1': {'repositories': ['xcp-ng-base'], 'hosting_pool': 'A'}, 'ip_or_hostname-2': {'repositories': ['xcp-ng-updates'], 'hosting_pool': 'B'}}`
 >
-> * Using *enablerepo flag* `-e` with inventory is still possible, it won't be used though.
+> * When `--inventory` flag is present, repos passed to `-e` flag won't be considered.

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Iterable
 class Pool:
     """Pool
 
-    :raises NotAMasterHostError: if initial host is not a master (primary)
+    :raises NotAMasterHostError: if initial host is not a master
     """
     xe_prefix = "pool"
 
@@ -300,4 +300,4 @@ class Pool:
         return self.master.xe('network-list', {'name-label': network_name}, minimal=True)
 
 class NotAMasterHostError(Exception):
-    """Host must be a master (primary)."""
+    """Host must be a master."""

--- a/lib/tools/cli.py
+++ b/lib/tools/cli.py
@@ -17,7 +17,7 @@ def _command_update(args: argparse.Namespace) -> None:
     if args.inventory:
         inventory = load_inventory(args.inventory)
     else:
-        inventory = into_inventory(args.hosts, args.repos)
+        inventory = into_inventory(args.hosts, args.repos, args.hosting_pool)
 
     update_pools(inventory)
 
@@ -52,6 +52,12 @@ def cli() -> None:
         action="append",
         dest="repos",
         help="repositories to enable when updating",
+    )
+    subparser_cmd_update.add_argument(
+        "-P",
+        "--hosting-pool",
+        type=HostAddress,
+        help="Address (hostname|ip) of hosting pool's master host (nested context)",
     )
     subparser_cmd_update.set_defaults(func=_command_update)
 

--- a/lib/tools/inventory.py
+++ b/lib/tools/inventory.py
@@ -13,25 +13,29 @@ class HostConfig(TypedDict):
     repositories: list[str]
 
 
-Inventory: TypeAlias = dict[HostAddress, HostConfig]
+HostConfigs: TypeAlias = dict[HostAddress, HostConfig]
+
+class Inventory(TypedDict):
+    hosts: HostConfigs
 
 
 def load_inventory(inventory_path: Path) -> Inventory:
     """Create an inventory object from loaded inventory file."""
-    inventory: Inventory = {}
-
     with open(inventory_path, "rb") as f:
         data = tomllib.load(f)
 
     all = data.get("all", {})
     hosts = data.get("hosts", [])
 
-    for server, config in hosts.items():
+    inventory_hosts: HostConfigs = {}
+    for h, config in hosts.items():
         repos = config.get("repositories", [])
         host: HostConfig = {"repositories": repos or all.get("repositories", [])}
-        inventory[server] = host
+        inventory_hosts[h] = host
 
-    return inventory
+    return {
+        "hosts": inventory_hosts,
+    }
 
 
 def into_inventory(hosts: list[HostAddress], repositories: list[str]) -> Inventory:
@@ -39,10 +43,11 @@ def into_inventory(hosts: list[HostAddress], repositories: list[str]) -> Invento
 
     Basically, it is used as compatibility when we don't want inventory from file.
     """
-    inventory: Inventory = {}
-
+    inventory_hosts: HostConfigs = {}
     for h in hosts:
         host: HostConfig = {"repositories": repositories or []}
-        inventory[h] = host
+        inventory_hosts[h] = host
 
-    return inventory
+    return {
+        "hosts": inventory_hosts,
+    }

--- a/lib/tools/inventory.py
+++ b/lib/tools/inventory.py
@@ -24,7 +24,7 @@ def load_inventory(inventory_path: Path) -> Inventory:
     with open(inventory_path, "rb") as f:
         data = tomllib.load(f)
 
-    all = data.get("all", {})
+    default = data.get("default", {})
     hosts = data.get("hosts", [])
 
     inventory_hosts: HostConfigs = {}
@@ -32,9 +32,9 @@ def load_inventory(inventory_path: Path) -> Inventory:
         repos = config.get("repositories", [])
         hosting_pool = config.get("hosting_pool", None)
         if hosting_pool is None:
-            hosting_pool = all.get("hosting_pool", None)
+            hosting_pool = default.get("hosting_pool", None)
         host: HostConfig = {
-            "repositories": repos or all.get("repositories", []),
+            "repositories": repos or default.get("repositories", []),
             "hosting_pool": hosting_pool,
         }
         inventory_hosts[h] = host

--- a/lib/tools/inventory.py
+++ b/lib/tools/inventory.py
@@ -11,13 +11,13 @@ from typing import TypeAlias, TypedDict
 
 class HostConfig(TypedDict):
     repositories: list[str]
+    hosting_pool: HostAddress | None
 
 
 HostConfigs: TypeAlias = dict[HostAddress, HostConfig]
 
 class Inventory(TypedDict):
     hosts: HostConfigs
-
 
 def load_inventory(inventory_path: Path) -> Inventory:
     """Create an inventory object from loaded inventory file."""
@@ -30,7 +30,13 @@ def load_inventory(inventory_path: Path) -> Inventory:
     inventory_hosts: HostConfigs = {}
     for h, config in hosts.items():
         repos = config.get("repositories", [])
-        host: HostConfig = {"repositories": repos or all.get("repositories", [])}
+        hosting_pool = config.get("hosting_pool", None)
+        if hosting_pool is None:
+            hosting_pool = all.get("hosting_pool", None)
+        host: HostConfig = {
+            "repositories": repos or all.get("repositories", []),
+            "hosting_pool": hosting_pool,
+        }
         inventory_hosts[h] = host
 
     return {
@@ -38,14 +44,17 @@ def load_inventory(inventory_path: Path) -> Inventory:
     }
 
 
-def into_inventory(hosts: list[HostAddress], repositories: list[str]) -> Inventory:
+def into_inventory(hosts: list[HostAddress], repositories: list[str], hosting_pool: HostAddress) -> Inventory:
     """Create an inventory object from arguments.
 
     Basically, it is used as compatibility when we don't want inventory from file.
     """
     inventory_hosts: HostConfigs = {}
     for h in hosts:
-        host: HostConfig = {"repositories": repositories or []}
+        host: HostConfig = {
+            "repositories": repositories or [],
+            "hosting_pool": hosting_pool or None,
+        }
         inventory_hosts[h] = host
 
     return {

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor
 
 from lib.pool import NotAMasterHostError, Pool
+from lib.tools.inventory import Inventory
 
 from .. import logger
 
-def update_pools(inventory: dict) -> None:
+def update_pools(inventory: Inventory) -> None:
     """Updates hosts in pool(s).
 
     .. note::
@@ -23,24 +24,25 @@ def update_pools(inventory: dict) -> None:
         Each host (key) holds its own config data (values, eg: `enablerepos`).
     """
     logger.debug(f"Inventory: {inventory}")
+    inventory_hosts = inventory["hosts"]
     # init related pools
-    pools = []
-    for h in inventory:
+    pools: list[Pool] = []
+    for host in inventory_hosts:
         try:
-            p = Pool(h)
+            p = Pool(host)
             pools.append(p)
         except NotAMasterHostError:
-            logger.warning(f"[{h}] Skipping: not a master host")
+            logger.warning(f"[{host}] Skipping: not a master host")
 
     with ThreadPoolExecutor() as executor:
         for p in pools:
-            executor.submit(p.master.update, inventory[p.master.hostname_or_ip]["enablerepos"])
+            executor.submit(p.master.update, inventory_hosts[p.master.hostname_or_ip]["enablerepos"])
 
     # secondary hosts
     with ThreadPoolExecutor() as executor:
         for p in pools:
             # omit first item because it is a primary (master)
-            for h in p.hosts[1:]:
+            for secondary in p.hosts[1:]:
                 # repos are the same as the primary (master)
-                repos = inventory[p.master.hostname_or_ip]["enablerepos"]
-                executor.submit(h.update, repos)
+                repos = inventory_hosts[p.master.hostname_or_ip]["enablerepos"]
+                executor.submit(secondary.update, repos)

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -36,7 +36,7 @@ def update_pools(inventory: Inventory) -> None:
 
     with ThreadPoolExecutor() as executor:
         for p in pools:
-            executor.submit(p.master.update, inventory_hosts[p.master.hostname_or_ip]["enablerepos"])
+            executor.submit(p.master.update, inventory_hosts[p.master.hostname_or_ip]["repositories"])
 
     # secondary hosts
     with ThreadPoolExecutor() as executor:
@@ -44,5 +44,5 @@ def update_pools(inventory: Inventory) -> None:
             # omit first item because it is a primary (master)
             for secondary in p.hosts[1:]:
                 # repos are the same as the primary (master)
-                repos = inventory_hosts[p.master.hostname_or_ip]["enablerepos"]
+                repos = inventory_hosts[p.master.hostname_or_ip]["repositories"]
                 executor.submit(secondary.update, repos)

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -18,7 +18,7 @@ def update_pools(inventory: Inventory) -> None:
 
         Every non-master hosts in inventory will be ignored
 
-    *Update master hosts declared in inventory first, then, update secondary hosts attached to each master.*
+    *Update each pool's master host declared in inventory first, then, update other hosts for each pool.*
 
     :param dict inventory:
         Each host (key) holds its own config data (values, eg: `enablerepos`).
@@ -34,15 +34,16 @@ def update_pools(inventory: Inventory) -> None:
         except NotAMasterHostError:
             logger.warning(f"[{host}] Skipping: not a master host")
 
+    # update master hosts
     with ThreadPoolExecutor() as executor:
         for p in pools:
             executor.submit(p.master.update, inventory_hosts[p.master.hostname_or_ip]["repositories"])
 
-    # secondary hosts
+    # update other hosts
     with ThreadPoolExecutor() as executor:
         for p in pools:
-            # omit first item because it is a primary (master)
-            for secondary in p.hosts[1:]:
-                # repos are the same as the primary (master)
+            # omit first item because it is the pool's master
+            for other_host in p.hosts[1:]:
+                # repos are the same as for the master host
                 repos = inventory_hosts[p.master.hostname_or_ip]["repositories"]
-                executor.submit(secondary.update, repos)
+                executor.submit(other_host.update, repos)


### PR DESCRIPTION
This PR changes the structure of the "python dict inventory".

Move all hosts inside a subkey named `hosts`.

```python
# before
{'host-1': ..., 'host-2': ...}

# after
{'hosts': {'host-1': ..., 'host-2': ...}}
```
Add a new cli arg to provide the address of hosting pool's master host (physical): `-P/--hosting-pool`

**What is the hosting pool's master host?**

This is the host where live my nested hosts. In a nested context, "nested hosts" are VM which are hosted by an Host (a physical one). This information is needed to perform a snapshot (incoming PR #468).

<img width="1437" height="727" alt="image" src="https://github.com/user-attachments/assets/6ab24be8-0e22-4b04-ab46-c81095451a00" />


* Orange: my own nested lab. My hosts (which are VM in real life) must be snapshotted.
* Blue: The Real host where my hosts live. This is the hosting pool of my hosts (A1, A2, B1) and **this is where I can perform the snapshot** (in nested context).

This is the reason why I've added the key `hosting_pool` in inventory. I needed a starting point to perform a snapshot.