### PR TITLE
migration: create a xfs sr on the second host for intra/cross-pool migration

### DIFF
--- a/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
@@ -16,14 +16,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_crosspool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_cephfs_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -23,11 +23,11 @@ class Test:
         live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_cephfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM) -> None:
         sr = vm_on_cephfs_sr.get_sr()

--- a/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
+++ b/tests/storage/cephfs/test_cephfs_sr_intrapool_migration.py
@@ -16,7 +16,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_cephfs_sr: VM) -> None:
         sr = vm_on_cephfs_sr.get_sr()

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -94,3 +94,43 @@ def xfs_sr_on_hostA2(
     except Exception as e:
         _xfs_config_on_hostA2.uninstall_xfs = False
         raise pytest.fail("Could not destroy xfs SR, leaving packages in place for manual cleanup") from e
+
+@pytest.fixture(scope='package')
+def _xfs_config_on_hostB1() -> XfsConfig:
+    return XfsConfig()
+
+# NOTE: @pytest.mark.usefixtures does not parametrize this fixture.
+# To recreate host_with_xfsprogs for each image_format value, accept
+# image_format in the fixture arguments.
+# ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
+@pytest.fixture(scope='package')
+def hostB1_with_xfsprogs(hostB1: Host, image_format: ImageFormat, _xfs_config_on_hostB1: XfsConfig) \
+        -> Generator[Host, None, None]:
+    assert not hostB1.file_exists('/usr/sbin/mkfs.xfs'), \
+        "xfsprogs must not be installed on the host at the beginning of the tests"
+    hostB1.yum_save_state()
+    hostB1.yum_install(['xfsprogs'])
+    yield hostB1
+    # teardown
+    if _xfs_config_on_hostB1.uninstall_xfs:
+        hostB1.yum_restore_saved_state()
+
+@pytest.fixture(scope='package')
+def xfs_sr_on_hostB1(
+    unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+    hostB1_with_xfsprogs: Host,
+    image_format: ImageFormat,
+    _xfs_config_on_hostB1: XfsConfig,
+) -> Generator[SR, None, None]:
+    """ A XFS SR on first host. """
+    sr_disk = unused_512B_disks[hostB1_with_xfsprogs][0]["name"]
+    sr = hostB1_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
+                                        {'device': '/dev/' + sr_disk,
+                                         'preferred-image-formats': image_format})
+    yield sr
+    # teardown
+    try:
+        sr.destroy()
+    except Exception as e:
+        _xfs_config_on_hostB1.uninstall_xfs = False
+        raise pytest.fail("Could not destroy xfs SR, leaving packages in place for manual cleanup") from e

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import pytest
 
 import logging
+from dataclasses import dataclass
 
 from lib import config
 from lib.common import randid
 from lib.host import Host
+from lib.sr import SR
+from lib.vdi import ImageFormat
 from lib.vm import VM
 from tests.storage import install_randstream
 
@@ -46,3 +49,48 @@ def temp_large_dir(host: Host) -> Generator[str, None, None]:
         host.ssh(f'mkdir {path}')
         yield path
         host.ssh(f'rm -rf {path}')
+
+
+@dataclass
+class XfsConfig:
+    uninstall_xfs: bool = True
+
+@pytest.fixture(scope='package')
+def _xfs_config_on_hostA2() -> XfsConfig:
+    return XfsConfig()
+
+# NOTE: @pytest.mark.usefixtures does not parametrize this fixture.
+# To recreate host_with_xfsprogs for each image_format value, accept
+# image_format in the fixture arguments.
+# ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
+@pytest.fixture(scope='package')
+def hostA2_with_xfsprogs(hostA2: Host, image_format: ImageFormat, _xfs_config_on_hostA2: XfsConfig) \
+        -> Generator[Host, None, None]:
+    assert not hostA2.file_exists('/usr/sbin/mkfs.xfs'), \
+        "xfsprogs must not be installed on the host at the beginning of the tests"
+    hostA2.yum_save_state()
+    hostA2.yum_install(['xfsprogs'])
+    yield hostA2
+    # teardown
+    if _xfs_config_on_hostA2.uninstall_xfs:
+        hostA2.yum_restore_saved_state()
+
+@pytest.fixture(scope='package')
+def xfs_sr_on_hostA2(
+    unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+    hostA2_with_xfsprogs: Host,
+    image_format: ImageFormat,
+    _xfs_config_on_hostA2: XfsConfig,
+) -> Generator[SR, None, None]:
+    """ A XFS SR on first host. """
+    sr_disk = unused_512B_disks[hostA2_with_xfsprogs][0]["name"]
+    sr = hostA2_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
+                                        {'device': '/dev/' + sr_disk,
+                                         'preferred-image-formats': image_format})
+    yield sr
+    # teardown
+    try:
+        sr.destroy()
+    except Exception as e:
+        _xfs_config_on_hostA2.uninstall_xfs = False
+        raise pytest.fail("Could not destroy xfs SR, leaving packages in place for manual cleanup") from e

