### PR TITLE
Use NFS for intrapool migration in the linstor tests

### DIFF
--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -1,9 +1,13 @@
 import pytest
 
+from lib import config
 from lib.host import Host
 from lib.sr import SR
+from lib.vdi import ImageFormat
 from lib.vm import VM
 from tests.storage import cold_migration_then_come_back, live_storage_migration_then_come_back
+
+from typing import Generator
 
 # Requirements:
 # From --hosts parameter:
@@ -14,6 +18,18 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 # And:
 # - access to XCP-ng RPM repository from hostA1
 
+@pytest.fixture(scope='package')
+def nfs_sr(host: Host, image_format: ImageFormat) -> Generator[SR, None, None]:
+    """
+    A NFS SR on first host.
+
+    Note: this fixture is already present in `tests/storage/nfs`, but it's scoped to the `nfs` package
+    """
+    nfs_device_config = config.sr_device_config("NFS_DEVICE_CONFIG") | {'preferred-image-formats': image_format}
+    sr = host.sr_create('nfs', "NFS-SR-test", nfs_device_config, shared=True)
+    yield sr
+    sr.destroy()
+
 @pytest.mark.small_vm # run with a small VM to test the features
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 class Test:
@@ -21,12 +37,8 @@ class Test:
         sr = vm_on_linstor_sr.get_sr()
         live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, sr)
 
-    def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostA2: SR
-    ) -> None:
-        cold_migration_then_come_back(vm_on_linstor_sr, host, hostA2, xfs_sr_on_hostA2)
+    def test_cold_intrapool_migration(self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, nfs_sr: SR) -> None:
+        cold_migration_then_come_back(vm_on_linstor_sr, host, hostA2, nfs_sr)
 
-    def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, xfs_sr_on_hostA2: SR
-    ) -> None:
-        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, xfs_sr_on_hostA2)
+    def test_live_intrapool_migration(self, host: Host, hostA2: Host, vm_on_linstor_sr: VM, nfs_sr: SR) -> None:
+        live_storage_migration_then_come_back(vm_on_linstor_sr, host, hostA2, nfs_sr)


### PR DESCRIPTION
The following tests are failing:
- test_linstor_sr_intrapool_migration.py::Test::test_cold_intrapool_migration
- test_linstor_sr_intrapool_migration.py::Test::test_live_intrapool_migration

Because of the lack of a free block device to instantiate the xfs pool. The extra disk of the test hosts is already used by the linstor SR.

Using NFS is much simpler and less error prone to test the linstor intrapool migration