### PR TITLE
extra_pkgs: refresh the yum metadata

### DIFF
--- a/tests/packages/extra/test_extra_group_pkgs.py
+++ b/tests/packages/extra/test_extra_group_pkgs.py
@@ -3,6 +3,7 @@
 # - host(A1): any master host of a pool, with access to XCP-ng RPM repositories and reports.xcp-ng.org.
 
 def test_extra_group_packages_url_resolved(host, extra_pkgs):
+    host.yum_clean_metadata()
     for p in extra_pkgs:
         host.ssh(['yumdownloader', '--resolve', '--urls', p])
 


### PR DESCRIPTION
Old yum metadata can make the test fail, because yum won't find a specific package listed in extra_installable.txt.