### PR TITLE
storage: add jobs for large volume tests

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -101,6 +101,62 @@ JOBS: dict[str, JobData] = {
         "markers": "(small_vm or no_vm) and not reboot and not quicktest and not unused_4k_disks",
         "name_filter": "not migration and not linstor",
     },
+    "storage-main-large-thin": {
+        "description":
+            "same as storage-main with 3TiB VDIs, no large gzip XVAs creation and no test requiring 3TiB allocation",
+        "requirements": [
+            "A pool with at least 3 hosts.",
+            "An additional free disk on every host.",
+            "Configuration in data.py for each remote SR that will be tested.",
+            "A small VM that can be imported on the SRs.",
+        ],
+        "nb_pools": 1,
+        "params": {
+            "--vm": "single/small_vm",
+            "--volume-size": "3TiB",
+        },
+        "paths": ["tests/storage"],
+        "markers": "(small_vm or no_vm) and not reboot and not quicktest and not unused_4k_disks"
+                   " and not thick_provisioned and not disk_throughput_intensive",
+        "name_filter": "not migration and not linstor and not gzip",
+    },
+    "storage-main-large-thick": {
+        "description":
+            "same as storage-main with 3TiB VDIs, no gzip XVAs and tests requiring 3TiB allocation",
+        "requirements": [
+            "A pool with at least 3 hosts.",
+            "An additional free disk on every host.",
+            "Configuration in data.py for each remote SR that will be tested.",
+            "A small VM that can be imported on the SRs.",
+        ],
+        "nb_pools": 1,
+        "params": {
+            "--vm": "single/small_vm",
+            "--volume-size": "3TiB",
+        },
+        "paths": ["tests/storage"],
+        "markers": "(small_vm or no_vm) and not reboot and not quicktest and not unused_4k_disks"
+                   " and not disk_throughput_intensive and thick_provisioned",
+        "name_filter": "not migration and not linstor and not gzip",
+    },
+    "storage-main-large-full-write": {
+        "description": "storage tests actually writing the full 3TiB volumes",
+        "requirements": [
+            "A pool with at least 3 hosts.",
+            "An additional free disk on every host.",
+            "Configuration in data.py for each remote SR that will be tested.",
+            "A small VM that can be imported on the SRs.",
+        ],
+        "nb_pools": 1,
+        "params": {
+            "--vm": "single/small_vm",
+            "--volume-size": "3TiB",
+        },
+        "paths": ["tests/storage"],
+        "markers": "(small_vm or no_vm) and not reboot and not quicktest and not unused_4k_disks"
+                   " and disk_throughput_intensive",
+        "name_filter": "not migration and not linstor and not gzip",
+    },
     "storage-migrations": {
         "description": "tests migrations with all storage drivers",
         "requirements": [
@@ -116,6 +172,42 @@ JOBS: dict[str, JobData] = {
         },
         "paths": ["tests/storage"],
         "markers": "not unused_4k_disks",
+        "name_filter": "migration and not linstor",
+    },
+    "storage-migrations-large-thin": {
+        "description": "same as storage-migrations with 3TiB VDIs, and no test requiring 3TiB allocation",
+        "requirements": [
+            "A pool with at least 3 hosts.",
+            "An additional free disk on every host.",
+            "A second pool with at least 1 host and a SR to receive VMs.",
+            "Configuration in data.py for each remote SR that will be tested.",
+            "A small VM that can be imported on the SRs.",
+        ],
+        "nb_pools": 2,
+        "params": {
+            "--vm": "single/small_vm",
+            "--volume-size": "3TiB",
+        },
+        "paths": ["tests/storage"],
+        "markers": "not unused_4k_disks and not thick_provisioned",
+        "name_filter": "migration and not linstor",
+    },
+    "storage-migrations-large-thick": {
+        "description": "same as storage-migrations with 3TiB VDIs, and tests requiring 3TiB allocation",
+        "requirements": [
+            "A pool with at least 3 hosts.",
+            "An additional free disk on every host.",
+            "A second pool with at least 1 host and a SR to receive VMs.",
+            "Configuration in data.py for each remote SR that will be tested.",
+            "A small VM that can be imported on the SRs.",
+        ],
+        "nb_pools": 2,
+        "params": {
+            "--vm": "single/small_vm",
+            "--volume-size": "3TiB",
+        },
+        "paths": ["tests/storage"],
+        "markers": "not unused_4k_disks and thick_provisioned",
         "name_filter": "migration and not linstor",
     },
     "storage-reboots": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,10 @@ markers =
     multi_vms: tests that it would be good to run on a variety of VMs (includes `small_vm` but excludes `big_vm`).
     debian_uefi_vm: tests that require a Debian UEFI VM
 
+    # * Disk-related markers
+    thick_provisioned: tests that use thick provisioned SRs.
+    disk_throughput_intensive: tests that fill a large VDI entirely (require a fast disk).
+
     # * Other markers
     reboot: tests that reboot one or more hosts.
     flaky: flaky tests. Usually pass, but sometimes fail unexpectedly.

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -104,6 +104,7 @@ class TestEXTSR:
         vdi_export_import(storage_test_vm, ext_sr, image_format, temp_large_dir, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_ext_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_ext_sr, defer)
 

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -54,6 +54,7 @@ class TestLVMSRCreateDestroy:
         sr.destroy(verify=True)
 
 @pytest.mark.usefixtures("lvm_sr")
+@pytest.mark.thick_provisioned
 class TestLVMSR:
     @pytest.mark.quicktest
     def test_quicktest(self, lvm_sr: SR) -> None:
@@ -150,6 +151,7 @@ class TestLVMSR:
         coalesce_integrity(storage_test_vm, vdi_on_lvm_sr, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_lvm_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_lvm_sr, defer)
 

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -15,6 +15,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, local_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_lvm_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -15,6 +15,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.thick_provisioned
 class Test:
     def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, local_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_lvm_sr, host, hostA2, local_sr_on_hostA2)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -43,6 +43,7 @@ class TestLVMOISCSISRCreateDestroy:
 
 @pytest.mark.usefixtures('image_format')
 @pytest.mark.usefixtures("lvmoiscsi_sr")
