### PR TITLE
Add autopep8 code formatter integration

### DIFF
--- a/.github/workflows/code-checkers.yml
+++ b/.github/workflows/code-checkers.yml
@@ -55,3 +55,12 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/uv-setup/
       - run: prek -a flake8
+
+  autopep8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/uv-setup/
+      - run: prek -a autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
         require_serial: true
         entry: "uv run ruff check"
         types: ["python"]
+      - id: "autopep8"
+        name: "autopep8"
+        language: "system"
+        require_serial: true
+        entry: "uv run autopep8 -i"
+        types: ["python"]
       - id: "flake8"
         name: "flake8"
         language: "system"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         name: "ruff"
         language: "system"
         require_serial: true
-        entry: "uv run ruff check"
+        entry: "uv run ruff check --fix --show-fixes"
         types: ["python"]
       - id: "autopep8"
         name: "autopep8"

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,16 @@ data.py:
 	@test -r data.py || echo "File 'data.py' does not exist. Refer to https://github.com/xcp-ng/xcp-ng-tests#configuration." && exit 1
 
 mypy: data.py
-	uv run mypy --install-types --non-interactive .
+	uv run prek -a mypy
 
 pyright: data.py
-	uv run pyright .
+	uv run prek -a pyright
 
 ruff: data.py
-	FORCE_COLOR=1 uv run ruff check --fix
+	uv run prek -a ruff
 
 flake8:
-	uv run flake8
+	uv run prek -a flake8
 
 autopep8:
-	uv run autopep8 -ir --exit-code .
+	uv run prek -a autopep8

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ pyright: data.py
 	uv run pyright .
 
 ruff: data.py
-	FORCE_COLOR=1 uv run ruff check
+	FORCE_COLOR=1 uv run ruff check --fix
 
 flake8:
 	uv run flake8

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,7 @@ all: ruff autopep8 flake8 mypy pyright
 data.py:
 	@test -r data.py || echo "File 'data.py' does not exist. Refer to https://github.com/xcp-ng/xcp-ng-tests#configuration." && exit 1
 
-mypy: data.py
-	uv run prek -a mypy
+mypy pyright ruff: data.py
 
-pyright: data.py
-	uv run prek -a pyright
-
-ruff: data.py
-	uv run prek -a ruff
-
-flake8:
-	uv run prek -a flake8
-
-autopep8:
-	uv run prek -a autopep8
+ruff autopep8 flake8 mypy pyright:
+	uv run prek -a $@

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all mypy pyright ruff flake8
 
-all: mypy pyright ruff flake8
+all: ruff autopep8 flake8 mypy pyright
 
 data.py:
 	@test -r data.py || echo "File 'data.py' does not exist. Refer to https://github.com/xcp-ng/xcp-ng-tests#configuration." && exit 1
@@ -19,3 +19,6 @@ ruff: data.py
 
 flake8:
 	uv run flake8
+
+autopep8:
+	uv run autopep8 -ir --exit-code .

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ language-servers = [
   "pylsp",
   "ruff",
 ]
-formatter = { command = "autopep8", args=["-"] }
+formatter = { command = "bash", args = ["-c", "ruff check --fix --silent - | autopep8 -"] }
 auto-format = true
 
 [language-server.basedpyright]

