### PR TITLE
Move root partition resizing logic to VM.grow_root_partition()

### DIFF
--- a/lib/vm.py
+++ b/lib/vm.py
@@ -526,8 +526,11 @@ class VM(BaseVM):
         return PackageManagerEnum.UNKNOWN
 
     def grow_root_partition(self) -> int | None:
-        if self.detect_package_manager() == PackageManagerEnum.APK:
+        pkg_manager = self.detect_package_manager()
+        if pkg_manager == PackageManagerEnum.APK:
             self.ssh('apk add util-linux e2fsprogs-extra')
+        elif pkg_manager == PackageManagerEnum.APT_GET:
+            self.ssh('apt-get update && apt-get install -y -qq util-linux e2fsprogs')
         else:
             return None
         mount_output = self.ssh('mount').strip()

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -531,6 +531,8 @@ class VM(BaseVM):
             self.ssh('apk add util-linux e2fsprogs-extra')
         elif pkg_manager == PackageManagerEnum.APT_GET:
             self.ssh('apt-get update && apt-get install -y -qq util-linux e2fsprogs')
+        elif pkg_manager == PackageManagerEnum.RPM:
+            self.ssh('yum install -y util-linux e2fsprogs')
         else:
             return None
         mount_output = self.ssh('mount').strip()

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -527,13 +527,7 @@ class VM(BaseVM):
 
     def grow_root_partition(self) -> int | None:
         if self.detect_package_manager() == PackageManagerEnum.APK:
-            # growpart is not available in alpine 3.12
-            # vm.ssh('apk add cloud-utils-growpart e2fsprogs-extra')
-            self.ssh('apk add gawk util-linux e2fsprogs-extra')
-            self.ssh(
-                'wget https://raw.githubusercontent.com/canonical/cloud-utils/main/bin/growpart -O /usr/bin/growpart'
-            )
-            self.ssh('chmod +x /usr/bin/growpart')
+            self.ssh('apk add util-linux e2fsprogs-extra')
         else:
             return None
         mount_output = self.ssh('mount').strip()
@@ -543,8 +537,8 @@ class VM(BaseVM):
         if not fs_type.startswith('ext'):
             logging.debug(f"Unsupported filesystem: {fs_type}")
             return None
