### PR TITLE
Fix t/m/test_access_links.py by using a stable URL

### DIFF
--- a/tests/misc/test_access_links.py
+++ b/tests/misc/test_access_links.py
@@ -25,7 +25,7 @@ def test_access_links(host: Host, command_id: str, url_id: str) -> None:
                "wget": ["wget", "-qO-"]}[command_id]
     url = {
         "xoa": "https://xoa.io/deploy",
-        "xcpng": "https://updates.xcp-ng.org/trace",
+        "xcpng": "https://updates.xcp-ng.org/README.txt",
         "vates": "https://repo.vates.tech/README.txt"
     }[url_id]
     COMMAND = command + [url]


### PR DESCRIPTION
The previous URL is evolving over time, so it makes the test flacky.

https://updates.xcp-ng.org/trace is used to track mirror updates:

It's used for the last update info of https://mirrors.xcp-ng.org/?mirrorstats

Let's use a file with stable contents.

Observed issue:

    def test_access_links(host: Host, command_id: str, url_id: str) -> None:
        (...)
        command = {"curl": ["curl", "-fsSL"],
                   "wget": ["wget", "-qO-"]}[command_id]
         (...)
            "xcpng": "https://updates.xcp-ng.org/trace",
        (...)
        }[url_id]
        (...)
        # Verify the download worked by comparing with local download
        (...)
        # This ensures the content is accessible and identical from both locations
        (...)
        AssertionError: Checksum mismatch:
        (...)

    tests/misc/test_access_links.py:48: AssertionError