### PR TITLE
Add basic tracing functionality to tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -116,6 +116,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default="2GiB",
         help="Maximum amount of data written to a volume"
     )
+    parser.addoption(
+        "--tracing-endpoint",
+        action="store",
+        default=None,
+        help="Specify distributed tracing endpoint."
+    )
 
 def pytest_configure(config: pytest.Config) -> None:
     global_config.ignore_ssh_banner = config.getoption('--ignore-ssh-banner')
@@ -192,6 +198,19 @@ def pytest_runtest_makereport(
 
 # END make test results visible from fixtures
 
+def setup_tracing(host: Host, endpoint: str):
+    logging.info(f'Enabling tracing on {host}, endpoint = {endpoint}')
+    host.ssh('printf "observer-endpoint-http-enabled=true\nobserver-experimental-components=\\"\\"\n" > /etc/xapi.conf.d/observer.conf')
+    host.restart_toolstack(verify=True)
+    observer_uuid = host.xe('observer-create', {'name-label': 'xcpng-test', 'endpoints': endpoint, 'enabled': 'true'})
+    host.restart_toolstack(verify=True)
+    return observer_uuid
+
+def teardown_tracing(host, observer):
+    logging.info(f'Disabling tracing on {host}')
+    host.xe('observer-destroy', {'uuid': observer})
+    host.ssh('rm -f /etc/xapi.conf.d/observer.conf')
+    host.restart_toolstack(verify=True)
 
 # fixtures
 
@@ -259,7 +278,19 @@ def hosts(pytestconfig: pytest.Config) -> Generator[list[Host], None, None]:
 
     if not host_list:
         pytest.fail("This test requires at least one --hosts parameter")
+
+    tracing_endpoint = pytestconfig.getoption("--tracing-endpoint")
+    has_tracing = tracing_endpoint is not None
+    observers = []
+    if has_tracing:
+        for h in host_list:
+            observers.append(setup_tracing(h, tracing_endpoint))
+
     yield host_list
+
+    if has_tracing:
+        for h, o in zip(host_list, observers):
+            teardown_tracing(h, o)
 
     cleanup_hosts()
 

--- a/tests/misc/test_tracing.py
+++ b/tests/misc/test_tracing.py
@@ -1,0 +1,45 @@
+import logging
+import pytest
+import time
+import uuid
+from urllib.parse import urlparse
+import requests
+
+@pytest.fixture
+def tracing_endpoint(request):
+    endpoint = request.config.getoption("--tracing-endpoint")
+    if endpoint is None:
+        pytest.exit("Missing required option: --tracing-endpoint")
+    return endpoint
+
+def locate_span(data, operation, tag):
+    if not data:
+        return None
+
+    for spans in data:
+        for span in spans:
+            if span.get('name') == operation:
+                if span.get('tags', {}).get('test.tag') == tag:
+                    return span
+
+def test_tracing(tracing_endpoint, host):
+    operation = "xe observer-list"
+    url = urlparse(tracing_endpoint)
+    api = f"{url.scheme}://{url.netloc}/api/v2/traces"
+    tag = str(uuid.uuid4())
+    logging.info(f"Peforming operation tagged with: {tag}")
+    o = host.ssh(f'BAGGAGE="test.tag={tag}" {operation}')
+    params = { "spanName": operation }
+
+    logging.info(f"Querying endpoint to locate our root span")
+    root_span = None
+    for i in range(15):
+        response = requests.get(api, params=params)
+        data = response.json()
+        root_span = locate_span(data, operation, tag)
+        if root_span:
+            break
+        time.sleep(5)
+
+    if not root_span:
+        pytest.fail("Could not find our operation's span in time")


### PR DESCRIPTION
Opening as a draft to receive commentary.

---

This simple change introduces a `--tracing-endpoint` option to the test framework that, if provided, will augment the host setup fixture to create an observer on each host. The effect of this is that toolstack operations will be traced, with their spans submitted to the provided endpoint (either Zipkin, Jaeger, or compatible span aggregator).

---

A simple test is provided that uses this to perform an operation and then query the endpoint to fetch the root span of the operation (with some metadata attached).

<img width="1230" height="804" alt="image" src="https://github.com/user-attachments/assets/ebd2d10a-8023-4581-afb6-35963a6707a9" />

---

The overall idea is that the benchmarking/performance teams can modify extant tests (or write new tests) to retrofit tracing (in a non-intrusive, opt-in, way).

I'm seeking some feedback about the direction of this change as there's more to consider:

- Tests with complex pool steps may want to have better identifying metadata by default. So, you can run a test and immediately place the separate hosts' span timeline together for debugging.
- The `Host` object's `xe` method could be modified to allow for environmental variables. Then, as done in the provided sample test (albeit manually), we could supply `BAGGAGE` to attach metadata to the spans of specific toolstack operations (relying on the metadata to fetch and process the related spans later).

---

Any feedback will be much appreciated. This change is very simple and could do with being made a lot more featureful and robust, but I'm not overly familiar with the testing framework or its tests, so I've kept it small and isolated for now.