### PR TITLE
Mark Broken tests

### DIFF
--- a/jobs.py
+++ b/jobs.py
@@ -570,6 +570,8 @@ JOBS: dict[str, JobData] = {
 BROKEN_TESTS = [
     # not really broken but has complex prerequisites (3 NICs on 3 different networks)
     "tests/migration/test_host_evacuate.py::TestHostEvacuateWithNetwork",
+    # needs maintenance (fail on xfs)
+    "tests/storage/glusterfs",
     # needs Fibre Channel host bus adapter (HBA)
     "tests/storage/lvmohba",
     # running quicktest on zfsvol generates dangling TAP devices that are hard to

--- a/jobs.py
+++ b/jobs.py
@@ -570,6 +570,8 @@ JOBS: dict[str, JobData] = {
 BROKEN_TESTS = [
     # not really broken but has complex prerequisites (3 NICs on 3 different networks)
     "tests/migration/test_host_evacuate.py::TestHostEvacuateWithNetwork",
+    # needs Fibre Channel host bus adapter (HBA)
+    "tests/storage/lvmohba",
     # running quicktest on zfsvol generates dangling TAP devices that are hard to
     # cleanup. Bug needs to be fixed before enabling quicktest on zfsvol.
     "tests/storage/zfsvol/test_zfsvol_sr.py::TestZfsvolVm::test_quicktest",


### PR DESCRIPTION
Recent CI runs shown that some tests can not work as expected , instead of disabling them on cmdline, it thought it's better to keep trace of status, until they are fixed again.