### PR TITLE
Add VS Code/Codium extensions recommendations for Python development

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+	"recommendations": [
+	  "detachhead.basedpyright",
+	  "ms-python.flake8",
+	  "charliermarsh.ruff",
+	  "bellini666.pytest-language-server"
+	],
+	"unwantedRecommendations": [
+	]
+}


### PR DESCRIPTION
This could help the non-Python developers working on the project get as much help as possible from their IDE.