--- a/tests/storage/ext/test_ext_sr_crosspool_migration.py
+++ b/tests/storage/ext/test_ext_sr_crosspool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, xfs_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_ext_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/ext/test_ext_sr_crosspool_migration.py
+++ b/tests/storage/ext/test_ext_sr_crosspool_migration.py
@@ -16,10 +16,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, local_sr_on_hostB1: SR) -> None:
-        cold_migration_then_come_back(vm_on_ext_sr, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        cold_migration_then_come_back(vm_on_ext_sr, host, hostB1, xfs_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, local_sr_on_hostB1: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_ext_sr, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_ext_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_ext_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/ext/test_ext_sr_intrapool_migration.py
+++ b/tests/storage/ext/test_ext_sr_intrapool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, xfs_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_ext_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/ext/test_ext_sr_intrapool_migration.py
+++ b/tests/storage/ext/test_ext_sr_intrapool_migration.py
@@ -16,10 +16,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, local_sr_on_hostA2: SR) -> None:
-        cold_migration_then_come_back(vm_on_ext_sr, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        cold_migration_then_come_back(vm_on_ext_sr, host, hostA2, xfs_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, local_sr_on_hostA2: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_ext_sr, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_ext_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_ext_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
@@ -16,14 +16,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_crosspool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM) -> None:
         sr = vm_on_glusterfs_sr.get_sr()

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -16,18 +16,18 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("local_sr_on_hostA2")
+@pytest.mark.usefixtures("xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM) -> None:
         sr = vm_on_glusterfs_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
@@ -14,14 +14,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
@@ -14,14 +14,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(
         self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostA2: SR

--- a/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
@@ -16,14 +16,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_linstor_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_linstor_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_crosspool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_linstor_sr: VM) -> None:
         sr = vm_on_linstor_sr.get_sr()

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -16,18 +16,18 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_linstor_sr: VM) -> None:
         sr = vm_on_linstor_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_linstor_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_linstor_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -14,11 +14,11 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
-    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, local_sr_on_hostB1: SR) -> None:
-        cold_migration_then_come_back(vm_on_lvm_sr, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        cold_migration_then_come_back(vm_on_lvm_sr, host, hostB1, xfs_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, local_sr_on_hostB1: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_crosspool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostB1: SR) -> None:

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -14,11 +14,11 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
-    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, local_sr_on_hostA2: SR) -> None:
-        cold_migration_then_come_back(vm_on_lvm_sr, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        cold_migration_then_come_back(vm_on_lvm_sr, host, hostA2, xfs_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, local_sr_on_hostA2: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_lvm_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
+++ b/tests/storage/lvm/test_lvm_sr_intrapool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
     def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_lvm_sr: VM, xfs_sr_on_hostA2: SR) -> None:

--- a/tests/storage/lvmohba/test_lvmohba_sr_crosspool_migration.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr_crosspool_migration.py
@@ -11,11 +11,11 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
-    def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvmohba_sr, local_sr_on_hostB1):
-        cold_migration_then_come_back(vm_on_lvmohba_sr, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvmohba_sr, xfs_sr_on_hostB1):
+        cold_migration_then_come_back(vm_on_lvmohba_sr, host, hostB1, xfs_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host, hostB1, vm_on_lvmohba_sr, local_sr_on_hostB1):
-        live_storage_migration_then_come_back(vm_on_lvmohba_sr, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host, hostB1, vm_on_lvmohba_sr, xfs_sr_on_hostB1):
+        live_storage_migration_then_come_back(vm_on_lvmohba_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/lvmohba/test_lvmohba_sr_crosspool_migration.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr_crosspool_migration.py
@@ -11,7 +11,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(self, host, hostB1, vm_on_lvmohba_sr, xfs_sr_on_hostB1):

--- a/tests/storage/lvmohba/test_lvmohba_sr_intrapool_migration.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr_intrapool_migration.py
@@ -11,15 +11,15 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_lvmohba_sr):
         sr = vm_on_lvmohba_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_lvmohba_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(self, host, hostA2, vm_on_lvmohba_sr, local_sr_on_hostA2):
-        cold_migration_then_come_back(vm_on_lvmohba_sr, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host, hostA2, vm_on_lvmohba_sr, xfs_sr_on_hostA2):
+        cold_migration_then_come_back(vm_on_lvmohba_sr, host, hostA2, xfs_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host, hostA2, vm_on_lvmohba_sr, local_sr_on_hostA2):
-        live_storage_migration_then_come_back(vm_on_lvmohba_sr, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host, hostA2, vm_on_lvmohba_sr, xfs_sr_on_hostA2):
+        live_storage_migration_then_come_back(vm_on_lvmohba_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/lvmohba/test_lvmohba_sr_intrapool_migration.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr_intrapool_migration.py
@@ -11,7 +11,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
     def test_live_intrapool_shared_migration(self, host, hostA2, vm_on_lvmohba_sr):

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_crosspool_migration.py
@@ -14,15 +14,15 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 @pytest.mark.thick_provisioned
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_lvmoiscsi_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -14,7 +14,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM) -> None:
@@ -22,11 +22,11 @@ class Test:
         live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_lvmoiscsi_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr_intrapool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 @pytest.mark.thick_provisioned
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_lvmoiscsi_sr: VM) -> None:

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -16,7 +16,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1", "host_no_ipv6") # MooseFS doesn't support IPv6
+@pytest.mark.usefixtures("host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_crosspool_migration.py
@@ -16,14 +16,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1", "host_no_ipv6") # MooseFS doesn't support IPv6
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_moosefs_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -16,18 +16,18 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2", "host_no_ipv6") # MooseFS doesn't support IPv6
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2", "host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM) -> None:
         sr = vm_on_moosefs_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_moosefs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
