### PR TITLE
pre-commit: add config for checks on commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,18 +7,18 @@ repos:
         require_serial: true
         entry: "uv run ruff check"
         types: ["python"]
+      - id: "flake8"
+        name: "flake8"
+        language: "system"
+        require_serial: true
+        entry: "uv run flake8"
+        types: ["python"]
       - id: "mypy"
         name: "mypy"
         language: "system"
         require_serial: true
         entry: "uv run mypy --install-types --non-interactive ."
         pass_filenames: false
-        types: ["python"]
-      - id: "flake8"
-        name: "flake8"
-        language: "system"
-        require_serial: true
-        entry: "uv run flake8"
         types: ["python"]
       - id: "pyright"
         name: "pyright"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: local
+    hooks:
+      - id: "ruff"
+        name: "ruff"
+        language: "system"
+        require_serial: true
+        entry: "uv run ruff check"
+        types: ["python"]
+      - id: "mypy"
+        name: "mypy"
+        language: "system"
+        require_serial: true
+        entry: "uv run mypy --install-types --non-interactive ."
+        pass_filenames: false
+        types: ["python"]
+      - id: "flake8"
+        name: "flake8"
+        language: "system"
+        require_serial: true
+        entry: "uv run flake8"
+        types: ["python"]
+      - id: "pyright"
+        name: "pyright"
+        language: "system"
+        require_serial: true
+        entry: "uv run pyright ."
+        pass_filenames: false
+        types: ["python"]

--- a/README.md
+++ b/README.md
@@ -377,49 +377,55 @@ servers (LSP).
 These configurations are provided as optional suggestions for convenience and do not imply official support or a
 requirement to use specific tools.
 
-### Pre commit
+### Pre-commit hook
 
 #### General
 
