### PR TITLE
Enhance block device management

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,19 @@
+name: Run unit tests
+
+on: [push]
+
+permissions: {}
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/uv-setup/
+        with:
+          dev: false
+      - name: Create a dummy data.py
+        run: cp data.py-dist data.py
+      - run: pytest tests/unit/

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import argparse
+import dataclasses
 import itertools
 import logging
 import os
@@ -435,6 +436,42 @@ def disks(pytestconfig: pytest.Config, pools_hosts_by_name_or_ip: dict[HostAddre
     ret = {host: list(_host_disks(host, cli_disks.get(host.hostname_or_ip)))
            for host in pools_hosts_by_name_or_ip.values()
            }
+    # Cross-host deduplication: a LUN in use on any host (same WWN) is unavailable on all hosts.
+    # This matters for shared FC/iSCSI LUNs visible on multiple hosts simultaneously.
+    used_wwns = {
+        disk.wwn
+        for host_disks in ret.values()
+        for disk in host_disks
+        if disk.wwn and not disk.available
+    }
+    if used_wwns:
+        logging.debug("cross-host used WWNs: %s", used_wwns)
+        ret = {
+            host: [
+                dataclasses.replace(disk, available=False) if (disk.wwn and disk.wwn in used_wwns) else disk
+                for disk in host_disks
+            ]
+            for host, host_disks in ret.items()
+        }
+    # LUNs reserved for lvmohba/lvmoiscsi: sort them to the end so they are
+    # only picked if no other disk is available.
+    reserved_wwns: set[str] = set()
+    try:
+        import data
+        for key in ('LVMOHBA_DEVICE_CONFIG', 'LVMOISCSI_DEVICE_CONFIG'):
+            cfg = getattr(data, key, None)
+            if isinstance(cfg, dict):
+                scsiid = cfg.get('SCSIid', '').lower().removeprefix('0x')
+                if len(scsiid) >= 16:
+                    reserved_wwns.add(scsiid[:16])
+    except ImportError:
+        pass
+    if reserved_wwns:
+        logging.debug("reserved WWNs (lvmohba/lvmoiscsi): %s", reserved_wwns)
+        ret = {
+            host: sorted(host_disks, key=lambda d: d.wwn in reserved_wwns)
+            for host, host_disks in ret.items()
+        }
     logging.debug("disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})
     return ret
 

--- a/conftest.py
+++ b/conftest.py
@@ -425,12 +425,12 @@ def disks(pytestconfig: pytest.Config, pools_hosts_by_name_or_ip: dict[HostAddre
         # check all disks in --disks=host:... exist
         for cli_disk in hosts_cli_disks:
             for disk in host_disks:
-                if disk['name'] == cli_disk:
+                if disk.name == cli_disk:
                     yield disk
                     break # names are unique, don't expect another one
             else:
                 raise Exception(f"no {cli_disk!r} disk on host {host.hostname_or_ip}, "
-                                f"has {','.join(disk['name'] for disk in host_disks)}")
+                                f"has {','.join(disk.name for disk in host_disks)}")
 
     ret = {host: list(_host_disks(host, cli_disks.get(host.hostname_or_ip)))
            for host in pools_hosts_by_name_or_ip.values()
@@ -443,7 +443,7 @@ def unused_512B_disks(disks: dict[Host, list[Host.BlockDeviceInfo]]
                       ) -> dict[Host, list[Host.BlockDeviceInfo]]:
     """Dict identifying names of all 512-bytes-blocks disks for on all hosts of first pool."""
     ret = {host: [disk for disk in host_disks
-                  if disk["log-sec"] == "512" and host.disk_is_available(disk["name"])]
+                  if disk.log_sec == 512 and disk.available]
            for host, host_disks in disks.items()
            }
     logging.debug("available disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})
@@ -454,7 +454,7 @@ def unused_4k_disks(disks: dict[Host, list[Host.BlockDeviceInfo]]
                     ) -> dict[Host, list[Host.BlockDeviceInfo]]:
     """Dict identifying names of all 4K-blocks disks for on all hosts of first pool."""
     ret = {host: [disk for disk in host_disks
-                  if disk["log-sec"] == "4096" and host.disk_is_available(disk["name"])]
+                  if disk.log_sec == 4096 and disk.available]
            for host, host_disks in disks.items()
            }
     logging.debug("available 4k disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})

--- a/lib/host.py
+++ b/lib/host.py
@@ -7,12 +7,12 @@ import shlex
 import subprocess
 import tempfile
 import uuid
+from dataclasses import dataclass
 
 from packaging import version
 
 import lib.commands as commands
 from lib.common import (
-    DiskDevName,
     _param_add,
     _param_clear,
     _param_get,
@@ -31,7 +31,7 @@ from lib.sr import SR
 from lib.vm import VM
 from lib.xo import xo_cli, xo_object_exists
 
-from typing import TYPE_CHECKING, Literal, TypedDict, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 if TYPE_CHECKING:
     from lib.pool import Pool
@@ -55,14 +55,15 @@ class Host:
     pool: "Pool"
 
     # Data extraction is automatic, no conversion from str is done.
-    BlockDeviceInfo = TypedDict('BlockDeviceInfo', {"name": str,
-                                                    "kname": str,
-                                                    "pkname": str,
-                                                    "size": str,
-                                                    "log-sec": str,
-                                                    "type": str,
-                                                    })
-    BLOCK_DEVICES_FIELDS = ','.join(k.upper() for k in BlockDeviceInfo.__annotations__)
+    @dataclass
+    class BlockDeviceInfo:
+        name: str       # short kernel name: "sda", "md0", "dm-3"
+        path: str       # full device path: "/dev/sda", "/dev/md/myarray", "/dev/mapper/mpathb"
+        size: int       # bytes
+        log_sec: int    # logical sector size
+        type: str       # "disk", "md", "mpath"
+        available: bool # not mounted, not member of md/lvm/mpath/zfs
+        wwn: str = ''   # LUN WWN (hex, no 0x prefix); same LUN has same WWN across hosts
 
     block_devices_info: list[BlockDeviceInfo]
 
@@ -669,48 +670,126 @@ class Host:
 
     def rescan_block_devices_info(self) -> None:
         """
-        Initalize static informations about the disks.
+        Initialize information about block devices: local disks, mdadm arrays, and multipath devices.
 
-        Despite those being static, it can be necessary to rescan,
+        Despite those being mostly static, it can be necessary to rescan,
         when we test how XCP-ng reacts to changes of hardware (or
         reconfiguration of device blocksize), or after a reboot.
-        """
-        output_string = self.ssh(
-            f'lsblk --pairs --bytes -I 8,259 --output {Host.BLOCK_DEVICES_FIELDS}'
-        )  # limit to: sd, blkext
 
-        self.block_devices_info = [
-            Host.BlockDeviceInfo({key.lower(): value.strip('"') # type: ignore[misc]
-                                  for key, value in re.findall(r'(\S+)=(".*?"|\S+)', line)})
-            for line in output_string.strip().splitlines()
+        Handled device scenarios and their effect on `available`:
+
+        - Plain disk, no children: available unless the disk itself has a
+          mountpoint.
+        - Partitioned disk: available if no partition is mounted and no partition
+          has a used child (lvm, md, mpath, crypt); unavailable otherwise.
+        - Disk member of an mdadm array: the disk itself is unavailable; the md
+          array is added as a separate entry (type 'md'), deduplicated across
+          member appearances, and available if it has no mountpoint and no used
+          children.
+        - LUN with multipath configured: each path appears as a 'disk' entry and
+          a shared 'mpath' entry as its child. The path disks are unavailable
+          (mpath child); the mpath device is added once (type 'mpath'),
+          deduplicated by kname across path appearances.
+        - LUN accessible through multiple paths without multipath configured:
+          multiple 'disk' entries with no children but sharing the same WWN.
+          Deduplicated to a single entry (first path seen) based on WWN.
+        """
+        RAID_TYPES = {'raid0', 'raid1', 'raid4', 'raid5', 'raid6', 'raid10', 'linear'}
+        USED_TYPES = RAID_TYPES | {'lvm', 'mpath', 'crypt'}
+        LSBLK_FIELDS = 'NAME,KNAME,PKNAME,SIZE,LOG-SEC,TYPE,MOUNTPOINT,WWN'
+
+        devices: list[Host.BlockDeviceInfo] = []
+
+        raw = self.ssh(f'lsblk --pairs --bytes --output {LSBLK_FIELDS}')
+
+        def _split_keys(line: str) -> list[tuple[str, str]]:
+            return re.findall(r'(\S+)=(".*?"|\S+)', line)
+
+        rows = [
+            {key.lower(): val.strip('"') for key, val in _split_keys(line)}
+            for line in raw.strip().splitlines()
         ]
-        logging.debug("blockdevs found: %s", [disk["name"] for disk in self.block_devices_info])
+
+        # build children map: kname -> list of child knames
+        children: dict[str, list[str]] = {}
+        for r in rows:
+            if r['pkname']:
+                children.setdefault(r['pkname'], []).append(r['kname'])
+
+        # availability from lsblk fields: no mountpoint, not a "used" type, all descendants also free
+        def _row_by_kname(kname: str) -> dict[str, str] | None:
+            for r in rows:
+                if r['kname'] == kname:
+                    return r
+            return None
+
+        def _all_available(kname: str) -> bool:
+            r = _row_by_kname(kname)
+            if r is None:
+                return False
+            if r['mountpoint'] or r['type'] in USED_TYPES:
+                return False
+            return all(_all_available(c) for c in children.get(kname, []))
+
+        seen_knames: set[str] = set()
+        seen_wwns: set[str] = set()
+
+        for r in rows:
+            # --- local disks ---
+            if r['type'] == 'disk' and not r['pkname']:
+                wwn = r['wwn']
+                if wwn:
+                    if wwn in seen_wwns:
+                        continue
+                    seen_wwns.add(wwn)
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['name'],
+                    path=f'/dev/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='disk',
+                    available=_all_available(r['kname']),
+                    wwn=wwn.removeprefix('0x'),
+                ))
+
+            # --- mdadm arrays (may appear once per member, deduplicate) ---
+            elif r['type'] in RAID_TYPES:
+                if r['kname'] in seen_knames:
+                    continue
+                seen_knames.add(r['kname'])
+                available = not r['mountpoint'] and all(_all_available(c) for c in children.get(r['kname'], []))
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['name'],
+                    path=f'/dev/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='md',
+                    available=available,
+                ))
+
+            # --- multipath devices (may appear once per path, deduplicate) ---
+            elif r['type'] == 'mpath':
+                if r['kname'] in seen_knames:
+                    continue
+                seen_knames.add(r['kname'])
+                available = not r['mountpoint'] and all(_all_available(c) for c in children.get(r['kname'], []))
+                wwn = r['name'][1:17] if re.fullmatch(r'3[0-9a-f]{32}', r['name']) else ''
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['kname'],
+                    path=f'/dev/mapper/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='mpath',
+                    available=available,
+                    wwn=wwn,
+                ))
+
+        self.block_devices_info = sorted(devices, key=lambda d: d.size, reverse=True)
+        logging.debug("blockdevs found: %s", [d.name for d in self.block_devices_info])
 
     def disks(self) -> list[Host.BlockDeviceInfo]:
-        """ List of BlockDeviceInfo for all disks. """
-        # store the names of the parent devices to filter out the devices with children
-        pknames = set(disk['pkname'] for disk in self.block_devices_info if disk['pkname'])
-        # filter out partitions from block_devices
-        return sorted(
-            (
-                disk
-                for disk in self.block_devices_info
-                if (not disk["pkname"] or disk['type'] == 'raid0') and disk['kname'] not in pknames
-            ),
-            key=lambda disk: disk["name"],
-        )
-
-    def disk_is_available(self, disk: DiskDevName) -> bool:
-        """
-        Check if a disk is unmounted and appears available for use.
-
-        It may or may not contain identifiable filesystem or partition label.
-        If there are no mountpoints, it is assumed that the disk is not in use.
-
-        Warn: This function may misclassify LVM_member disks (e.g. in XOSTOR, RAID, ZFS) as "available".
-        Such disks may not have mountpoints but still be in use.
-        """
-        return len(self.ssh(f'lsblk --noheadings -o MOUNTPOINT /dev/{disk}').strip()) == 0
+        """ List of all block devices (local disks, mdadm arrays, multipath devices). """
+        return list(self.block_devices_info)
 
     def file_exists(self, filepath: str, regular_file: bool = True) -> bool:
         option = '-f' if regular_file else '-e'

--- a/pkgfixtures.py
+++ b/pkgfixtures.py
@@ -25,7 +25,7 @@ def sr_disk_wiped(host: Host, unused_512B_disks: dict[Host, list[Host.BlockDevic
     """A disk on MASTER HOST OF FIRST POOL which we wipe."""
     host_disks = unused_512B_disks[host]
     assert host_disks, f"No 512B disk available on host {host}"
-    sr_disk = host_disks[0]["name"]
+    sr_disk = host_disks[0].name
     logging.info(">> wipe disk %s" % sr_disk)
     host.ssh(f'wipefs -a /dev/{sr_disk}')
     yield sr_disk
@@ -38,7 +38,7 @@ def formatted_and_mounted_ext4_disk(host: Host, unused_512B_disks: dict[Host, li
     mountpoint = '/var/tmp/sr_disk_mountpoint'
     host_disks = unused_512B_disks[host]
     assert host_disks, f"No 512B disk available on host {host}"
-    sr_disk = host_disks[0]["name"]
+    sr_disk = host_disks[0].name
     setup_formatted_and_mounted_disk(host, sr_disk, 'ext4', mountpoint)
     yield mountpoint
     teardown_formatted_and_mounted_disk(host, mountpoint)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra --maxfail=1 --ignore=contrib/
+addopts = -ra --maxfail=1 --ignore=contrib/ --ignore=tests/unit
 markers =
     # *** Markers that change test behaviour ***
     default_vm: mark a test with a default VM in case no --vm parameter was given.

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -83,7 +83,7 @@ def xfs_sr_on_hostA2(
     _xfs_config_on_hostA2: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[hostA2_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[hostA2_with_xfsprogs][0].name
     sr = hostA2_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                         {'device': '/dev/' + sr_disk,
                                          'preferred-image-formats': image_format})
@@ -123,7 +123,7 @@ def xfs_sr_on_hostB1(
     _xfs_config_on_hostB1: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[hostB1_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[hostB1_with_xfsprogs][0].name
     sr = hostB1_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                         {'device': '/dev/' + sr_disk,
                                          'preferred-image-formats': image_format})

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -18,7 +18,7 @@ def ext_sr(host: Host,
            image_format: ImageFormat
            ) -> Generator[SR, None, None]:
     """ An EXT SR on first host. """
-    sr_disk = unused_512B_disks[host][0]["name"]
+    sr_disk = unused_512B_disks[host][0].name
     sr = host.sr_create('ext', "EXT-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -42,7 +42,7 @@ class TestEXTSRCreateDestroy:
                                    image_format: ImageFormat
                                    ) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr = host.sr_create('ext', "EXT-local-SR-test",
                             {'device': '/dev/' + sr_disk,
                              'preferred-image-formats': image_format}, verify=True)

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -122,7 +122,7 @@ def gluster_disk(
     pool = pool_with_unused_512B_disk
     mountpoint = '/mnt/sr_disk'
     for h in pool.hosts:
-        sr_disk = unused_512B_disks[h][0]["name"]
+        sr_disk = unused_512B_disks[h][0].name
         setup_formatted_and_mounted_disk(h, sr_disk, 'xfs', mountpoint)
 
     yield

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -20,7 +20,7 @@ def largeblock_sr(host: Host,
                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
                   image_format: ImageFormat) -> Generator[SR, None, None]:
     """ A LARGEBLOCK SR on first host. """
-    sr_disk = unused_4k_disks[host][0]["name"]
+    sr_disk = unused_4k_disks[host][0].name
     sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/largeblock/test_largeblock_sr.py
+++ b/tests/storage/largeblock/test_largeblock_sr.py
@@ -31,7 +31,7 @@ class TestLARGEBLOCKSRCreateDestroy:
                                    unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
                                    image_format: ImageFormat) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_4k_disks[host][0]["name"]
+        sr_disk = unused_4k_disks[host][0].name
         sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
                             {'device': '/dev/' + sr_disk,
                              'preferred-image-formats': image_format}, verify=True)

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -60,7 +60,7 @@ def lvm_disks(
 
     @functools.cache
     def host_devices(host: Host) -> list[str]:
-        return [os.path.join("/dev", disk["name"]) for disk in unused_512B_disks[host][0:1]]
+        return [disk.path for disk in unused_512B_disks[host][0:1]]
 
     for host in hosts:
         devices = host_devices(host)

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -18,7 +18,7 @@ def lvm_sr(host: Host,
            image_format: ImageFormat
            ) -> Generator[SR, None, None]:
     """ An LVM SR on first host. """
-    sr_disk = unused_512B_disks[host][0]["name"]
+    sr_disk = unused_512B_disks[host][0].name
     sr = host.sr_create('lvm', "LVM-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -41,7 +41,7 @@ class TestLVMSRCreateDestroy:
                                    unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
                                    image_format: ImageFormat
                                    ) -> None:
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('lvm', "LVM-local-SR-test", {
             'device': '/dev/' + sr_disk,

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -44,7 +44,7 @@ def xfs_sr(
     _xfs_config: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[host_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[host_with_xfsprogs][0].name
     sr = host_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                       {'device': '/dev/' + sr_disk,
                                        'preferred-image-formats': image_format})

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -42,7 +42,7 @@ class TestXFSSRCreateDestroy:
         # This test must be the first in the series in this module
         assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
             "xfsprogs must not be installed on the host at the beginning of the tests"
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr: SR | None = None
         try:
             sr = host.sr_create('xfs', "XFS-local-SR-test", {
@@ -61,7 +61,7 @@ class TestXFSSRCreateDestroy:
                                    ) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         host = host_with_xfsprogs
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
         # the next tests, because errors in fixtures break teardown

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -44,6 +44,7 @@ def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None,
     yield
     # teardown
     host_with_zfs.ssh(f'zpool destroy {POOL_NAME}')
+    host_with_zfs.ssh(f'wipefs -a /dev/{sr_disk_wiped}')
 
 @pytest.fixture(scope='package')
 def zfs_sr(host: Host, image_format: ImageFormat, zpool_vol0: None) -> Generator[SR, None, None]:

--- a/tests/unit/test_rescan_block_devices_info.py
+++ b/tests/unit/test_rescan_block_devices_info.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+# flake8: noqa: E501 - lsblk output lines are intentionally long
+from unittest.mock import MagicMock
+
+from lib.common import KiB
+from lib.host import Host
+
+# ---------------------------------------------------------------------------
+# lsblk fixtures
+# ---------------------------------------------------------------------------
+
+# Full real-world output with multipath (multiple paths per device).
+# Two mpath devices:
+#   dm-0  (3600507681381022548000000000001ec)  - in use: mounted partitions
+#   dm-8  (3600507638081046dd800000000000043)  - free: one lvm child (unused)
+# Plain disks:
+#   sdf / sdb / sdm / sde / sdc / sdj / sdr  - free (no children, no mpath)
+#   sdd / sdk / sdg / sdh / sdl / sdp / sdq / sdt - paths for dm-0 (in use)
+#   sdo / sds / sdi / sda                         - paths for dm-8 (free)
+LSBLK_FULL = """\
+NAME="sdf" KNAME="sdf" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdo" KNAME="sdo" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sdo" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdd" KNAME="sdd" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd2" KNAME="sdd2" PKNAME="sdd" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd5" KNAME="sdd5" PKNAME="sdd" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd3" KNAME="sdd3" PKNAME="sdd" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd1" KNAME="sdd1" PKNAME="sdd" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd6" KNAME="sdd6" PKNAME="sdd" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd4" KNAME="sdd4" PKNAME="sdd" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdd" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdm" KNAME="sdm" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdk" KNAME="sdk" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk5" KNAME="sdk5" PKNAME="sdk" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk3" KNAME="sdk3" PKNAME="sdk" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk1" KNAME="sdk1" PKNAME="sdk" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk6" KNAME="sdk6" PKNAME="sdk" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk4" KNAME="sdk4" PKNAME="sdk" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk2" KNAME="sdk2" PKNAME="sdk" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdk" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sds" KNAME="sds" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sds" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdi" KNAME="sdi" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sdi" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdq" KNAME="sdq" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq4" KNAME="sdq4" PKNAME="sdq" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq2" KNAME="sdq2" PKNAME="sdq" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq5" KNAME="sdq5" PKNAME="sdq" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq3" KNAME="sdq3" PKNAME="sdq" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq1" KNAME="sdq1" PKNAME="sdq" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq6" KNAME="sdq6" PKNAME="sdq" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdq" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdg" KNAME="sdg" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg5" KNAME="sdg5" PKNAME="sdg" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg3" KNAME="sdg3" PKNAME="sdg" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg1" KNAME="sdg1" PKNAME="sdg" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg6" KNAME="sdg6" PKNAME="sdg" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg4" KNAME="sdg4" PKNAME="sdg" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg2" KNAME="sdg2" PKNAME="sdg" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdg" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sde" KNAME="sde" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdn" KNAME="sdn" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdc" KNAME="sdc" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdl" KNAME="sdl" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl5" KNAME="sdl5" PKNAME="sdl" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl3" KNAME="sdl3" PKNAME="sdl" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl1" KNAME="sdl1" PKNAME="sdl" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl6" KNAME="sdl6" PKNAME="sdl" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl4" KNAME="sdl4" PKNAME="sdl" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl2" KNAME="sdl2" PKNAME="sdl" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdl" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdt" KNAME="sdt" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdt" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sda" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdj" KNAME="sdj" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdr" KNAME="sdr" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdh" KNAME="sdh" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh5" KNAME="sdh5" PKNAME="sdh" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh3" KNAME="sdh3" PKNAME="sdh" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh1" KNAME="sdh1" PKNAME="sdh" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh6" KNAME="sdh6" PKNAME="sdh" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh4" KNAME="sdh4" PKNAME="sdh" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh2" KNAME="sdh2" PKNAME="sdh" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdh" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdp" KNAME="sdp" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp4" KNAME="sdp4" PKNAME="sdp" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp2" KNAME="sdp2" PKNAME="sdp" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp5" KNAME="sdp5" PKNAME="sdp" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp3" KNAME="sdp3" PKNAME="sdq" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp1" KNAME="sdp1" PKNAME="sdp" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp6" KNAME="sdp6" PKNAME="sdp" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdp" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+"""
+
+# Minimal: single plain disk, no children
+# Minimal: md array across two disks, not mounted
+LSBLK_MD_FREE = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+"""
+
+
+# ---------------------------------------------------------------------------
+# helper
+# ---------------------------------------------------------------------------
+
+def _rescan(lsblk_output: str) -> list[Host.BlockDeviceInfo]:
+    host = MagicMock(spec=Host)
+    host.ssh.return_value = lsblk_output
+    Host.rescan_block_devices_info(host)
+    return host.block_devices_info
+
+
+def _by_name(devices: list[Host.BlockDeviceInfo], name: str) -> Host.BlockDeviceInfo:
+    matches = [d for d in devices if d.name == name]
+    assert len(matches) == 1, f"{name!r} found {len(matches)} times in {[d.name for d in devices]}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# focused tests
+# ---------------------------------------------------------------------------
+
+def test_plain_disk_no_children():
+    devices = _rescan(
+        'NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""\n'
+    )
+    assert len(devices) == 1
+    d = devices[0]
+    assert d.name == 'sda'
+    assert d.path == '/dev/sda'
+    assert d.type == 'disk'
+    assert d.size == 500107862016
+    assert d.log_sec == 512
+    assert d.available is True
+    assert d.wwn == ''
+
+
+def test_plain_disk_wwn_stripped():
+    devices = _rescan(
+        'NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"\n'
+    )
+    assert devices[0].wwn == '6005076813810286'
+
+
+def test_disk_with_free_partitions_is_available():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+""")
+    assert len(devices) == 1
+    d = devices[0]
+    assert d.name == 'sda'
+    assert d.type == 'disk'
+    assert d.available is True
+
+
+def test_disk_with_mounted_partition_is_unavailable():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+""")
+    assert len(devices) == 1
+    assert devices[0].available is False
+
+
+def test_disk_with_partition_in_raid_is_unavailable():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="sda1" SIZE="536739586048" LOG-SEC="512" TYPE="raid1" MOUNTPOINT="" WWN=""
+""")
+    # sda is a disk (unavailable), md0 is the raid array
+    disk = _by_name(devices, 'sda')
+    assert disk.available is False
+
+
+def test_md_array_detected():
+    devices = _rescan(LSBLK_MD_FREE)
+    md = _by_name(devices, 'md0')
+    assert md.type == 'md'
+    assert md.path == '/dev/md0'
+    assert md.size == 30721630535680
+
+
+def test_md_array_deduplicated():
+    # md0 appears twice in the lsblk output (once per member disk)
+    devices = _rescan(LSBLK_MD_FREE)
+    md_devices = [d for d in devices if d.name == 'md0']
+    assert len(md_devices) == 1
+
+
+def test_md_array_free_is_available():
+    devices = _rescan(LSBLK_MD_FREE)
+    assert _by_name(devices, 'md0').available is True
+
+
+def test_md_array_mounted_is_unavailable():
+    devices = _rescan("""\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="/mnt/data" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="/mnt/data" WWN=""
+""")
+    assert _by_name(devices, 'md0').available is False
+
+
+def test_md_member_disks_are_unavailable():
+    devices = _rescan(LSBLK_MD_FREE)
+    assert _by_name(devices, 'nvme0n1').available is False
+    assert _by_name(devices, 'nvme1n1').available is False
+
+
+# ---------------------------------------------------------------------------
+# full real-world output tests
+# ---------------------------------------------------------------------------
+
+def test_full_output_device_count():
+    devices = _rescan(LSBLK_FULL)
+    disks = [d for d in devices if d.type == 'disk']
+    mpaths = [d for d in devices if d.type == 'mpath']
+    # 3 unique WWNs across all disks:
+    #   sdf  (WWN 0x6005076813810286) - representative of 8 free plain disks
+    #   sdd  (WWN 0x6005076813810225) - representative of 8 paths for dm-0
+    #   sdo  (WWN 0x600507638081046d) - representative of 4 paths for dm-8
+    assert len(disks) == 3
+    # 2 mpath devices: dm-0 and dm-8
+    assert len(mpaths) == 2
+
+
+def test_full_output_mpath_deduplicated():
+    devices = _rescan(LSBLK_FULL)
+    mpaths = [d for d in devices if d.type == 'mpath']
+    names = {d.name for d in mpaths}
+    assert names == {'dm-0', 'dm-8'}
+
+
+def test_full_output_mpath_paths():
+    devices = _rescan(LSBLK_FULL)
+    dm0 = _by_name(devices, 'dm-0')
+    dm8 = _by_name(devices, 'dm-8')
+    assert dm0.path == '/dev/mapper/3600507681381022548000000000001ec'
+    assert dm8.path == '/dev/mapper/3600507638081046dd800000000000043'
+
+
+def test_full_output_mpath_availability():
+    devices = _rescan(LSBLK_FULL)
+    # dm-0 has mounted partitions (/, [SWAP], /boot/efi, /var/log) -> unavailable
+    assert _by_name(devices, 'dm-0').available is False
+    # dm-8 has an lvm child (dm-9) -> unavailable
+    assert _by_name(devices, 'dm-8').available is False
+
+
+def test_full_output_mpath_path_disks_unavailable():
+    devices = _rescan(LSBLK_FULL)
+    # First-seen path disk for dm-0 and dm-8 must be unavailable (mpath child)
+    assert _by_name(devices, 'sdd').available is False
+    assert _by_name(devices, 'sdo').available is False
+
+
+def test_full_output_free_plain_disks_available():
+    devices = _rescan(LSBLK_FULL)
+    # sdf is the first-seen representative of the 8 free disks sharing the same WWN
+    assert _by_name(devices, 'sdf').available is True
+
+
+def test_full_output_disk_wwn():
+    devices = _rescan(LSBLK_FULL)
+    # only the first-seen representative per WWN group is present after deduplication
+    assert _by_name(devices, 'sdf').wwn == '6005076813810286'
+    assert _by_name(devices, 'sdd').wwn == '6005076813810225'
+    assert _by_name(devices, 'sdo').wwn == '600507638081046d'
+
+
+def test_full_output_mpath_wwn():
+    devices = _rescan(LSBLK_FULL)
+    # mpath NAME is the T10 NAA identifier; strip the leading '3' and truncate to 16 hex chars
+    assert _by_name(devices, 'dm-0').wwn == '6005076813810225'
+    assert _by_name(devices, 'dm-8').wwn == '600507638081046d'
+
+
+def test_disk_with_lvm_child_is_unavailable():
+    # part -> lvm (mounted): unavailability must propagate up through the partition to the disk
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="myvg-mylv" KNAME="dm-0" PKNAME="sda1" SIZE="536220073984" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/data" WWN=""
+""")
+    assert _by_name(devices, 'sda').available is False
+
+
+# Full lsblk --pairs output from a host with:
+#   - sda: boot disk (mounted partitions, lvm child)
+#   - sdb: free disk with unused partitions
+#   - nvme0n1, nvme1n1: members of md0 (raid0)
+LSBLK_RAID1_HOST = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="240057409536" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sdb9" KNAME="sdb9" PKNAME="sdb" SIZE="8388608" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sdb1" KNAME="sdb1" PKNAME="sdb" SIZE="240047357952" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="240057409536" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda4" KNAME="sda4" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda5" KNAME="sda5" PKNAME="sda" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="sda3" KNAME="sda3" PKNAME="sda" SIZE="195496058368" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--9cf600ab--221b--8deb--a1f6--51354b56fb85-9cf600ab--221b--8deb--a1f6--51354b56fb85" KNAME="dm-0" PKNAME="sda3" SIZE="195483926528" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/9cf600ab-221b-8deb-a1f6-51354b56fb85" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda6" KNAME="sda6" PKNAME="sda" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+"""
+
+
+def test_raid1_host_sdb_free():
+    # sdb has only unused partitions -> available
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'sdb').available is True
+
+
+def test_raid1_host_sda_unavailable():
+    # sda has mounted partitions and an lvm child -> unavailable
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'sda').available is False
+
+
+def test_raid1_host_md0_detected_and_deduplicated():
+    devices = _rescan(LSBLK_RAID1_HOST)
+    md_devices = [d for d in devices if d.name == 'md0']
+    assert len(md_devices) == 1
+    assert md_devices[0].type == 'md'
+    assert md_devices[0].available is True
+
+
+def test_raid1_host_nvme_members_unavailable():
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'nvme0n1').available is False
+    assert _by_name(devices, 'nvme1n1').available is False
+
+
+# Full lsblk --pairs output from a simple host with no mpath or raid:
+#   - nvme0n1: free disk, no children
+#   - sda: boot disk (mounted partitions, lvm child)
+LSBLK_SIMPLE_HOST = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="512110190592" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="120034123776" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda4" KNAME="sda4" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda5" KNAME="sda5" PKNAME="sda" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="sda3" KNAME="sda3" PKNAME="sda" SIZE="75499053056" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--1fa367e3--84ac--b13d--7dc1--6c5ec5ad1808-1fa367e3--84ac--b13d--7dc1--6c5ec5ad1808" KNAME="dm-1" PKNAME="sda3" SIZE="75485585408" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/1fa367e3-84ac-b13d-7dc1-6c5ec5ad1808" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda6" KNAME="sda6" PKNAME="sda" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+"""
+
+
+def test_simple_host_nvme_free():
+    devices = _rescan(LSBLK_SIMPLE_HOST)
+    assert _by_name(devices, 'nvme0n1').available is True
+
+
+def test_simple_host_sda_unavailable():
+    devices = _rescan(LSBLK_SIMPLE_HOST)
+    assert _by_name(devices, 'sda').available is False
+
+
+# Full lsblk --pairs output from a host with:
+#   - nvme0n1: 4K logical sector size, free disk (no children)
+#   - nvme1n1: 512B logical sector size, boot disk (mounted partitions, lvm child)
+LSBLK_4K_BLOCK_DEVICE = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="1000204886016" LOG-SEC="4096" TYPE="disk" MOUNTPOINT="" WWN="eui.e8238fa6bf530001001b444a41dd2519"
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="512110190592" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p4" KNAME="nvme1n1p4" PKNAME="nvme1n1" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p2" KNAME="nvme1n1p2" PKNAME="nvme1n1" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p5" KNAME="nvme1n1p5" PKNAME="nvme1n1" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p3" KNAME="nvme1n1p3" PKNAME="nvme1n1" SIZE="467548839424" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="XSLocalEXT--1465252c--889c--e87a--b490--8a9f1dc848b0-1465252c--889c--e87a--b490--8a9f1dc848b0" KNAME="dm-1" PKNAME="nvme1n1p3" SIZE="467534872576" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/1465252c-889c-e87a-b490-8a9f1dc848b0" WWN=""
+NAME="nvme1n1p1" KNAME="nvme1n1p1" PKNAME="nvme1n1" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p6" KNAME="nvme1n1p6" PKNAME="nvme1n1" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN="eui.000000000000001000080d0300274f1e"
+"""
+
+
+def test_4k_block_device_detected():
+    devices = _rescan(LSBLK_4K_BLOCK_DEVICE)
+    d = _by_name(devices, 'nvme0n1')
+    assert d.path == '/dev/nvme0n1'
+    assert d.type == 'disk'
+    assert d.size == 1000204886016
+    assert d.log_sec == 4 * KiB
+    assert d.available is True
+
+
+# Two paths to the same LUN (same WWN), no multipath configured → deduplicate to one disk entry
+LSBLK_NO_MPATH_SAME_WWN = """\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0xAABBCCDD00112233"
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0xAABBCCDD00112233"
+"""
+
+
+def test_no_mpath_same_wwn_deduplicated():
+    devices = _rescan(LSBLK_NO_MPATH_SAME_WWN)
+    assert len(devices) == 1
+    assert devices[0].name == 'sda'
+
+
+def test_no_mpath_same_wwn_available():
+    devices = _rescan(LSBLK_NO_MPATH_SAME_WWN)
+    assert devices[0].available is True


### PR DESCRIPTION
Some block devices may be used to build other devices (mdadm, lvm) or be accessible on multiple hosts, but only usable on a single one at a time (fc, iscsi).

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. **"Enhance block device management" (this PR) → #497**
19. #500 → #498
20. #509 → #500
<!-- end jj-vine stack -->