### PR TITLE
zfsvol: disable coalesce test

### DIFF
--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -63,6 +63,7 @@ class TestZfsvolVm:
 
     @pytest.mark.small_vm
     @pytest.mark.parametrize("vdi_op", ["snapshot"])  # "clone" requires a snapshot
+    @pytest.mark.skip("zfsvol doesn't provide vhd-parent")
     def test_coalesce(self, storage_test_vm: VM, vdi_on_zfsvol_sr: VDI, vdi_op: CoalesceOperation):
         coalesce_integrity(storage_test_vm, vdi_on_zfsvol_sr, vdi_op)
 


### PR DESCRIPTION
vhd-parent, which is used to detect when the coalesce is done, is
not available for that SR type.

Note: It was #445 before. I somehow screwed up, and github closed the PR while moving it to the base of the stack to be able to merge it without the other ones.

<!-- start jj-vine stack -->
This PR is part of a stack containing 12 PRs:

1. `master`
2. **"zfsvol: disable coalesce test" (this PR)**
3. #436
4. #437
5. #447
6. #446
7. #449
8. #450
9. #452
10. #453
11. #454
12. #461
13. #464
<!-- end jj-vine stack -->