### PR TITLE
Add ty type checker configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,15 @@ repos:
         require_serial: true
         entry: "uv run flake8"
         types: ["python"]
+      - id: "ty"
+        name: "ty"
+        language: "system"
+        require_serial: true
+        entry: "uv run ty check ."
+        types: ["python"]
+        stages: ["manual"]
+        pass_filenames: false
+        always_run: true
       - id: "pyright"
         name: "pyright"
         language: "system"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile to run static code checkers locally
 # Equivalent to the GitHub Actions workflow in .github/workflows/code-checkers.yml
 
-.PHONY: all pyright ruff ruff-fix flake8 autopep8 autopep8-fix
+.PHONY: all pyright ruff ruff-fix flake8 autopep8 autopep8-fix ty
 
 # By default, only run the non-fix version of the hooks so it doesn't modify any files
 # It runs on all files managed by git (untracked files are not checked)
@@ -19,5 +19,5 @@ vm_data.py:
 
 pyright ruff: data.py vm_data.py
 
-ruff ruff-fix autopep8 autopep8-fix flake8 pyright:
+ruff ruff-fix autopep8 autopep8-fix flake8 ty pyright:
 	uv run prek -a $@

--- a/conftest.py
+++ b/conftest.py
@@ -280,6 +280,7 @@ def pytest_runtest_makereport(
 
     # store test results for each phase of a call, which can
     # be "setup", "call", "teardown"
+    assert rep.when is not None
     item.stash.setdefault(PHASE_REPORT_KEY, {})[rep.when] = rep
 
     return rep

--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ from packaging import version
 
 import lib.config as global_config
 from lib import pxe
+from lib.commands import local_cmd
 from lib.common import (
     Defer,
     DiskDevName,
@@ -322,7 +323,7 @@ def hosts(pytestconfig: pytest.Config) -> Generator[list[Host], None, None]:
             assert len(ips) == 1
             host_vm.ip = ips[0]
 
-            wait_for(lambda: not os.system(f"nc -zw5 {host_vm.ip} 22"),
+            wait_for(lambda: local_cmd(["nc", "-zw5", str(host_vm.ip), "22"], check=False).returncode == 0,
                      "Wait for ssh up on nested host", retry_delay_secs=5)
 
             hostname_or_ip = host_vm.ip

--- a/data.py-dist
+++ b/data.py-dist
@@ -171,7 +171,7 @@ ISO_IMAGES: dict[str, "IsoImageDef"] = {
 # - 'default': keep using the pool's default SR
 # - 'local': use the first local SR found instead
 # - A UUID of the SR to be used
-DEFAULT_SR = 'default'
+DEFAULT_SR: str = 'default'
 
 # Whether to cache VMs on the test host, that is import them only if not already
 # present in the target SR. This also causes the VM to be cloned at the beginning
@@ -182,7 +182,7 @@ DEFAULT_SR = 'default'
 # Example description: "[Cache for http://example.com/images/filename.xva]"
 # Delete the VM to remove it from cache.
 # This setting affects VMs managed by the `imported_vm` fixture.
-CACHE_IMPORTED_VM = False
+CACHE_IMPORTED_VM: bool = False
 
 # Default LINSTOR redundancy configuration for creating SRs.
 LINSTOR_REDUNDANCY = 2

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,10 +1,10 @@
 from lib.common import GiB
 
-ignore_ssh_banner = False
-ssh_output_max_lines = 20
-volume_size = 1 * GiB
-write_volume_cap = 2 * GiB
-write_volume_align = 1
+ignore_ssh_banner: bool = False
+ssh_output_max_lines: int = 20
+volume_size: int = 1 * GiB
+write_volume_cap: int = 2 * GiB
+write_volume_align: int = 1
 
 def sr_device_config(datakey: str, *, required: list[str] = []) -> dict[str, str]:
     import data  # import here to avoid depending on this user file for collecting tests

--- a/scripts/install_xcpng.py
+++ b/scripts/install_xcpng.py
@@ -18,7 +18,7 @@ from packaging import version
 # flake8: noqa: E402
 sys.path.append(f"{os.path.abspath(os.path.dirname(__file__))}/..")
 from lib import pxe
-from lib.commands import SSHCommandFailed, ssh
+from lib.commands import SSHCommandFailed, local_cmd, ssh
 from lib.common import is_uuid, wait_for
 from lib.host import Host, host_data
 from lib.pool import Pool
@@ -72,7 +72,7 @@ def generate_answerfile(directory: str, installer: str, hostname_or_ip: str, tar
             raise Exception(f"Unknown action: `{action}`")
 
 def is_ip_active(ip: str) -> bool:
-    return not os.system(f"ping -c 3 -W 10 {ip} > /dev/null 2>&1")
+    return local_cmd(["ping", "-c", "3", "-W", "10", ip], check=False).returncode == 0
 
 def is_ssh_up(ip: str) -> bool:
     try:

--- a/tests/network/test_vif_allowed_ip.py
+++ b/tests/network/test_vif_allowed_ip.py
@@ -3,6 +3,7 @@ import pytest
 import ipaddress
 import os
 
+from lib.commands import local_cmd
 from lib.vm import VM
 
 # Requirements:
@@ -10,7 +11,7 @@ from lib.vm import VM
 # - a VM (--vm)
 
 def ip_responsive(ip: str) -> bool:
-    return not os.system(f"ping -c 3 -W 10 {ip} > /dev/null 2>&1")
+    return local_cmd(["ping", "-c", "3", "-W", "10", ip], check=False).returncode == 0
 
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("host_no_sdn_controller")


### PR DESCRIPTION
Add ty configuration. ty provides fast type checking that complements
pyright/mypy, while ruff handles missing type hints detection.

ty is not yet reporting as much problems as mypy or pyright, but it is
much, much faster, and is already interesting to use interactively.

This change only aims at making ty usable in this project, without
replacing mypy or pyright. As such it is not added in the dev dependencies
and must be installed manually, for example with

<!-- start jj-vine stack -->
This PR is part of a stack containing 2 PRs:

1. `master`
2. #460
3. **"chore: add ty type checker and reorder make commands for faster feedback" (this PR)**
<!-- end jj-vine stack -->