### PR TITLE
Revert xfs SR as destination SR for largeblock tests

### DIFF
--- a/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_crosspool_migration.py
@@ -16,11 +16,11 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 class Test:
     def test_cold_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, xfs_sr_on_hostB1)
+        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)
 
     def test_live_crosspool_migration(
-        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostB1: SR
+        self, host: Host, hostB1: Host, vm_on_largeblock_sr: VM, local_sr_on_hostB1: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, xfs_sr_on_hostB1)
+        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostB1, local_sr_on_hostB1)

--- a/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
+++ b/tests/storage/largeblock/test_largeblock_sr_intrapool_migration.py
@@ -16,11 +16,11 @@ from tests.storage import cold_migration_then_come_back, live_storage_migration_
 @pytest.mark.big_vm # and ideally with a big VM to test it scales
 class Test:
     def test_cold_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
     ) -> None:
-        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, xfs_sr_on_hostA2)
+        cold_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)
 
     def test_live_intrapool_migration(
-        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, xfs_sr_on_hostA2: SR
+        self, host: Host, hostA2: Host, vm_on_largeblock_sr: VM, local_sr_on_hostA2: SR
     ) -> None:
-        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, xfs_sr_on_hostA2)
+        live_storage_migration_then_come_back(vm_on_largeblock_sr, host, hostA2, local_sr_on_hostA2)


### PR DESCRIPTION
The hosts don't have any available 512 bytes disk that could be used for that task.