### PR TITLE
Fix XAPI session leak by vdi_is_open

### DIFF
--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -139,7 +139,10 @@ def get_xapi_session():
     return session
 
 session = get_xapi_session()
-sr_ref = session.xenapi.SR.get_by_uuid(\"{sr.uuid}\")
+try:
+    sr_ref = session.xenapi.SR.get_by_uuid(\"{sr.uuid}\")
+finally:
+    session.xenapi.logout()
 print(sr_ref)
 """
 


### PR DESCRIPTION
In the case of `vdi_is_open` tests, we are using a script to obtain the sr_ref of XAPI. This script doesn't free the XAPI session it obtained.
```
Apr 15 09:46:55 r620-x1 xapi: [debug||115 db_gc|DB GC D:d2304dcf287c|db_gc_util] Session.destroy _ref=OpaqueRef:77699499-92e7-ad96-2703-fc53adaae642 uuid=e8a67d26-9aae-4451-ea87-66a3180141fb trackid=3c4e5b67d27d1b17ff45f3e41b478632 (last active 20260414T07:46:32Z): Timed out session in group 'originator:xcp-ng-tests session' because of its age
```
This add the logout to the script to avoid leaking the session.