+++ b/tests/storage/moosefs/test_moosefs_sr_intrapool_migration.py
@@ -16,7 +16,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2", "host_no_ipv6") # MooseFS doesn't support IPv6
+@pytest.mark.usefixtures("host_no_ipv6") # MooseFS doesn't support IPv6
 class Test:
     def test_live_intrapool_shared_migration(self, host: Host, hostA2: Host, vm_on_moosefs_sr: VM) -> None:
         sr = vm_on_moosefs_sr.get_sr()

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 # Make sure these fixtures are called before the parametrized one
 @pytest.mark.usefixtures('vm_ref')
 @pytest.mark.usefixtures('image_format')

--- a/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_crosspool_migration.py
@@ -14,15 +14,15 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 # Make sure these fixtures are called before the parametrized one
 @pytest.mark.usefixtures('vm_ref')
 @pytest.mark.usefixtures('image_format')
 class Test:
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, local_sr_on_hostB1: SR) -> None:
-        cold_migration_then_come_back(dispatch_nfs, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, xfs_sr_on_hostB1: SR) -> None:
+        cold_migration_then_come_back(dispatch_nfs, host, hostB1, xfs_sr_on_hostB1)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_live_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, local_sr_on_hostB1: SR) -> None:
-        live_storage_migration_then_come_back(dispatch_nfs, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, dispatch_nfs: VM, xfs_sr_on_hostB1: SR) -> None:
+        live_storage_migration_then_come_back(dispatch_nfs, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -14,7 +14,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 # Make sure these fixtures are called before the parametrized one
 @pytest.mark.usefixtures('vm_ref')
 @pytest.mark.usefixtures('image_format')

--- a/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
+++ b/tests/storage/nfs/test_nfs_sr_intrapool_migration.py
@@ -14,7 +14,7 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 # Make sure these fixtures are called before the parametrized one
 @pytest.mark.usefixtures('vm_ref')
 @pytest.mark.usefixtures('image_format')
@@ -25,9 +25,9 @@ class Test:
         live_storage_migration_then_come_back(dispatch_nfs, host, hostA2, sr)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, local_sr_on_hostA2: SR) -> None:
