### PR TITLE
zfsvol: Mark test_xva_export_import as xfail until properly fixed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import argparse
 import itertools
 import logging
 import os
@@ -49,6 +50,15 @@ try:
 except ImportError:
     CACHE_IMPORTED_VM = False
 assert CACHE_IMPORTED_VM in [True, False]
+
+class SplitCommaAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None)
+        if items is None:
+            items = []
+        if isinstance(values, str):
+            items.extend([v.strip() for v in values.split(",") if v.strip()])
+        setattr(namespace, self.dest, items)
 
 # pytest hooks
 
@@ -99,7 +109,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
     parser.addoption(
         "--image-format",
-        action="append",
+        action=SplitCommaAction,
         default=[],
         help="Format of VDI to execute tests on."
         "Example: vhd,qcow2"

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -93,6 +93,7 @@ class TestZfsvolVm:
             zfsvol_sr.create_vdi(virtual_size=MAX_VDI_SIZE[image_format] + 1)
         assert 'VDI Invalid size' in excinfo.value.stdout
 
+    @pytest.mark.xfail # Failing on Exception "Only snapshots can be cloned!"
     @pytest.mark.small_vm
     @pytest.mark.parametrize("compression", ["none", "gzip", "zstd"])
     def test_xva_export_import(self, vm_on_zfsvol_sr: VM, compression: XVACompression, temp_large_dir: str,


### PR DESCRIPTION
An issue has been observed while running storage tests:

   tests/storage/storage.py:227: in xva_export_import
       vm: VM | None = source_vm.clone()
   lib/vm.py:663: in clone
      uuid = self.host.xe('vm-clone', {'uuid': self.uuid, 'new-name-label': name})
   lib/host.py:178: in xe
      return self.ssh(command, check=check, simple_output=True)
   lib/host.py:134: in ssh
      return commands.ssh(self.hostname_or_ip, cmd, check=check, simple_output=simple_output,
   E           lib.commands.SSHCommandFailed: SSH command (xe vm-clone   uuid=9b170db4-2914-1bc3-6680-d12539769e6b new-name-label='[jenkins] Alpine minimal for CI_clone_for_tests') failed with return code 1: There was an SR backend failure.
   E           status: Exception
   E           stdout: Only snapshots can be cloned!
   E           stderr: <unknown>

Related-to: XCPNG-3297