### PR TITLE
Robustify LINSTOR `test_diskless_kept` test

### DIFF
--- a/data.py-dist
+++ b/data.py-dist
@@ -188,6 +188,9 @@ DEFAULT_SR = 'default'
 # This setting affects VMs managed by the `imported_vm` fixture.
 CACHE_IMPORTED_VM = False
 
+# Default LINSTOR redundancy configuration for creating SRs.
+LINSTOR_REDUNDANCY = 2
+
 # Default NFS device config:
 NFS_DEVICE_CONFIG: dict[str, str] = {
 #    'server': '10.0.0.2', # URL/Hostname of NFS server

--- a/lib/host.py
+++ b/lib/host.py
@@ -89,6 +89,9 @@ class Host:
     def __str__(self) -> str:
         return self.hostname_or_ip
 
+    def name(self) -> str:
+        return self.param_get('name-label')
+
     @overload
     def ssh(self, cmd: str, *, check: bool = True, simple_output: Literal[True] = True,
             suppress_fingerprint_warnings: bool = True, background: Literal[False] = False,

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -8,6 +8,7 @@ import os
 from dataclasses import dataclass
 
 import lib.commands as commands
+from data import LINSTOR_REDUNDANCY
 
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state
@@ -142,8 +143,13 @@ def pool_with_linstor(
         executor.map(remove_linstor, pool.hosts)
 
 @pytest.fixture(scope='package')
+def linstor_redundancy(pool_with_linstor: Pool) -> int:
+    return min(len(pool_with_linstor.hosts), LINSTOR_REDUNDANCY)
+
+@pytest.fixture(scope='package')
 def linstor_sr(
     pool_with_linstor: Pool,
+    linstor_redundancy: int,
     provisioning_type: str,
     storage_pool_name: str,
     lvm_disks: None,
@@ -151,7 +157,7 @@ def linstor_sr(
 ) -> Generator[SR, None, None]:
     sr = pool_with_linstor.master.sr_create('linstor', 'LINSTOR-SR-test', {
         'group-name': storage_pool_name,
-        'redundancy': str(min(len(pool_with_linstor.hosts), 3)),
+        'redundancy': str(linstor_redundancy),
         'provisioning': provisioning_type
     }, shared=True)
     yield sr

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -8,7 +8,11 @@ import os
 from dataclasses import dataclass
 
 import lib.commands as commands
-from data import LINSTOR_REDUNDANCY
+
+try:
+    from data import LINSTOR_REDUNDANCY  # type: ignore
+except ImportError:
+    LINSTOR_REDUNDANCY = 2
 
 # explicit import for package-scope fixtures
 from pkgfixtures import pool_with_saved_yum_state

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -183,7 +183,7 @@ def _ensure_resource_remain_diskless(
 ) -> None:
     diskfuls = _get_diskful_hosts(host, controller_option, sr_group_name, vdi_uuid)
     for diskless_host in diskless:
-        assert diskless_host.param_get("name-label").lower() not in diskfuls
+        assert diskless_host.name().lower() not in diskfuls
 
 class TestLinstorDisklessResource:
     @pytest.mark.small_vm
@@ -193,27 +193,38 @@ class TestLinstorDisklessResource:
         if len(linstor_sr.pool.hosts) <= linstor_redundancy:
             pytest.skip("This test requires at least one DRBD diskless")
 
-        vm = vm_on_linstor_sr
-        vdi_uuids = vm.vdi_uuids(sr_uuid=linstor_sr.uuid)
-        vdi_uuid = vdi_uuids[0]
-        assert vdi_uuid is not None
-
+        # 1. Prepare options.
         controller_option = "--controllers="
         for member in host.pool.hosts:
             controller_option += f"{member.hostname_or_ip},"
 
         sr_group_name = "xcp-sr-" + storage_pool_name.replace("/", "_")
-        diskfuls = _get_diskful_hosts(host, controller_option, sr_group_name, vdi_uuid)
-        diskless = []
-        for member in host.pool.hosts:
-            if member.param_get("name-label").lower() not in diskfuls:
-                diskless += [member]
-        assert diskless
 
-        # Start VM on host with diskless resource
-        vm.start(on=diskless[0].uuid)
-        vm.wait_for_os_booted()
-        _ensure_resource_remain_diskless(host, controller_option, sr_group_name, vdi_uuid, diskless)
+        # 2. Get VM VDI.
+        vm = vm_on_linstor_sr
+        vdi = vm.vdis[0]
 
-        vm.shutdown(verify=True)
-        _ensure_resource_remain_diskless(host, controller_option, sr_group_name, vdi_uuid, diskless)
+        # 3. Create a snap to ensure VDI cannot be coalesced during diskless checks.
+        # To be more clear: if a coalesce is executed on the leaf, the VDI path is modified,
+        # and we must prevent this situation otherwise we can't compare diskless state
+        # between VM running and stopped.
+        snap = vdi.snapshot()
+
+        try:
+            # 4. Fetch DRBD diskless.
+            diskfuls = _get_diskful_hosts(host, controller_option, sr_group_name, vdi.uuid)
+            diskless = []
+            for member in host.pool.hosts:
+                if member.name().lower() not in diskfuls:
+                    diskless += [member]
+            assert diskless
+
+            # 5. Verify diskless state after VM boot and shutdown.
+            vm.start(on=diskless[0].uuid)
+            vm.wait_for_os_booted()
+            _ensure_resource_remain_diskless(host, controller_option, sr_group_name, vdi.uuid, diskless)
+
+            vm.shutdown(verify=True)
+            _ensure_resource_remain_diskless(host, controller_option, sr_group_name, vdi.uuid, diskless)
+        finally:
+            snap.destroy()

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -187,7 +187,12 @@ def _ensure_resource_remain_diskless(
 
 class TestLinstorDisklessResource:
     @pytest.mark.small_vm
-    def test_diskless_kept(self, host: Host, linstor_sr: SR, vm_on_linstor_sr: VM, storage_pool_name: str) -> None:
+    def test_diskless_kept(
+        self, host: Host, linstor_sr: SR, linstor_redundancy: int, vm_on_linstor_sr: VM, storage_pool_name: str
+    ) -> None:
+        if len(linstor_sr.pool.hosts) <= linstor_redundancy:
+            pytest.skip("This test requires at least one DRBD diskless")
+
         vm = vm_on_linstor_sr
         vdi_uuids = vm.vdi_uuids(sr_uuid=linstor_sr.uuid)
         vdi_uuid = vdi_uuids[0]


### PR DESCRIPTION
- Execute test only when required (when we have at least one diskless).
- Ensure we are not impacted by a coalesce. Otherwise the test can fail.
- Add `LINSTOR_REDUNDANCY` to configure LINSTOR replication count.