### PR TITLE
Add a Host.wait_for_xapi_enabled method

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -24,6 +24,7 @@ from lib.common import (
     strtobool,
     to_xapi_bool,
     wait_for,
+    wait_for_not,
 )
 from lib.netutil import wrap_ip
 from lib.pif import PIF
@@ -530,7 +531,36 @@ class Host:
         logging.info("Restart toolstack on host %s" % self)
         self.ssh('xe-toolstack-restart')
         if verify:
-            wait_for(self.is_enabled, "Wait for host enabled", timeout_secs=30 * 60)
+            self.wait_for_xapi_enabled()
+
+    def wait_for_host_down(self, timeout_secs: int = 2 * 60) -> None:
+        wait_for_not(
+            lambda: commands.local_cmd(["ping", "-c1", self.hostname_or_ip], check=False).returncode == 0,
+            "Wait for host down",
+            timeout_secs=timeout_secs,
+            retry_delay_secs=2,
+        )
+
+    def wait_for_host_up(self, timeout_secs: int = 10 * 60) -> None:
+        wait_for(
+            lambda: commands.local_cmd(["ping", "-c1", self.hostname_or_ip], check=False).returncode == 0,
+            "Wait for host up",
+            timeout_secs=timeout_secs,
+            retry_delay_secs=10,
+        )
+
+    def wait_for_ssh_reachable(self, timeout_secs: int = 10 * 60) -> None:
+        wait_for(
+            lambda: commands.local_cmd(["nc", "-zw5", self.hostname_or_ip, "22"], check=False).returncode == 0,
+            "Wait for ssh up on host",
+            timeout_secs=timeout_secs,
+            retry_delay_secs=5
+        )
+
+    def wait_for_xapi_enabled(self, timeout_secs: int = 30 * 60) -> None:
+        logging.info(f"Wait for XAPI to complete initialization on {self.hostname_or_ip}")
+        self.ssh(f"xapi-wait-init-complete {timeout_secs}")
+        assert self.is_enabled()
 
     def is_enabled(self) -> bool:
         try:
@@ -654,12 +684,10 @@ class Host:
         # error code. Instead, we schedule the reboot a few seconds later to let the ssh command return properly.
         self.ssh('systemd-run --on-active=2s reboot')
         if verify:
-            wait_for(lambda: os.system(f"ping -c1 {self.hostname_or_ip} > /dev/null 2>&1"), "Wait for host down")
-            wait_for(lambda: not os.system(f"ping -c1 {self.hostname_or_ip} > /dev/null 2>&1"),
-                     "Wait for host up", timeout_secs=10 * 60, retry_delay_secs=10)
-            wait_for(lambda: not os.system(f"nc -zw5 {self.hostname_or_ip} 22"),
-                     "Wait for ssh up on host", timeout_secs=10 * 60, retry_delay_secs=5)
-            wait_for(self.is_enabled, "Wait for XAPI to be ready", timeout_secs=30 * 60)
+            self.wait_for_host_down()
+            self.wait_for_host_up()
+            self.wait_for_ssh_reachable()
+            self.wait_for_xapi_enabled()
 
     def management_network(self) -> str:
         return self.xe('network-list', {'bridge': self.inventory['MANAGEMENT_INTERFACE']}, minimal=True)

--- a/lib/pool.py
+++ b/lib/pool.py
@@ -7,7 +7,7 @@ import traceback
 from packaging import version
 
 import lib.commands as commands
-from lib.common import HostAddress, _param_get, _param_set, safe_split, wait_for, wait_for_not
+from lib.common import HostAddress, _param_get, _param_set, safe_split, wait_for_not
 from lib.efi import EFIAuth
 from lib.host import Host
 from lib.sr import SR
@@ -30,10 +30,7 @@ class Pool:
 
         # wait for XAPI startup to be done, or we can get "Connection
         # refused (calling connect )" when calling self.hosts_uuids()
-        wait_for(lambda: commands.ssh_with_result(master_hostname_or_ip,
-                                                  'xapi-wait-init-complete 60').returncode == 0,
-                 f"Wait for XAPI init to be complete on {master_hostname_or_ip}",
-                 timeout_secs=30 * 60)
+        self.master.wait_for_xapi_enabled()
 
         logging.info("Getting Pool info for %r", master_hostname_or_ip)
         for host_uuid in self.hosts_uuids():
@@ -294,7 +291,11 @@ class Pool:
         master.xe('pool-eject', {'host-uuid': host.uuid, 'force': True})
         wait_for_not(lambda: host.uuid in self.hosts_uuids(), f"Wait for host {host} to be ejected of pool {master}.")
         self.hosts = [h for h in self.hosts if h.uuid != host.uuid]
-        wait_for(host.is_enabled, f"Wait for host {host} to restart in its own pool.", timeout_secs=10 * 60)
+        # The ejected host should reboot
+        host.wait_for_host_down()
+        host.wait_for_host_up()
+        host.wait_for_ssh_reachable()
+        host.wait_for_xapi_enabled()
 
     def network_named(self, network_name: str) -> str:
         return self.master.xe('network-list', {'name-label': network_name}, minimal=True)

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -207,8 +207,8 @@ class TestNested:
             # pool master must be reachable here
             pool = Pool(ip)
 
-            # wait for XAPI
-            wait_for(pool.master.is_enabled, "Wait for XAPI to be ready", timeout_secs=30 * 60)
+            # Master should be available now that the pool is instanciated
+            assert pool.master.is_enabled()
 
             if lsb_rel in ["8.2.1", "8.3.0", "8.4.0"]:
                 SERVICES = ["control-domain-params-init",


### PR DESCRIPTION
From `XCPNG-1061`:
>  `xapi-wait-init-complete` is the right tool, we only use it in one place, should move the code to a helper, audit all other `is_enabled` uses, and replace the relevant ones with the helper

This PR introduces four methods:
- `Host.wait_for_host_down` method
   - use the `ping` logic that was already present in `Host.reboot`
   - refactored with `local_cmd`
- `Host.wait_for_host_up` method
   - use the `ping` logic that was already present in `Host.reboot`
   - refactored with `local_cmd` 
- `Host.wait_for_ssh_reachable` method
   - use the `nc` logic that was already present in `Host.reboot`
   - refactored with `local_cmd` 
- `Host.wait_for_xapi_enabled`
   -  relies on the `xapi-wait-init-complete` command

It also goes through all the existing occurrences of `host.is_enabled`, and updates them according to the context.

## Tests

I've tested the following:
- the `main` job: `uv run jobs.py run main`
- the `test_pool` module: `uv run pytest tests/misc/test_pool.py`
