### PR TITLE
Use NFS for intrapool migration in the glusterfs tests

### DIFF
--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -1,9 +1,13 @@
 import pytest
 
+from lib import config
 from lib.host import Host
 from lib.sr import SR
+from lib.vdi import ImageFormat
 from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
+
+from typing import Generator
 
 # Requirements:
 # From --hosts parameter:
@@ -14,6 +18,20 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 # And:
 # - access to XCP-ng RPM repository from hostA1
 
+
+@pytest.fixture(scope='package')
+def nfs_sr(host: Host, image_format: ImageFormat) -> Generator[SR, None, None]:
+    """
+    A NFS SR on first host.
+
+    Note: this fixture is already present in `tests/storage/nfs`, but it's scoped to the `nfs` package
+    """
+    nfs_device_config = config.sr_device_config("NFS_DEVICE_CONFIG") | {'preferred-image-formats': image_format}
+    sr = host.sr_create('nfs', "NFS-SR-test", nfs_device_config, shared=True)
+    yield sr
+    sr.destroy()
+
+
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 class Test:
@@ -22,11 +40,11 @@ class Test:
         live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, sr)
 
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, nfs_sr: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, xfs_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, nfs_sr)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, xfs_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_glusterfs_sr: VM, nfs_sr: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, xfs_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_glusterfs_sr, host, hostA2, nfs_sr)


### PR DESCRIPTION
The following tests are failing:
- test_glusterfs_sr_intrapool_migration.py::Test::test_cold_intrapool_migration
- test_glusterfs_sr_intrapool_migration.py::Test::test_live_intrapool_migration

With either one of those errors depending on the fixture resolution order:
- [AssertionError: xfsprogs must not be installed on the host at the beginning of the tests](https://github.com/xcp-ng/xcp-ng-tests/blob/377e8bd9d6ba0149728c5f4e535f55fb5fef84cf/tests/storage/conftest.py#L69)
- [AssertionError: There is already a saved package list set](https://github.com/xcp-ng/xcp-ng-tests/blob/488cbdc1258cc0e0a38bcf45ba39a7cb065a0491/lib/host.py#L621)[AssertionError: There is already a saved package list set](https://github.com/xcp-ng/xcp-ng-tests/blob/488cbdc1258cc0e0a38bcf45ba39a7cb065a0491/lib/host.py#L621) 

This is due to both mangled package installation in underlying fixtures and the lack of enough unused disks for both SR.

@glehmann, @rzr and I concluded that using NFS was much simpler and less error prone to test the glusterfs intrapool migration