-        growpart_returncode = self.ssh_with_result(f'growpart /dev/{disk} {partition}').returncode
-        assert growpart_returncode in [0, 1] # growpart returns 1 if the size is already the expected one
+        self.ssh(f'echo ", +" | sfdisk --no-reread --force -N {partition} /dev/{disk}')
+        self.ssh(f'partx -u -n {partition}:{partition} /dev/{disk}')
         self.ssh(f'resize2fs /dev/{disk}{p}{partition}')
         df_output = self.ssh('df /')
         return int(df_output.splitlines()[-1].split()[3]) * KiB

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -4,6 +4,7 @@ import pytest
 
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import uuid
@@ -12,6 +13,7 @@ import lib.commands as commands
 import lib.efi as efi
 from lib.basevm import BaseVM
 from lib.common import (
+    KiB,
     PackageManagerEnum,
     expand_scope_relative_nodeid,
     parse_xe_dict,
@@ -522,6 +524,30 @@ class VM(BaseVM):
         if self.file_exists('/usr/bin/zypper'):
             return PackageManagerEnum.ZYPPER
         return PackageManagerEnum.UNKNOWN
+
+    def grow_root_partition(self) -> int | None:
+        if self.detect_package_manager() == PackageManagerEnum.APK:
+            # growpart is not available in alpine 3.12
+            # vm.ssh('apk add cloud-utils-growpart e2fsprogs-extra')
+            self.ssh('apk add gawk util-linux e2fsprogs-extra')
+            self.ssh(
+                'wget https://raw.githubusercontent.com/canonical/cloud-utils/main/bin/growpart -O /usr/bin/growpart'
+            )
+            self.ssh('chmod +x /usr/bin/growpart')
+        else:
+            return None
+        mount_output = self.ssh('mount').strip()
+        root_match = re.search(r'/dev/(\w+?)(p?)(\d+) on / type (\w+)', mount_output)
+        assert root_match is not None
+        disk, p, partition, fs_type = root_match.groups()
+        if not fs_type.startswith('ext'):
+            logging.debug(f"Unsupported filesystem: {fs_type}")
+            return None
+        growpart_returncode = self.ssh_with_result(f'growpart /dev/{disk} {partition}').returncode
+        assert growpart_returncode in [0, 1] # growpart returns 1 if the size is already the expected one
+        self.ssh(f'resize2fs /dev/{disk}{p}{partition}')
+        df_output = self.ssh('df /')
+        return int(df_output.splitlines()[-1].split()[3]) * KiB
 
     def insert_cd(self, vdi_name: str) -> None:
         logging.info("Insert CD %r in VM %s", vdi_name, self.uuid)

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -29,7 +29,7 @@ from lib.vbd import VBD
 from lib.vdi import VDI
 from lib.vif import VIF
 
-from typing import TYPE_CHECKING, Iterable, List, Literal, overload
+from typing import TYPE_CHECKING, Iterable, List, Literal, assert_never, overload
 
 if TYPE_CHECKING:
     from lib.host import Host
@@ -527,14 +527,21 @@ class VM(BaseVM):
 
     def grow_root_partition(self) -> int | None:
         pkg_manager = self.detect_package_manager()
-        if pkg_manager == PackageManagerEnum.APK:
-            self.ssh('apk add util-linux e2fsprogs-extra')
-        elif pkg_manager == PackageManagerEnum.APT_GET:
-            self.ssh('apt-get update && apt-get install -y -qq util-linux e2fsprogs')
-        elif pkg_manager == PackageManagerEnum.RPM:
-            self.ssh('yum install -y util-linux e2fsprogs')
-        else:
-            return None
+        match pkg_manager:
+            case PackageManagerEnum.APK:
+                self.ssh('apk add util-linux e2fsprogs-extra')
+            case PackageManagerEnum.APT_GET:
+                self.ssh('apt-get update && apt-get install -y -qq util-linux e2fsprogs')
+            case PackageManagerEnum.DNF:
+                self.ssh('dnf install -y util-linux e2fsprogs')
+            case PackageManagerEnum.YUM:
+                self.ssh('yum install -y util-linux e2fsprogs')
+            case PackageManagerEnum.ZYPPER:
+                self.ssh('zypper --non-interactive install util-linux e2fsprogs')
+            case PackageManagerEnum.UNKNOWN:
+                return None
+            case _:
+                assert_never(pkg_manager)
         mount_output = self.ssh('mount').strip()
         root_match = re.search(r'/dev/(\w+?)(p?)(\d+) on / type (\w+)', mount_output)
         assert root_match is not None

--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -250,17 +250,9 @@ def xva_export_import(source_vm: VM, compression: XVACompression, temp_large_dir
     vm.wait_for_vm_running_and_ssh_up()
     install_randstream(vm)
 
-    if vm.detect_package_manager() == PackageManagerEnum.APK:
-        # growpart is not available in alpine 3.12
-        # vm.ssh('apk add cloud-utils-growpart e2fsprogs-extra')
-        vm.ssh('apk add gawk util-linux e2fsprogs-extra')
-        vm.ssh('wget https://raw.githubusercontent.com/canonical/cloud-utils/main/bin/growpart -O /usr/bin/growpart')
-        vm.ssh('chmod +x /usr/bin/growpart')
-        # TODO: maybe use `findmnt -no SOURCE /` from util-linux to get the blockdevice mounted on /
-        growpart_returncode = vm.ssh_with_result('growpart /dev/xvda 3').returncode
-        assert growpart_returncode in [0, 1] # growpart returns 1 if the size is already the expected one
-        vm.ssh('resize2fs /dev/xvda3')
-        stream_size = min(volume_size // 2, config.write_volume_cap)
+    root_partition_size = vm.grow_root_partition()
+    if root_partition_size is not None:
+        stream_size = min(root_partition_size // 2, config.write_volume_cap)
     else:
         stream_size = 500 * MiB
 


### PR DESCRIPTION
And make it a bit more robust, by fetching the actual partition mounted on `/`

Also add support for other Linux distributions than Alpine.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>

<!-- start jj-vine stack -->
This PR is part of a stack containing 2 PRs:

1. `master`
2. #540
3. **"Move root partition resizing logic to VM.grow_root_partition()" (this PR)**
<!-- end jj-vine stack -->