--- a/README.md
+++ b/README.md
@@ -439,6 +439,18 @@ A few plugins are recommended to properly report the diagnostics during the deve
 * [BasedPyright](https://open-vsx.org/extension/detachhead/basedpyright)
 * [flake8](https://open-vsx.org/extension/ms-python/flake8)
 * [ruff](https://open-vsx.org/extension/charliermarsh/ruff)
+* [autopep8](https://open-vsx.org/extension/ms-python/autopep8)
+
+
+You can ensure VS Code automatically formats all your Python files by setting the following in your User settings
+(View > Command Palette… and run Preferences: Open User Settings (JSON)):
+
+~~~json
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8",
+    "editor.formatOnSave": true
+  }
+~~~
 
 ### [Helix](https://helix-editor.com/)
 
@@ -461,7 +473,8 @@ language-servers = [
   "pylsp",
   "ruff",
 ]
-auto-format = false
+formatter = { command = "autopep8", args=["-"] }
+auto-format = true
 
 [language-server.basedpyright]
 environment = { "LANG" = "en" }

--- a/lib/host.py
+++ b/lib/host.py
@@ -173,7 +173,7 @@ class Host:
             return f'{key}={shlex.quote(value)}'
 
         command: str = f'xe {action} {maybe_param_minimal} {maybe_param_force} ' + \
-                       ' '.join(stringify(key, value) for key, value in args.items())
+            ' '.join(stringify(key, value) for key, value in args.items())
         if simple_output:
             return self.ssh(command, check=check, simple_output=True)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "types-pexpect",
     "zizmor",
     "prek>=0.3.11",
+    "autopep8",
 ]
 
 [tool.pyright]
@@ -121,6 +122,18 @@ ignore = [
   "F",  # already done by ruff
 ]
 exclude=[".git", ".venv", "data.py", "vm_data.py"]
+
+[tool.autopep8]
+max_line_length = 120
+ignore = [
+  "E261",
+  "E302",
+  "E305",
+  "E402",
+  "W503",
+  "F",
+]
+exclude=".git,.venv,data.py,vm_data.py"
 
 [tool.uv]
 # fedora is changing the defaults: https://src.fedoraproject.org/rpms/uv/blob/f43/f/uv.toml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,4 +14,5 @@ types-colorama
 types-pexpect
 zizmor
 prek>=0.3.11
+autopep8
 -r base.txt

--- a/tests/limits/test_vif_limit.py
+++ b/tests/limits/test_vif_limit.py
@@ -71,7 +71,7 @@ class TestVIFLimit:
             # Clean up on exceptions
             logging.info('Create separate iperf servers on the host')
             with tempfile.NamedTemporaryFile('w') as host_script:
-                iperf_configs = [f'iperf3 -s -p {5100+i} &'
+                iperf_configs = [f'iperf3 -s -p {5100 + i} &'
                                  for i in range(0, VIF_LIMIT)]
                 host_script.write('\n'.join(iperf_configs))
                 host_script.flush()
@@ -82,7 +82,7 @@ class TestVIFLimit:
             logging.info('Start multiple iperfs on separate interfaces on the VM')
             with tempfile.NamedTemporaryFile('w') as vm_script:
                 iperf_configs = [f'iperf3 --no-delay -c {host.hostname_or_ip} '
-                                 f'-p {5100+i} --bind-dev {interface_name}{i} '
+                                 f'-p {5100 + i} --bind-dev {interface_name}{i} '
                                  f'--interval 0 --parallel 1 --time 30 &'
                                  for i in range(0, VIF_LIMIT)]
                 vm_script.write('\n'.join(iperf_configs))

--- a/tests/packages/netdata/test_netdata.py
+++ b/tests/packages/netdata/test_netdata.py
@@ -36,7 +36,7 @@ class TestsNetdata:
         lines = TestsNetdata.__get_headers(host, 19999, "netdata.conf")
         response = lines[0].strip()
         assert response == "HTTP/1.1 403 Forbidden" or \
-               response == "HTTP/1.1 451 Unavailable For Legal Reasons"
+            response == "HTTP/1.1 451 Unavailable For Legal Reasons"
 
         stdout = host.ssh('curl -XGET -k -I -s localhost:19999/netdata.conf')
         lines = stdout.splitlines()

--- a/tests/security/test_tls.py
+++ b/tests/security/test_tls.py
@@ -29,7 +29,7 @@ def test_tls_disabled(host: Host, protocol_name: str) -> None:
     with pytest.raises(ssl.SSLError):
         context = ssl.SSLContext(protocol)
         with socket.create_connection((str(host), PORT), timeout=10) as sock, \
-             context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+                context.wrap_socket(sock, server_hostname=str(host)) as ssock:
             ssock.do_handshake()
             # If we reach this point, the protocol is enabled (test should fail)
             pytest.fail(f"Protocol {protocol} should be disabled but connection succeeded")
@@ -51,7 +51,7 @@ def test_enabled(host: Host, protocol_name: str) -> None:
     try:
         context = ssl.SSLContext(protocol)
         with socket.create_connection((str(host), PORT), timeout=10) as sock, \
-             context.wrap_socket(sock, server_hostname=str(host)) as ssock:
+                context.wrap_socket(sock, server_hostname=str(host)) as ssock:
             ssock.do_handshake()
             assert ssock.version()
     except ssl.SSLError as e:

--- a/tests/system/test_irqbalance.py
+++ b/tests/system/test_irqbalance.py
@@ -41,6 +41,7 @@ class TestIrqBalance:
     We want to avoid this to happen again, so this testcase runs several VMs
     and verifies that the IRQs are balanced on more than one CPU.
     """
+
     def test_start_four_vms(self, host: Host, four_vms: tuple[VM, VM, VM, VM]) -> None:
         for vm in four_vms:
             vm.start(on=host.uuid)

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,18 @@ wheels = [
 ]
 
 [[package]]
+name = "autopep8"
+version = "2.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycodestyle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -895,6 +907,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "autopep8" },
     { name = "bs4" },
     { name = "flake8" },
     { name = "flake8-pyproject" },
@@ -927,6 +940,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "autopep8" },
     { name = "bs4", specifier = ">=0.0.1" },
     { name = "flake8" },
     { name = "flake8-pyproject" },


### PR DESCRIPTION
autopep8 is an autoformatter that focuses on fixing pep8 formatting
problems, and doesn't impose a hard coded coding style as would do black
or ruff formatter.
For example, if the author chose to use split a line at a specific
position, ruff or black might decide to reformat the code in their own
way, but autopep8 won't, as long as it respects the pep8.
So it gives the author the option to automatically fix pep8 problems but
still allows to format the code as they think is the most readable.