-        cold_migration_then_come_back(dispatch_nfs, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, xfs_sr_on_hostA2: SR) -> None:
+        cold_migration_then_come_back(dispatch_nfs, host, hostA2, xfs_sr_on_hostA2)
 
     @pytest.mark.parametrize('dispatch_nfs', ['vm_on_nfs_sr', 'vm_on_nfs4_sr'], indirect=True)
-    def test_live_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, local_sr_on_hostA2: SR) -> None:
-        live_storage_migration_then_come_back(dispatch_nfs, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, dispatch_nfs: VM, xfs_sr_on_hostA2: SR) -> None:
+        live_storage_migration_then_come_back(dispatch_nfs, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
@@ -18,7 +18,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_xfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_crosspool_migration.py
@@ -18,10 +18,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, local_sr_on_hostB1: SR) -> None:
-        cold_migration_then_come_back(vm_on_xfs_sr, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        cold_migration_then_come_back(vm_on_xfs_sr, host, hostB1, xfs_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, local_sr_on_hostB1: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
@@ -18,10 +18,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, local_sr_on_hostA2: SR) -> None:
-        cold_migration_then_come_back(vm_on_xfs_sr, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        cold_migration_then_come_back(vm_on_xfs_sr, host, hostA2, xfs_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, local_sr_on_hostA2: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_xfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
+++ b/tests/storage/xfs/test_xfs_sr_intrapool_migration.py
@@ -18,7 +18,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally on a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_xfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_xfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
         cold_migration_then_come_back(vm_on_zfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_crosspool_migration.py
@@ -16,10 +16,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
-    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, local_sr_on_hostB1: SR) -> None:
-        cold_migration_then_come_back(vm_on_zfs_sr, host, hostB1, local_sr_on_hostB1)
+    def test_cold_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        cold_migration_then_come_back(vm_on_zfs_sr, host, hostB1, xfs_sr_on_hostB1)
 
-    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, local_sr_on_hostB1: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostB1, local_sr_on_hostB1)
+    def test_live_crosspool_migration(self, host: Host, hostB1: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostB1: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
@@ -16,10 +16,10 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
-    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, local_sr_on_hostA2: SR) -> None:
-        cold_migration_then_come_back(vm_on_zfs_sr, host, hostA2, local_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        cold_migration_then_come_back(vm_on_zfs_sr, host, hostA2, xfs_sr_on_hostA2)
 
-    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, local_sr_on_hostA2: SR) -> None:
-        live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostA2, local_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_zfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
+++ b/tests/storage/zfs/test_zfs_sr_intrapool_migration.py
@@ -16,7 +16,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_zfs_sr: VM, xfs_sr_on_hostA2: SR) -> None:
         cold_migration_then_come_back(vm_on_zfs_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
@@ -17,14 +17,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.xfail
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "local_sr_on_hostB1")
+@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, local_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, xfs_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, local_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostB1, xfs_sr_on_hostB1)

--- a/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_crosspool_migration.py
@@ -17,7 +17,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.xfail
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostB1", "xfs_sr_on_hostB1")
 class Test:
     def test_cold_crosspool_migration(
         self, host: Host, hostB1: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostB1: SR

--- a/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
@@ -17,14 +17,14 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.xfail
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "local_sr_on_hostA2")
+@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, local_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, xfs_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, local_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, local_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_zfsvol_sr, host, hostA2, xfs_sr_on_hostA2)

--- a/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr_intrapool_migration.py
@@ -17,7 +17,6 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.xfail
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
-@pytest.mark.usefixtures("hostA2", "xfs_sr_on_hostA2")
 class Test:
     def test_cold_intrapool_migration(
         self, host: Host, hostA2: Host, vm_on_zfsvol_sr: VM, xfs_sr_on_hostA2: SR


### PR DESCRIPTION
in order to have large enough disks to migrate VMs with large disks.

Note for later: we should think of a better way to say 'I need a local SR with 16TiB available'.

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. **"migration: create a xfs sr on the second host for intra/cross-pool migration" (this PR) → #481**
18. #498 → #497
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->