### PR TITLE
skip large volume tests for zvol and nfsv4

### DIFF
--- a/lib/sr.py
+++ b/lib/sr.py
@@ -205,6 +205,9 @@ class SR:
             self._type = self.param_get('type')
         return self._type
 
+    def get_name_label(self) -> str:
+        return self.param_get('name-label')
+
     def create_vdi(
         self, name_label: str | None = None, virtual_size: int = 1 * GiB, image_format: ImageFormat | None = None
     ) -> VDI:

--- a/lib/sr.py
+++ b/lib/sr.py
@@ -6,6 +6,11 @@ import time
 import lib.commands as commands
 from lib.common import (
     GiB,
+    _param_add,
+    _param_clear,
+    _param_get,
+    _param_remove,
+    _param_set,
     prefix_object_name,
     randid,
     safe_split,
@@ -15,13 +20,15 @@ from lib.common import (
 )
 from lib.vdi import VDI, ImageFormat
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 if TYPE_CHECKING:
     from lib.host import Host
     from lib.pool import Pool
 
 class SR:
+    xe_prefix = 'sr'
+
     def __init__(self, uuid: str, pool: Pool):
         self.uuid = uuid
         self.pool = pool
@@ -160,18 +167,42 @@ class SR:
                 self._main_host = self.pool.get_host_by_uuid(self.hosts_uuids()[0])
         return self._main_host
 
+    @overload
+    def param_get(self, param_name: str, key: str | None = ..., accept_unknown_key: Literal[False] = ...) -> str:
+        ...
+
+    @overload
+    def param_get(
+        self, param_name: str, key: str | None = ..., accept_unknown_key: Literal[True] = ...
+    ) -> str | None:
+        ...
+
+    def param_get(self, param_name: str, key: str | None = None, accept_unknown_key: bool = False) -> str | None:
+        return _param_get(self.pool.master, self.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+
+    def param_set(self, param_name: str, value: str | bool | dict[str, str], key: str | None = None) -> None:
+        _param_set(self.pool.master, self.xe_prefix, self.uuid, param_name, value, key)
+
+    def param_remove(self, param_name: str, key: str, accept_unknown_key: bool = False) -> None:
+        _param_remove(self.pool.master, self.xe_prefix, self.uuid, param_name, key, accept_unknown_key)
+
+    def param_add(self, param_name: str, value: str, key: str | None = None) -> None:
+        _param_add(self.pool.master, self.xe_prefix, self.uuid, param_name, value, key)
+
+    def param_clear(self, param_name: str) -> None:
+        _param_clear(self.pool.master, self.xe_prefix, self.uuid, param_name)
+
     def content_type(self) -> str:
-        return self.pool.master.xe('sr-param-get', {'uuid': self.uuid, 'param-name': 'content-type'})
+        return self.param_get('content-type')
 
     def is_shared(self) -> bool:
         if self._is_shared is None:
-            self._is_shared = strtobool(self.pool.master.xe('sr-param-get',
-                                                            {'uuid': self.uuid, 'param-name': 'shared'}))
+            self._is_shared = strtobool(self.param_get('shared'))
         return self._is_shared
 
     def get_type(self) -> str:
         if self._type is None:
-            self._type = self.pool.master.xe("sr-param-get", {"uuid": self.uuid, "param-name": "type"})
+            self._type = self.param_get('type')
         return self._type
 
     def create_vdi(

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from lib import config
 from lib.commands import SSHCommandFailed
-from lib.common import Defer, vm_image, wait_for
+from lib.common import Defer, GiB, vm_image, wait_for
 from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI
@@ -119,6 +120,8 @@ class TestNFSSR:
     @pytest.mark.parametrize('dispatch_nfs', ['vdi_on_nfs_sr', 'vdi_on_nfs4_sr'], indirect=True)
     @pytest.mark.parametrize('vdi_op', ['snapshot', 'clone'])
     def test_coalesce(self, storage_test_vm: VM, dispatch_nfs: VDI, vdi_op: CoalesceOperation, defer: Defer) -> None:
+        if "NFS4" in dispatch_nfs.sr.get_name_label() and config.volume_size > 20 * GiB:
+            pytest.skip("Skipping NFSv4 large VDI test (known performance issue)")
         coalesce_integrity(storage_test_vm, dispatch_nfs, vdi_op, defer)
 
     @pytest.mark.small_vm
@@ -139,12 +142,16 @@ class TestNFSSR:
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
     def test_xva_export_import(self, dispatch_nfs: VM, compression: XVACompression, temp_large_dir: str, defer: Defer) \
             -> None:
+        if "NFS4" in dispatch_nfs.vdis[0].sr.get_name_label() and config.volume_size > 20 * GiB:
+            pytest.skip("Skipping NFSv4 large VDI test (known performance issue)")
         xva_export_import(dispatch_nfs, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize('dispatch_nfs', ['nfs_sr', 'nfs4_sr'], indirect=True)
     def test_vdi_export_import(self, storage_test_vm: VM, dispatch_nfs: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer) -> None:
+        if "NFS4" in dispatch_nfs.get_name_label() and config.volume_size > 20 * GiB:
+            pytest.skip("Skipping NFSv4 large VDI test (known performance issue)")
         vdi_export_import(storage_test_vm, dispatch_nfs, image_format, temp_large_dir, defer)
 
     # *** tests with reboots (longer tests).

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -6,7 +6,7 @@ import logging
 
 from lib import config
 from lib.commands import SSHCommandFailed
-from lib.common import Defer, KiB, MiB, vm_image, wait_for
+from lib.common import Defer, GiB, KiB, MiB, vm_image, wait_for
 from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI
@@ -97,11 +97,15 @@ class TestZfsvolVm:
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
     def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression, temp_large_dir: str,
                                defer: Defer) -> None:
+        if config.volume_size > 20 * GiB:
+            pytest.skip("Skipping large VDI test (known performance issue)")
         xva_export_import(vm_on_zfsvol_sr, compression, temp_large_dir, defer)
 
     @pytest.mark.small_vm
     def test_vdi_export_import(self, storage_test_vm: VM, zfsvol_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
+        if config.volume_size > 20 * GiB:
+            pytest.skip("Skipping large VDI test (known performance issue)")
         vm = storage_test_vm
         sr = zfsvol_sr
         vdi_export_import(vm, sr, image_format, temp_large_dir, defer)


### PR DESCRIPTION
They are slow and currently out of scope.

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. **"skip large volume tests for zvol and nfsv4" (this PR) → #461**
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->