### PR TITLE
Fix helix config to avoid ruff removing imports where it shouldn't

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ language-servers = [
   "pylsp",
   "ruff",
 ]
-formatter = { command = "bash", args = ["-c", "ruff check --fix --silent - | autopep8 -"] }
+formatter = { command = "bash", args = ["-c", "ruff check --fix --silent --stdin-filename %sh{realpath %{buffer_name}} | autopep8 -"] }
 auto-format = true
 
 [language-server.basedpyright]


### PR DESCRIPTION
ruff needs to know the file name so it can apply the expected rule set for that file