### PR TITLE
Add VHD_MAX and QCOW2_MAX symbolic size constants

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -119,13 +119,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--volume-size",
         action="store",
         default="1GiB",
-        help="Default volume size for tests"
+        help="Default volume size for tests."
+             " Accepts sizes like '1GiB', '2.5TiB', or symbolic values 'VHD_MAX', 'QCOW2_MAX'."
     )
     parser.addoption(
         "--write-volume-cap",
         action="store",
         default="2GiB",
-        help="Maximum amount of data written to a volume"
+        help="Maximum amount of data written to a volume."
+             " Accepts sizes like '1GiB', '2.5TiB', or symbolic values 'VHD_MAX', 'QCOW2_MAX'."
     )
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/lib/common.py
+++ b/lib/common.py
@@ -40,10 +40,21 @@ MiB = KiB**2
 GiB = KiB**3
 TiB = KiB**4
 
+VHD_MAX = 2040 * GiB
+QCOW2_MAX = 16 * TiB - 2561 * MiB
+
+_SYMBOLIC_SIZES: dict[str, int] = {
+    'VHD_MAX': VHD_MAX,
+    'QCOW2_MAX': QCOW2_MAX,
+}
+
 def parse_size(size_str: str) -> int:
     """
-    Parse a size string like "2.5TiB", "1GiB" or "1024".
+    Parse a size string like "2.5TiB", "1GiB", "1024", "VHD_MAX", or "QCOW2_MAX".
     """
+    symbolic = _SYMBOLIC_SIZES.get(size_str.strip().upper())
+    if symbolic is not None:
+        return symbolic
     try:
         return int(size_str)
     except ValueError:

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from lib import config
 from lib.commands import SSHCommandFailed
-from lib.common import Defer, GiB, MiB, TiB, strtobool, wait_for
+from lib.common import QCOW2_MAX, VHD_MAX, Defer, GiB, MiB, TiB, strtobool, wait_for
 from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI, ImageFormat
@@ -13,7 +13,7 @@ from lib.vm import VM
 
 from typing import Literal
 
-MAX_VDI_SIZE: dict[ImageFormat, int] = {'qcow2': 16 * TiB - 2561 * MiB, 'vhd': 2040 * GiB}
+MAX_VDI_SIZE: dict[ImageFormat, int] = {'qcow2': QCOW2_MAX, 'vhd': VHD_MAX}
 
 def try_to_create_sr_with_missing_device(sr_type, label, host) -> None:
     try:


### PR DESCRIPTION
Allow passing VHD_MAX and QCOW2_MAX as values to --volume-size and
--write-volume-cap, making it easy to test at the maximum supported VDI
size for each image format. MAX_VDI_SIZE in storage.py is now derived
from the same constants to keep a single source of truth.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>

<!-- start jj-vine stack -->
This PR is part of a tree containing 19 PRs:

1. `master`
2. #436 → `master`
3. #437 → #436
4. #447 → #437
5. #446 → #447
6. #449 → #446
7. #450 → #449
8. #452 → #450
9. #453 → #452
10. #454 → #453
11. #461 → #454
12. #464 → #461
13. #470 → #464
14. #471 → #470
15. #481 → #471
16. #523 → #481
17. #497 → #481
18. #498 → #497
19. **"Add VHD_MAX and QCOW2_MAX symbolic size constants" (this PR) → #498**
20. #509 → #500
<!-- end jj-vine stack -->