+@pytest.mark.thick_provisioned
 class TestLVMOISCSISR:
     @pytest.mark.quicktest
     def test_quicktest(self, lvmoiscsi_sr: SR) -> None:
@@ -77,6 +78,7 @@ class TestLVMOISCSISR:
         coalesce_integrity(storage_test_vm, vdi_on_lvmoiscsi_sr, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_lvmoiscsi_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_lvmoiscsi_sr, defer)
 

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -15,6 +15,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostB1: SR

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -15,6 +15,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 @pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.thick_provisioned
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM) -> None:
         sr = vm_on_lvmoiscsi_sr.get_sr()

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -122,6 +122,7 @@ class TestNFSSR:
         coalesce_integrity(storage_test_vm, dispatch_nfs, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_nfs_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_nfs_sr, defer)
 

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -110,6 +110,7 @@ class TestXFSSR:
         coalesce_integrity(storage_test_vm, vdi_on_xfs_sr, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_xfs_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_xfs_sr, defer)
 

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -107,6 +107,7 @@ class TestZFSSR:
         coalesce_integrity(storage_test_vm, vdi_on_zfs_sr, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_zfs_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_zfs_sr, defer)
 

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -82,6 +82,7 @@ class TestZfsvolVm:
         coalesce_integrity(storage_test_vm, vdi_on_zfsvol_sr, vdi_op, defer)
 
     @pytest.mark.small_vm
+    @pytest.mark.disk_throughput_intensive
     def test_full_vdi_write(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, defer: Defer):
         full_vdi_write(storage_test_vm, vdi_on_zfsvol_sr, defer)
 


### PR DESCRIPTION
Mark LVM and lvmoiscsi tests that allocate large VDIs with disk_space_allocation,
and all test_full_vdi_write tests with disk_throughput_intensive, to allow running
large-VDI jobs only on hardware that can handle the respective disk requirements.

Add storage-main-16tb-{thin,thick,full-write} and storage-migrations-16tb-{thin,thick}
jobs that use these markers to split 16TiB volume testing by disk speed requirement.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. **"storage: add jobs for large volume tests" (this PR) → #454**
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->