-Checks can be done while committing with [pre-commit](https://pre-commit.com/). For installing, run:
+The repository has a [prek](https://prek.j178.dev/) configuration, which allows for making sure that each commit created is compliant with the [code checking implemented in the CI](./.github/workflows/code-checkers.yml). This feature is **opt-in** and can be run manually.
 
-```bash
-~/xcp-ng-tests $ prek|pre-commit install
+This tool is configured via the [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) file.
+
+In order to run all the checks that the CI performs, you can simply run:
+```shell
+$ uv run prek -a
+ruff.....................................................................Passed
+flake8...................................................................Passed
+mypy.....................................................................Passed
+pyright..................................................................Passed
 ```
 
-This repository provides a pre-commit config `.pre-commit-config.yaml`.
+#### Install git hooks
 
-> [!NOTE]
-> For those who use [prek](https://prek.j178.dev/) instead, the `.pre-commit-config.yaml` is compatible.
-
-**Useful commands to run locally**
+[prek](https://prek.j178.dev/) really shines once you start to run it automatically before each commit.
+For this, we need to tell [prek](https://prek.j178.dev/) to install a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) in our local repository:
 
 ```bash
-# run all checks before committing
-$ uvx prek|pre-commit run -a
-
-# run only mypy before committing
-$ uvx prek|pre-commit run mypy -a
+$ uv run prek install
 ```
 
-#### Is there a hurry? Skip pre-commit
-
-*While under development, you may want to skip pre-commit behaviour to speed up your workflow.*
+Note that you can easily remove this hook by running:
 
 ```bash
-# run all checks before committing
-$ uvx prek run -a # with prek
-$ uvx pre-commit run -a # with pre-commit
-
-# run only mypy before committing
-$ uvx prek run mypy -a # with prek
-$ uvx pre-commit run mypy -a # with pre-commit
+$ uv run prek uninstall
 ```
 
-You can even bypass when committing by adding git option `--no-verify`:
+Once the hooks are in place, `git commit` will automatically:
+- stash the changes that are not staged for this commit
+- perform the `ruff`, `mypy`, `flake8` and `pyright` checks (unless the staged changes do not affect any python files, in which case the checks are skipped)
+- re-apply the changes that were stashed
+
+If the checks happen to fail, the commit is cancelled.
+
+If for some reason, you are fine with a specific check failing, you can simply skip it with the `SKIP` environment variable.
+You can also bypass all the hooks by adding the git option `--no-verify`, or the environment variable `GIT_NO_HOOKS=1`:
 
 ```bash
-$ git commit -m "wip: tmp commit" --no-verify
+# Only skip the `flake8` hook
+$ SKIP=flake8 git commit -m "my message"
+# Do not run any hook before commit
+$ git commit -m "my message" --no-verify
+# Same thing, using an environment variable instead
+$ GIT_NO_HOOKS=1 git commit -m "my message"
 ```
 
 ### [VSCodium](https://vscodium.com/)

--- a/README.md
+++ b/README.md
@@ -377,6 +377,51 @@ servers (LSP).
 These configurations are provided as optional suggestions for convenience and do not imply official support or a
 requirement to use specific tools.
 
+### Pre commit
+
+#### General
+
+Checks can be done while committing with [pre-commit](https://pre-commit.com/). For installing, run:
+
+```bash
+~/xcp-ng-tests $ prek|pre-commit install
+```
+
+This repository provides a pre-commit config `.pre-commit-config.yaml`.
+
+> [!NOTE]
+> For those who use [prek](https://prek.j178.dev/) instead, the `.pre-commit-config.yaml` is compatible.
+
+**Useful commands to run locally**
+
+```bash
+# run all checks before committing
+$ uvx prek|pre-commit run -a
+
+# run only mypy before committing
+$ uvx prek|pre-commit run mypy -a
+```
+
+#### Is there a hurry? Skip pre-commit
+
+*While under development, you may want to skip pre-commit behaviour to speed up your workflow.*
+
+```bash
+# run all checks before committing
+$ uvx prek run -a # with prek
+$ uvx pre-commit run -a # with pre-commit
+
+# run only mypy before committing
+$ uvx prek run mypy -a # with prek
+$ uvx pre-commit run mypy -a # with pre-commit
+```
+
+You can even bypass when committing by adding git option `--no-verify`:
+
+```bash
+$ git commit -m "wip: tmp commit" --no-verify
+```
+
 ### [VSCodium](https://vscodium.com/)
 
 A few plugins are recommended to properly report the diagnostics during the development:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "types-colorama",
     "types-pexpect",
     "zizmor",
+    "prek>=0.3.11",
 ]
 
 [tool.pyright]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,4 +13,5 @@ types-pygments
 types-colorama
 types-pexpect
 zizmor
+prek>=0.3.11
 -r base.txt

--- a/uv.lock
+++ b/uv.lock
@@ -498,6 +498,30 @@ wheels = [
 ]
 
 [[package]]
+name = "prek"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/60/5b980c70525ca5f0d17942d8eae13b399051aa384413366fe5df229712ea/prek-0.3.11.tar.gz", hash = "sha256:c4cf77848009503c58d80ff216e32af45b63ea49652bb5546748c1ebfd4d9847", size = 433440, upload-time = "2026-04-27T04:22:59.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/2a/3392fa7d1fd1ce538915baa7597e7203bbe888367a8b15bfd51ca74d4714/prek-0.3.11-py3-none-linux_armv6l.whl", hash = "sha256:787e605716cfdc86ec01e7c5cf62799f39c28d49de5e37d75595c8e6248cb0f3", size = 5423112, upload-time = "2026-04-27T04:22:52.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b0/3fc653b30b70d6c2714fc56bcfe1c2439437fc38f60b72bc300603ace4cd/prek-0.3.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ef1f37187ca52d75ba9c46b53007476c4eab2c3f11bd23defd57a81c62d90442", size = 5801382, upload-time = "2026-04-27T04:23:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/46/39aedc7843c3703f1f43b686622e4f8cd123e03b87a163e5c8f2fbd56cda/prek-0.3.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d0828a1b50447502ea1be3f5a84da474fdca558cd5d76a1a5205169bb808c7", size = 5370817, upload-time = "2026-04-27T04:22:49.277Z" },
+    { url = "https://files.pythonhosted.org/packages/15/83/df5f3aeacbdea96a88c4f06c98d3932469711fed4e3bf5b703dd6507abe7/prek-0.3.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:bf49464b526ee36d2130baf60ab9580560bfaa60efd2997328e6d6671e209014", size = 5621405, upload-time = "2026-04-27T04:23:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/e32c9720747a327669863a4f92d05b9e6fadb851e903b0d7310a97c956a4/prek-0.3.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac344529f0d34757c7c95f65e66b9f6440a691f826eaf43f503247bd22023558", size = 5339780, upload-time = "2026-04-27T04:22:47.614Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2e/0e2f71b63bc2e5372575d5c1574b0666d2f90d30da51ed706a32cbf465a0/prek-0.3.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83672d963f249e2f246d3bec97f8fd2e8032e70da0a7d9acb2fa38af76dd82d2", size = 5735277, upload-time = "2026-04-27T04:23:12.437Z" },
+    { url = "https://files.pythonhosted.org/packages/09/46/88abf51ac88eeff1ad2fe7d1797ca1fea43eb1ac1ddb8331463ac5b27ed2/prek-0.3.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef70957195d2896a30dd849e64f88344df7bb51af9c950cf16bd11519e7424b0", size = 6622420, upload-time = "2026-04-27T04:23:05.982Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/592028a45b084a68b76c7edef909c789d1c96b26761388f63659beef7166/prek-0.3.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f0cc07d2cdb5fe2882015d5fdafc9af98b4c560d4caa1ae948caeab4341b79", size = 6020038, upload-time = "2026-04-27T04:22:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/e97f55a1645a2e9becffeee28892ad8bb66cd144dabfa4392ea8e2674bbe/prek-0.3.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d7554b436dae2ec97f4351a46817e3561657244307d1c0915f355b859f4fab71", size = 5622539, upload-time = "2026-04-27T04:23:01.314Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/f3119eef6b621782ad216a86d449609858ea34c57cf4a40fc6dc80556d7e/prek-0.3.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:caba5d635a5b64b7ac64d903f29b043ca5b0d9d9693543a0ef331ade89e6ad3f", size = 5440681, upload-time = "2026-04-27T04:23:07.422Z" },
+    { url = "https://files.pythonhosted.org/packages/04/62/22dd4f59a47654faeebe74651182ecc48d436542646cc92723052dfd9a45/prek-0.3.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:c95a63f19dde48e84b70bd63a235670834af15fa4df8b85d8b7894dd5bc419a9", size = 5314773, upload-time = "2026-04-27T04:22:57.912Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/94/a8361462acb8d8f5b8505255b95ffbfc2ee0872a79b4e066eb330692f7be/prek-0.3.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:7353b45f44a386c676fe96ba72a5ee326b676f789339f405cf6f1d69a1707194", size = 5596208, upload-time = "2026-04-27T04:23:09.08Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0c/5f065b86bbeb9977074a055d8a05e90c7201f6c4c7032dada61739b5f8cb/prek-0.3.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:39f4e86176ccbb70c098df6abbc8e36c1d86cb81281abe92fb79dcd572418214", size = 6132833, upload-time = "2026-04-27T04:22:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/8ab0ae140201dcee505f58b60abbe56bd05ac96b821a6866f6f90c4d971f/prek-0.3.11-py3-none-win32.whl", hash = "sha256:35d2361049653a3dcf27227b7f1b340c5c42a12c0e0361c4b785921bfd125839", size = 5120856, upload-time = "2026-04-27T04:23:02.752Z" },
+    { url = "https://files.pythonhosted.org/packages/57/05/9844c1125d3714f6f6c7b475884128a4b0c6c3ee0cd208ead44ca8174687/prek-0.3.11-py3-none-win_amd64.whl", hash = "sha256:a387689cd2e182f92dbb681151ee5a04f494fe97e95d6d783875da90b950e6d5", size = 5510916, upload-time = "2026-04-27T04:22:45.704Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/13/24b0288c553dc8d61f44c4d0746fe9bb1e1bd29d1e70571658536e4c0f72/prek-0.3.11-py3-none-win_arm64.whl", hash = "sha256:e4a8f900378a6657c7eb2fc4b12fa5c934edf209d0a24544539842479ec16e0b", size = 5345988, upload-time = "2026-04-27T04:22:50.918Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -876,6 +900,7 @@ dev = [
     { name = "flake8-pyproject" },
     { name = "libarchive-c" },
     { name = "mypy" },
+    { name = "prek" },
     { name = "pydocstyle" },
     { name = "pyright" },
     { name = "ruff" },
@@ -907,6 +932,7 @@ dev = [
     { name = "flake8-pyproject" },
     { name = "libarchive-c", specifier = "==5.3" },
     { name = "mypy" },
+    { name = "prek", specifier = ">=0.3.11" },
     { name = "pydocstyle" },
     { name = "pyright" },
     { name = "ruff" },


### PR DESCRIPTION
At the moment, the [Makefile](https://github.com/xcp-ng/xcp-ng-tests/blob/master/Makefile) is used as an entry point for running the code quality checks locally. However, there exists tools specifically designed to run code checkers. Those tools are widely adopted by open-source projects, especially in the python community. The most common approach is to use [pre-commit](https://pre-commit.com/) or [prek](https://github.com/j178/prek) to leverage so-called [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) in order to make sure that each commit is compliant with the quality standard of a given project. 

> [!NOTE]
> **The use of this tool is completely optional.**
> It is up to the developer to decide whether to install the git hooks locally or not. 

This PR adds a `.pre-commit-config.yaml` configuration file that can be used with [prek](https://prek.j178.dev/). It also adds [prek](https://prek.j178.dev/) to the `dev` dependencies so that the tool can be easily invoked using `uv run prek`.

**How do I use it?**

Find below a longer version of the *Pre-commit hook* section that is being added to the README:

---

#### General

The repository has a [prek](https://prek.j178.dev/) configuration, which allows for making sure that each commit created is compliant with the [code checking implemented in the CI](https://github.com/xcp-ng/xcp-ng-tests/blob/master/.github/workflows/code-checkers.yml). This feature is **opt-in** and can be run manually.

This tool is configured via the [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) file.

In order to run all the checks that the CI performs, you can simply run:
```shell
$ uv run prek -a
ruff.....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
pyright..................................................................Passed
```

#### Install git hooks

[prek](https://prek.j178.dev/) really shines once you start to run it automatically before each commit.
For this, we need to tell [prek](https://prek.j178.dev/) to install a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) in our local repository:
```bash
$ uv run prek install
```

Note that you can easily remove this hook by running:
```bash
$ uv run prek uninstall
```
  
Once the hooks are in place, `git commit` will automatically:
- stash the changes that are not staged for this commit
- perform the `ruff`, `mypy`, `flake8` and `pyright` checks (unless the staged changes do not affect any python files, in which case the checks are skipped)
- re-apply the changes that were stashed

```bash
$ git commit -m "my message"
Unstaged changes detected, stashing unstaged changes to `/home/vinmic/.cache/prek/patches/1777548785387-57881.patch`
ruff.....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
pyright..................................................................Passed
Restored working tree changes from `/home/vinmic/.cache/prek/patches/1777548785387-57881.patch`
[my-branch f332b03] my message
1 file changed, 1 insertion(+)
```

If the checks happen to fail, the commit is cancelled:
```bash
$ git commit -m "my message"
ruff.....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1
tests/install/test.py:21:1: E303 too many blank lines (3)
mypy.....................................................................Passed
pyright..................................................................Passed
```
  
If for some reason, you are fine with a specific check failing, you can simply skip it:
```bash
$ SKIP=flake8 git commit -m "my message"
ruff.....................................................................Passed
mypy.....................................................................Passed
pyright..................................................................Passed
```
  
You can also bypass all the hooks by adding the git option `--no-verify`, or the environment variable `GIT_NO_HOOKS=1`:
  
```bash
# With a git option
$ git commit -m "my message" --no-verify
# Or with an environment variable
$ GIT_NO_HOOKS=1 git commit -m "my message"
```