### PR TITLE
storage: fix SR create/destroy tests scheduling conflict

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,19 @@
+name: Run unit tests
+
+on: [push]
+
+permissions: {}
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/uv-setup/
+        with:
+          dev: false
+      - name: Create a dummy data.py
+        run: cp data.py-dist data.py
+      - run: pytest tests/unit/*.py

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import argparse
+import dataclasses
 import itertools
 import logging
 import os
@@ -435,6 +436,42 @@ def disks(pytestconfig: pytest.Config, pools_hosts_by_name_or_ip: dict[HostAddre
     ret = {host: list(_host_disks(host, cli_disks.get(host.hostname_or_ip)))
            for host in pools_hosts_by_name_or_ip.values()
            }
+    # Cross-host deduplication: a LUN in use on any host (same WWN) is unavailable on all hosts.
+    # This matters for shared FC/iSCSI LUNs visible on multiple hosts simultaneously.
+    used_wwns = {
+        disk.wwn
+        for host_disks in ret.values()
+        for disk in host_disks
+        if disk.wwn and not disk.available
+    }
+    if used_wwns:
+        logging.debug("cross-host used WWNs: %s", used_wwns)
+        ret = {
+            host: [
+                dataclasses.replace(disk, available=False) if (disk.wwn and disk.wwn in used_wwns) else disk
+                for disk in host_disks
+            ]
+            for host, host_disks in ret.items()
+        }
+    # LUNs reserved for lvmohba/lvmoiscsi: sort them to the end so they are
+    # only picked if no other disk is available.
+    reserved_wwns: set[str] = set()
+    try:
+        import data
+        for key in ('LVMOHBA_DEVICE_CONFIG', 'LVMOISCSI_DEVICE_CONFIG'):
+            cfg = getattr(data, key, None)
+            if isinstance(cfg, dict):
+                scsiid = cfg.get('SCSIid', '').lower().removeprefix('0x')
+                if len(scsiid) >= 16:
+                    reserved_wwns.add(scsiid[:16])
+    except ImportError:
+        pass
+    if reserved_wwns:
+        logging.debug("reserved WWNs (lvmohba/lvmoiscsi): %s", reserved_wwns)
+        ret = {
+            host: sorted(host_disks, key=lambda d: d.wwn in reserved_wwns)
+            for host, host_disks in ret.items()
+        }
     logging.debug("disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})
     return ret
 

--- a/conftest.py
+++ b/conftest.py
@@ -425,12 +425,12 @@ def disks(pytestconfig: pytest.Config, pools_hosts_by_name_or_ip: dict[HostAddre
         # check all disks in --disks=host:... exist
         for cli_disk in hosts_cli_disks:
             for disk in host_disks:
-                if disk['name'] == cli_disk:
+                if disk.name == cli_disk:
                     yield disk
                     break # names are unique, don't expect another one
             else:
                 raise Exception(f"no {cli_disk!r} disk on host {host.hostname_or_ip}, "
-                                f"has {','.join(disk['name'] for disk in host_disks)}")
+                                f"has {','.join(disk.name for disk in host_disks)}")
 
     ret = {host: list(_host_disks(host, cli_disks.get(host.hostname_or_ip)))
            for host in pools_hosts_by_name_or_ip.values()
@@ -443,7 +443,7 @@ def unused_512B_disks(disks: dict[Host, list[Host.BlockDeviceInfo]]
                       ) -> dict[Host, list[Host.BlockDeviceInfo]]:
     """Dict identifying names of all 512-bytes-blocks disks for on all hosts of first pool."""
     ret = {host: [disk for disk in host_disks
-                  if disk["log-sec"] == "512" and host.disk_is_available(disk["name"])]
+                  if disk.log_sec == 512 and disk.available]
            for host, host_disks in disks.items()
            }
     logging.debug("available disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})
@@ -454,7 +454,7 @@ def unused_4k_disks(disks: dict[Host, list[Host.BlockDeviceInfo]]
                     ) -> dict[Host, list[Host.BlockDeviceInfo]]:
     """Dict identifying names of all 4K-blocks disks for on all hosts of first pool."""
     ret = {host: [disk for disk in host_disks
-                  if disk["log-sec"] == "4096" and host.disk_is_available(disk["name"])]
+                  if disk.log_sec == 4096 and disk.available]
            for host, host_disks in disks.items()
            }
     logging.debug("available 4k disks collected: %s", {host.hostname_or_ip: value for host, value in ret.items()})

--- a/lib/host.py
+++ b/lib/host.py
@@ -7,12 +7,12 @@ import shlex
 import subprocess
 import tempfile
 import uuid
+from dataclasses import dataclass
 
 from packaging import version
 
 import lib.commands as commands
 from lib.common import (
-    DiskDevName,
     _param_add,
     _param_clear,
     _param_get,
@@ -31,7 +31,7 @@ from lib.sr import SR
 from lib.vm import VM
 from lib.xo import xo_cli, xo_object_exists
 
-from typing import TYPE_CHECKING, Literal, TypedDict, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 if TYPE_CHECKING:
     from lib.pool import Pool
@@ -55,14 +55,15 @@ class Host:
     pool: "Pool"
 
     # Data extraction is automatic, no conversion from str is done.
-    BlockDeviceInfo = TypedDict('BlockDeviceInfo', {"name": str,
-                                                    "kname": str,
-                                                    "pkname": str,
-                                                    "size": str,
-                                                    "log-sec": str,
-                                                    "type": str,
-                                                    })
-    BLOCK_DEVICES_FIELDS = ','.join(k.upper() for k in BlockDeviceInfo.__annotations__)
+    @dataclass
+    class BlockDeviceInfo:
+        name: str       # short kernel name: "sda", "md0", "dm-3"
+        path: str       # full device path: "/dev/sda", "/dev/md/myarray", "/dev/mapper/mpathb"
+        size: int       # bytes
+        log_sec: int    # logical sector size
+        type: str       # "disk", "md", "mpath"
+        available: bool # not mounted, not member of md/lvm/mpath/zfs
+        wwn: str = ''   # LUN WWN (hex, no 0x prefix); same LUN has same WWN across hosts
 
     block_devices_info: list[BlockDeviceInfo]
 
@@ -669,48 +670,126 @@ class Host:
 
     def rescan_block_devices_info(self) -> None:
         """
-        Initalize static informations about the disks.
+        Initialize information about block devices: local disks, mdadm arrays, and multipath devices.
 
-        Despite those being static, it can be necessary to rescan,
+        Despite those being mostly static, it can be necessary to rescan,
         when we test how XCP-ng reacts to changes of hardware (or
         reconfiguration of device blocksize), or after a reboot.
-        """
-        output_string = self.ssh(
-            f'lsblk --pairs --bytes -I 8,259 --output {Host.BLOCK_DEVICES_FIELDS}'
-        )  # limit to: sd, blkext
 
-        self.block_devices_info = [
-            Host.BlockDeviceInfo({key.lower(): value.strip('"') # type: ignore[misc]
-                                  for key, value in re.findall(r'(\S+)=(".*?"|\S+)', line)})
-            for line in output_string.strip().splitlines()
+        Handled device scenarios and their effect on `available`:
+
+        - Plain disk, no children: available unless the disk itself has a
+          mountpoint.
+        - Partitioned disk: available if no partition is mounted and no partition
+          has a used child (lvm, md, mpath, crypt); unavailable otherwise.
+        - Disk member of an mdadm array: the disk itself is unavailable; the md
+          array is added as a separate entry (type 'md'), deduplicated across
+          member appearances, and available if it has no mountpoint and no used
+          children.
+        - LUN with multipath configured: each path appears as a 'disk' entry and
+          a shared 'mpath' entry as its child. The path disks are unavailable
+          (mpath child); the mpath device is added once (type 'mpath'),
+          deduplicated by kname across path appearances.
+        - LUN accessible through multiple paths without multipath configured:
+          multiple 'disk' entries with no children but sharing the same WWN.
+          Deduplicated to a single entry (first path seen) based on WWN.
+        """
+        RAID_TYPES = {'raid0', 'raid1', 'raid4', 'raid5', 'raid6', 'raid10', 'linear'}
+        USED_TYPES = RAID_TYPES | {'lvm', 'mpath', 'crypt'}
+        LSBLK_FIELDS = 'NAME,KNAME,PKNAME,SIZE,LOG-SEC,TYPE,MOUNTPOINT,WWN'
+
+        devices: list[Host.BlockDeviceInfo] = []
+
+        raw = self.ssh(f'lsblk --pairs --bytes --output {LSBLK_FIELDS}')
+
+        def _split_keys(line: str) -> list[tuple[str, str]]:
+            return re.findall(r'(\S+)=(".*?"|\S+)', line)
+
+        rows = [
+            {key.lower(): val.strip('"') for key, val in _split_keys(line)}
+            for line in raw.strip().splitlines()
         ]
-        logging.debug("blockdevs found: %s", [disk["name"] for disk in self.block_devices_info])
+
+        # build children map: kname -> list of child knames
+        children: dict[str, list[str]] = {}
+        for r in rows:
+            if r['pkname']:
+                children.setdefault(r['pkname'], []).append(r['kname'])
+
+        # availability from lsblk fields: no mountpoint, not a "used" type, all descendants also free
+        def _row_by_kname(kname: str) -> dict[str, str] | None:
+            for r in rows:
+                if r['kname'] == kname:
+                    return r
+            return None
+
+        def _all_available(kname: str) -> bool:
+            r = _row_by_kname(kname)
+            if r is None:
+                return False
+            if r['mountpoint'] or r['type'] in USED_TYPES:
+                return False
+            return all(_all_available(c) for c in children.get(kname, []))
+
+        seen_knames: set[str] = set()
+        seen_wwns: set[str] = set()
+
+        for r in rows:
+            # --- local disks ---
+            if r['type'] == 'disk' and not r['pkname']:
+                wwn = r['wwn']
+                if wwn:
+                    if wwn in seen_wwns:
+                        continue
+                    seen_wwns.add(wwn)
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['name'],
+                    path=f'/dev/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='disk',
+                    available=_all_available(r['kname']),
+                    wwn=wwn.removeprefix('0x'),
+                ))
+
+            # --- mdadm arrays (may appear once per member, deduplicate) ---
+            elif r['type'] in RAID_TYPES:
+                if r['kname'] in seen_knames:
+                    continue
+                seen_knames.add(r['kname'])
+                available = not r['mountpoint'] and all(_all_available(c) for c in children.get(r['kname'], []))
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['name'],
+                    path=f'/dev/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='md',
+                    available=available,
+                ))
+
+            # --- multipath devices (may appear once per path, deduplicate) ---
+            elif r['type'] == 'mpath':
+                if r['kname'] in seen_knames:
+                    continue
+                seen_knames.add(r['kname'])
+                available = not r['mountpoint'] and all(_all_available(c) for c in children.get(r['kname'], []))
+                wwn = r['name'][1:17] if re.fullmatch(r'3[0-9a-f]{32}', r['name']) else ''
+                devices.append(Host.BlockDeviceInfo(
+                    name=r['kname'],
+                    path=f'/dev/mapper/{r["name"]}',
+                    size=int(r['size']),
+                    log_sec=int(r['log-sec']),
+                    type='mpath',
+                    available=available,
+                    wwn=wwn,
+                ))
+
+        self.block_devices_info = sorted(devices, key=lambda d: d.size, reverse=True)
+        logging.debug("blockdevs found: %s", [d.name for d in self.block_devices_info])
 
     def disks(self) -> list[Host.BlockDeviceInfo]:
-        """ List of BlockDeviceInfo for all disks. """
-        # store the names of the parent devices to filter out the devices with children
-        pknames = set(disk['pkname'] for disk in self.block_devices_info if disk['pkname'])
-        # filter out partitions from block_devices
-        return sorted(
-            (
-                disk
-                for disk in self.block_devices_info
-                if (not disk["pkname"] or disk['type'] == 'raid0') and disk['kname'] not in pknames
-            ),
-            key=lambda disk: disk["name"],
-        )
-
-    def disk_is_available(self, disk: DiskDevName) -> bool:
-        """
-        Check if a disk is unmounted and appears available for use.
-
-        It may or may not contain identifiable filesystem or partition label.
-        If there are no mountpoints, it is assumed that the disk is not in use.
-
-        Warn: This function may misclassify LVM_member disks (e.g. in XOSTOR, RAID, ZFS) as "available".
-        Such disks may not have mountpoints but still be in use.
-        """
-        return len(self.ssh(f'lsblk --noheadings -o MOUNTPOINT /dev/{disk}').strip()) == 0
+        """ List of all block devices (local disks, mdadm arrays, multipath devices). """
+        return list(self.block_devices_info)
 
     def file_exists(self, filepath: str, regular_file: bool = True) -> bool:
         option = '-f' if regular_file else '-e'

--- a/pkgfixtures.py
+++ b/pkgfixtures.py
@@ -25,7 +25,7 @@ def sr_disk_wiped(host: Host, unused_512B_disks: dict[Host, list[Host.BlockDevic
     """A disk on MASTER HOST OF FIRST POOL which we wipe."""
     host_disks = unused_512B_disks[host]
     assert host_disks, f"No 512B disk available on host {host}"
-    sr_disk = host_disks[0]["name"]
+    sr_disk = host_disks[0].name
     logging.info(">> wipe disk %s" % sr_disk)
     host.ssh(f'wipefs -a /dev/{sr_disk}')
     yield sr_disk
@@ -38,7 +38,7 @@ def formatted_and_mounted_ext4_disk(host: Host, unused_512B_disks: dict[Host, li
     mountpoint = '/var/tmp/sr_disk_mountpoint'
     host_disks = unused_512B_disks[host]
     assert host_disks, f"No 512B disk available on host {host}"
-    sr_disk = host_disks[0]["name"]
+    sr_disk = host_disks[0].name
     setup_formatted_and_mounted_disk(host, sr_disk, 'ext4', mountpoint)
     yield mountpoint
     teardown_formatted_and_mounted_disk(host, mountpoint)

--- a/pkgfixtures.py
+++ b/pkgfixtures.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 # Reference: https://github.com/pytest-dev/pytest/issues/8189
 
 # package scope because previous test packages may have used the disk
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def sr_disk_wiped(host: Host, unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]]) -> Generator[DiskDevName]:
     """A disk on MASTER HOST OF FIRST POOL which we wipe."""
     host_disks = unused_512B_disks[host]
@@ -31,7 +31,7 @@ def sr_disk_wiped(host: Host, unused_512B_disks: dict[Host, list[Host.BlockDevic
     yield sr_disk
 
 # package scope so that the device is unmounted before tests from the next package is executed.
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def formatted_and_mounted_ext4_disk(host: Host, unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]]
                                     ) -> Generator[str]:
     """Mountpoint for newly-formatted disk on MASTER HOST OF FIRST POOL."""
@@ -56,7 +56,7 @@ def _host_with_saved_yum_state(host: Host, restart_toolstack: bool) -> Generator
     if restart_toolstack:
         host.restart_toolstack(verify=True)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_saved_yum_state(host: Host) -> Generator[Host]:
     """
     Saves the yum state and then restore it on teardown.
@@ -65,7 +65,7 @@ def host_with_saved_yum_state(host: Host) -> Generator[Host]:
     """
     yield from _host_with_saved_yum_state(host, False)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_saved_yum_state_toolstack_restart(host: Host) -> Generator[Host]:
     """
     Saves the yum state then restore it and restarts the toolstack on teardown.
@@ -74,7 +74,7 @@ def host_with_saved_yum_state_toolstack_restart(host: Host) -> Generator[Host]:
     """
     yield from _host_with_saved_yum_state(host, True)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_with_saved_yum_state(host: Host) -> Generator[Pool]:
     for h in host.pool.hosts:
         h.yum_save_state()

--- a/tests/packages/linux_image/conftest.py
+++ b/tests/packages/linux_image/conftest.py
@@ -10,7 +10,7 @@ from pkgfixtures import host_with_saved_yum_state
 
 from typing import Generator
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_with_perf(host_at_least_8_3: Host, host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
 

--- a/tests/packages/mlx/conftest.py
+++ b/tests/packages/mlx/conftest.py
@@ -8,7 +8,7 @@ from pkgfixtures import host_with_saved_yum_state
 
 from typing import Generator
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_without_mlx_compat_loaded(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
 

--- a/tests/packages/netdata/conftest.py
+++ b/tests/packages/netdata/conftest.py
@@ -7,7 +7,7 @@ from pkgfixtures import host_with_saved_yum_state
 
 from typing import Generator
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_with_netdata(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     # Installing netdata-ui also installs netdata and all required dependencies

--- a/tests/storage/cephfs/conftest.py
+++ b/tests/storage/cephfs/conftest.py
@@ -10,31 +10,31 @@ from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
 
-# explicit import for package-scope fixtures
-from pkgfixtures import pool_with_saved_yum_state
-
 from typing import Generator
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_without_ceph(host: Host) -> Generator[Pool, None, None]:
     for h in host.pool.hosts:
         assert not host.file_exists('/usr/sbin/mount.ceph'), \
             "mount.ceph must not be installed on the host at the beginning of the tests"
     yield host.pool
 
-@pytest.fixture(scope='package')
-def pool_with_ceph(pool_without_ceph: Pool, pool_with_saved_yum_state: Pool) -> Generator[Pool, None, None]:
-    pool = pool_with_saved_yum_state
+@pytest.fixture(scope='module')
+def pool_with_ceph(pool_without_ceph: Pool) -> Generator[Pool, None, None]:
+    pool = pool_without_ceph
+    for h in pool.hosts:
+        h.yum_save_state()
     for h in pool.hosts:
         h.yum_install(['centos-release-ceph-jewel'], enablerepo="base,extras")
         h.yum_install(['ceph-common'], enablerepo="base,extras")
     yield pool
+    pool.exec_on_hosts_on_error_continue(lambda h: h.yum_restore_saved_state())
 
 @pytest.fixture(scope='package')
 def cephfs_device_config() -> dict[str, str]:
     return config.sr_device_config("CEPHFS_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def cephfs_sr(host: Host, cephfs_device_config: dict[str, str], pool_with_ceph: Pool) -> Generator[SR, None, None]:
     """ A CephFS SR on first host. """
     sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)

--- a/tests/storage/cephfs/test_cephfs_sr.py
+++ b/tests/storage/cephfs/test_cephfs_sr.py
@@ -17,37 +17,6 @@ from tests.storage import vdi_is_open
 # - remote cephfs mountpoint
 # - access to XCP-ng RPM repository from the host
 
-class TestCephFSSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_cephfs_sr_without_ceph(self, host: Host, cephfs_device_config: dict[str, str]) -> None:
-        # This test must be the first in the series in this module
-        assert not host.file_exists('/usr/sbin/mount.ceph'), \
-            "mount.ceph must not be installed on the host at the beginning of the tests"
-        sr = None
-        try:
-            sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(
-        self, host: Host, cephfs_device_config: dict[str, str], pool_with_ceph: Pool
-    ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("cephfs_sr")
 class TestCephFSSR:
     @pytest.mark.quicktest

--- a/tests/storage/cephfs/test_create_destroy_cephfs_sr.py
+++ b/tests/storage/cephfs/test_create_destroy_cephfs_sr.py
@@ -1,0 +1,43 @@
+import pytest
+
+import logging
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.pool import Pool
+
+# Requirements:
+# - one XCP-ng host >= 8.2
+# - remote cephfs mountpoint
+# - access to XCP-ng RPM repository from the host
+
+class TestCephFSSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_cephfs_sr_without_ceph(self, host: Host, cephfs_device_config: dict[str, str]) -> None:
+        # This test must be the first in the series in this module
+        assert not host.file_exists('/usr/sbin/mount.ceph'), \
+            "mount.ceph must not be installed on the host at the beginning of the tests"
+        sr = None
+        try:
+            sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(
+        self, host: Host, cephfs_device_config: dict[str, str], pool_with_ceph: Pool
+    ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('cephfs', "CephFS-SR-test", cephfs_device_config, shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_cephfs_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -83,7 +83,7 @@ def xfs_sr_on_hostA2(
     _xfs_config_on_hostA2: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[hostA2_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[hostA2_with_xfsprogs][0].name
     sr = hostA2_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                         {'device': '/dev/' + sr_disk,
                                          'preferred-image-formats': image_format})
@@ -123,7 +123,7 @@ def xfs_sr_on_hostB1(
     _xfs_config_on_hostB1: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[hostB1_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[hostB1_with_xfsprogs][0].name
     sr = hostB1_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                         {'device': '/dev/' + sr_disk,
                                          'preferred-image-formats': image_format})

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -55,7 +55,7 @@ def temp_large_dir(host: Host) -> Generator[str, None, None]:
 class XfsConfig:
     uninstall_xfs: bool = True
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def _xfs_config_on_hostA2() -> XfsConfig:
     return XfsConfig()
 
@@ -63,7 +63,7 @@ def _xfs_config_on_hostA2() -> XfsConfig:
 # To recreate host_with_xfsprogs for each image_format value, accept
 # image_format in the fixture arguments.
 # ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def hostA2_with_xfsprogs(hostA2: Host, image_format: ImageFormat, _xfs_config_on_hostA2: XfsConfig) \
         -> Generator[Host, None, None]:
     assert not hostA2.file_exists('/usr/sbin/mkfs.xfs'), \
@@ -75,7 +75,7 @@ def hostA2_with_xfsprogs(hostA2: Host, image_format: ImageFormat, _xfs_config_on
     if _xfs_config_on_hostA2.uninstall_xfs:
         hostA2.yum_restore_saved_state()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def xfs_sr_on_hostA2(
     unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
     hostA2_with_xfsprogs: Host,
@@ -95,7 +95,7 @@ def xfs_sr_on_hostA2(
         _xfs_config_on_hostA2.uninstall_xfs = False
         raise pytest.fail("Could not destroy xfs SR, leaving packages in place for manual cleanup") from e
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def _xfs_config_on_hostB1() -> XfsConfig:
     return XfsConfig()
 
@@ -103,7 +103,7 @@ def _xfs_config_on_hostB1() -> XfsConfig:
 # To recreate host_with_xfsprogs for each image_format value, accept
 # image_format in the fixture arguments.
 # ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def hostB1_with_xfsprogs(hostB1: Host, image_format: ImageFormat, _xfs_config_on_hostB1: XfsConfig) \
         -> Generator[Host, None, None]:
     assert not hostB1.file_exists('/usr/sbin/mkfs.xfs'), \
@@ -115,7 +115,7 @@ def hostB1_with_xfsprogs(hostB1: Host, image_format: ImageFormat, _xfs_config_on
     if _xfs_config_on_hostB1.uninstall_xfs:
         hostB1.yum_restore_saved_state()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def xfs_sr_on_hostB1(
     unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
     hostB1_with_xfsprogs: Host,

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -18,7 +18,7 @@ def ext_sr(host: Host,
            image_format: ImageFormat
            ) -> Generator[SR, None, None]:
     """ An EXT SR on first host. """
-    sr_disk = unused_512B_disks[host][0]["name"]
+    sr_disk = unused_512B_disks[host][0].name
     sr = host.sr_create('ext', "EXT-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/ext/conftest.py
+++ b/tests/storage/ext/conftest.py
@@ -12,7 +12,7 @@ from lib.vm import VM
 
 from typing import Any, Generator
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def ext_sr(host: Host,
            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
            image_format: ImageFormat

--- a/tests/storage/ext/test_create_destroy_ext_sr.py
+++ b/tests/storage/ext/test_create_destroy_ext_sr.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.vdi import ImageFormat
+from tests.storage import try_to_create_sr_with_missing_device
+
+# Requirements:
+# - one XCP-ng host with an additional unused disk for the SR
+
+class TestEXTSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
+        try_to_create_sr_with_missing_device('ext', 'EXT-local-SR-test', host)
+
+    def test_create_and_destroy_sr(self, host: Host,
+                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+                                   image_format: ImageFormat
+                                   ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr_disk = unused_512B_disks[host][0].name
+        sr = host.sr_create('ext', "EXT-local-SR-test",
+                            {'device': '/dev/' + sr_disk,
+                             'preferred-image-formats': image_format}, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_ext_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -42,7 +42,7 @@ class TestEXTSRCreateDestroy:
                                    image_format: ImageFormat
                                    ) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr = host.sr_create('ext', "EXT-local-SR-test",
                             {'device': '/dev/' + sr_disk,
                              'preferred-image-formats': image_format}, verify=True)

--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -27,31 +27,6 @@ from tests.storage import (
 # Requirements:
 # - one XCP-ng host with an additional unused disk for the SR
 
-class TestEXTSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_sr_with_missing_device(self, host: Host) -> None:
-        try_to_create_sr_with_missing_device('ext', 'EXT-local-SR-test', host)
-
-    def test_create_and_destroy_sr(self, host: Host,
-                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                                   image_format: ImageFormat
-                                   ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_512B_disks[host][0].name
-        sr = host.sr_create('ext', "EXT-local-SR-test",
-                            {'device': '/dev/' + sr_disk,
-                             'preferred-image-formats': image_format}, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("ext_sr")
 class TestEXTSR:
     @pytest.mark.quicktest

--- a/tests/storage/fsp/conftest.py
+++ b/tests/storage/fsp/conftest.py
@@ -15,7 +15,7 @@ FSP_PACKAGES = ['xcp-ng-xapi-storage']
 
 DIRECTORIES_PATH = 'directories'
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state_toolstack_restart
     host.add_xcpng_repo(FSP_REPO_NAME, 'vates')
@@ -23,7 +23,7 @@ def host_with_runx_repo(host_with_saved_yum_state_toolstack_restart: Host) -> Ge
     # teardown
     host.remove_xcpng_repo(FSP_REPO_NAME)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_fsp(host_with_runx_repo: Host) -> Generator[Host, None, None]:
     host = host_with_runx_repo
     host.yum_install(FSP_PACKAGES)
@@ -33,7 +33,7 @@ def host_with_fsp(host_with_runx_repo: Host) -> Generator[Host, None, None]:
     yield host
     # teardown: nothing to do, done by host_with_saved_yum_state.
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def fsp_config(host_with_fsp: Host) -> dict[str, str]:
     db_path = host_with_fsp.ssh('mktemp -d')
     shared_dir_path = host_with_fsp.ssh('mktemp -d')
@@ -42,7 +42,7 @@ def fsp_config(host_with_fsp: Host) -> dict[str, str]:
         'shared_dir_path': shared_dir_path
     }
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def fsp_sr(host_with_fsp: Host, fsp_config: dict[str, str]) -> Generator[SR, None, None]:
     """ An FSP SR on first host. """
     db_path = fsp_config['db_path']

--- a/tests/storage/fsp/test_create_destroy_fsp_sr.py
+++ b/tests/storage/fsp/test_create_destroy_fsp_sr.py
@@ -1,0 +1,36 @@
+import pytest
+
+import logging
+
+from lib.host import Host
+
+from .conftest import DIRECTORIES_PATH
+
+# Requirements:
+# From --hosts parameter:
+# - host: a XCP-ng host >= 8.2
+
+class TestFSPSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR
+    because they precisely need to test SR creation and destruction.
+    """
+
+    def test_create_and_destroy_sr(self, host_with_fsp: Host) -> None:
+        db_path = host_with_fsp.ssh('mktemp -d')
+        host_with_fsp.ssh(f'mkdir {db_path}/{DIRECTORIES_PATH}')
+        sr = host_with_fsp.sr_create('fsp', "fsp-local-SR-test", {'file-uri': db_path})
+        sr.destroy()
+        host_with_fsp.ssh(f'rm -rf {db_path}')
+
+    def test_create_and_destroy_sr_non_existing_path(self, host_with_fsp: Host) -> None:
+        # get an unique non-existing path
+        db_path = host_with_fsp.ssh('mktemp -d --dry-run')
+        sr = None
+        try:
+            sr = host_with_fsp.sr_create('fsp', "fsp-local-SR-test", {'file-uri': db_path})
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"

--- a/tests/storage/fsp/test_fsp_sr.py
+++ b/tests/storage/fsp/test_fsp_sr.py
@@ -12,31 +12,6 @@ from .conftest import DIRECTORIES_PATH
 # From --hosts parameter:
 # - host: a XCP-ng host >= 8.2
 
-class TestFSPSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR
-    because they precisely need to test SR creation and destruction.
-    """
-
-    def test_create_and_destroy_sr(self, host_with_fsp: Host) -> None:
-        db_path = host_with_fsp.ssh('mktemp -d')
-        host_with_fsp.ssh(f'mkdir {db_path}/{DIRECTORIES_PATH}')
-        sr = host_with_fsp.sr_create('fsp', "fsp-local-SR-test", {'file-uri': db_path})
-        sr.destroy()
-        host_with_fsp.ssh(f'rm -rf {db_path}')
-
-    def test_create_and_destroy_sr_non_existing_path(self, host_with_fsp: Host) -> None:
-        # get an unique non-existing path
-        db_path = host_with_fsp.ssh('mktemp -d --dry-run')
-        sr = None
-        try:
-            sr = host_with_fsp.sr_create('fsp', "fsp-local-SR-test", {'file-uri': db_path})
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
 class TestFSPVDI:
     def test_create_and_destroy_VDI(self, host_with_fsp: Host, fsp_sr: SR, fsp_config: dict[str, str]) -> None:
         linkname = 'vdifor' + os.path.basename(fsp_config['shared_dir_path'])

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -122,7 +122,7 @@ def gluster_disk(
     pool = pool_with_unused_512B_disk
     mountpoint = '/mnt/sr_disk'
     for h in pool.hosts:
-        sr_disk = unused_512B_disks[h][0]["name"]
+        sr_disk = unused_512B_disks[h][0].name
         setup_formatted_and_mounted_disk(h, sr_disk, 'xfs', mountpoint)
 
     yield

--- a/tests/storage/glusterfs/conftest.py
+++ b/tests/storage/glusterfs/conftest.py
@@ -18,16 +18,13 @@ if TYPE_CHECKING:
     from lib.vdi import VDI
     from lib.vm import VM
 
-# explicit import for package-scope fixtures
-from pkgfixtures import pool_with_saved_yum_state
-
 GLUSTERFS_PORTS = [('24007', 'tcp'), ('49152:49251', 'tcp')]
 
 @dataclass
 class GlusterFsConfig:
     uninstall_glusterfs: bool = True
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def _glusterfs_config() -> GlusterFsConfig:
     return GlusterFsConfig()
 
@@ -78,7 +75,7 @@ def _restore_host_iptables(host: Host) -> None:
 
     raise_errors(errors)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_without_glusterfs(host: Host) -> Generator[Pool, None, None]:
     for h in host.pool.hosts:
         if h.file_exists('/usr/sbin/glusterd'):
@@ -87,10 +84,9 @@ def pool_without_glusterfs(host: Host) -> Generator[Pool, None, None]:
             )
     yield host.pool
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_with_glusterfs(
     pool_without_glusterfs: Pool,
-    pool_with_saved_yum_state: Pool,
     _glusterfs_config: GlusterFsConfig
 ) -> Generator[Pool, None, None]:
 
@@ -101,7 +97,8 @@ def pool_with_glusterfs(
     def _disable_yum_rollback(host: Host) -> None:
         host.saved_rollback_id = None
 
-    pool = pool_with_saved_yum_state
+    pool = pool_without_glusterfs
+    pool.exec_on_hosts_on_error_continue(lambda h: h.yum_save_state())
     pool.exec_on_hosts_on_error_rollback(_setup_host_with_glusterfs, _host_rollback)
 
     yield pool
@@ -112,8 +109,9 @@ def pool_with_glusterfs(
 
     pool.exec_on_hosts_on_error_continue(_uninstall_host_glusterfs)
     pool.exec_on_hosts_on_error_continue(_restore_host_iptables)
+    pool.exec_on_hosts_on_error_continue(lambda h: h.yum_restore_saved_state())
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def gluster_disk(
     pool_with_unused_512B_disk: Pool,
     unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
@@ -174,7 +172,7 @@ def _fallback_gluster_teardown(host: Host) -> None:
                 logging.error("< Fallback teardown failed on host: %s with error: %s" % (h, e))
                 pass
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def gluster_volume_started(
     host: Host,
     hostA2: Host,
@@ -243,7 +241,7 @@ def glusterfs_device_config(host: Host) -> dict[str, str]:
         'backupservers': ':'.join(backup_servers)
     }
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def glusterfs_sr(
     host: Host,
     pool_with_glusterfs: Pool,

--- a/tests/storage/glusterfs/test_create_destroy_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_create_destroy_glusterfs_sr.py
@@ -1,0 +1,47 @@
+import pytest
+
+import logging
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.pool import Pool
+
+# Requirements:
+# - one XCP-ng host >= 8.2 with an additional unused disk for the SR
+# - access to XCP-ng RPM repository from the host
+
+@pytest.mark.usefixtures("pool_with_unused_512B_disk") # don't even run the tests if there's no free disk
+class TestGlusterFSSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_glusterfs_sr_without_gluster(self, host: Host, glusterfs_device_config: dict[str, str]) -> None:
+        # This test must be the first in the series in this module
+        assert not host.file_exists('/usr/sbin/glusterd'), \
+            "glusterd must not be installed on the host at the beginning of the tests"
+        sr = None
+        try:
+            sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(
+        self,
+        host: Host,
+        glusterfs_device_config: dict[str, str],
+        pool_with_glusterfs: Pool,
+        gluster_volume_started: None,
+    ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_glusterfs_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/glusterfs/test_glusterfs_sr.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr.py
@@ -15,42 +15,6 @@ from tests.storage import vdi_is_open
 # - one XCP-ng host >= 8.2 with an additional unused disk for the SR
 # - access to XCP-ng RPM repository from the host
 
-@pytest.mark.usefixtures("pool_with_unused_512B_disk") # don't even run the tests if there's no free disk
-class TestGlusterFSSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_glusterfs_sr_without_gluster(self, host: Host, glusterfs_device_config: dict[str, str]) -> None:
-        # This test must be the first in the series in this module
-        assert not host.file_exists('/usr/sbin/glusterd'), \
-            "glusterd must not be installed on the host at the beginning of the tests"
-        sr = None
-        try:
-            sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(
-        self,
-        host: Host,
-        glusterfs_device_config: dict[str, str],
-        pool_with_glusterfs: Pool,
-        gluster_volume_started: None,
-    ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('glusterfs', "GlusterFS-SR-test", glusterfs_device_config, shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_glusterfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 class TestGlusterFSSR:
     @pytest.mark.quicktest
     def test_quicktest(self, glusterfs_sr: SR) -> None:

--- a/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
+++ b/tests/storage/glusterfs/test_glusterfs_sr_intrapool_migration.py
@@ -19,7 +19,7 @@ from typing import Generator
 # - access to XCP-ng RPM repository from hostA1
 
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs_sr(host: Host, image_format: ImageFormat) -> Generator[SR, None, None]:
     """
     A NFS SR on first host.

--- a/tests/storage/iso/test_cifs_iso_sr.py
+++ b/tests/storage/iso/test_cifs_iso_sr.py
@@ -16,28 +16,6 @@ from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr
 # - A VM to import
 # From data.py or --sr-device-config parameter: configuration to create a new CIFS (SAMBA) ISO SR.
 
-class TestCIFSISOSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction
-    """
-
-    def test_create_sr_with_bad_location(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
-        sr = None
-        try:
-            wrong_device_config = cifs_iso_device_config.copy()
-            wrong_device_config['location'] += r'\wrongpath'
-            sr = host.sr_create('iso', "ISO-CIFS-SR-test", wrong_device_config, verify=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.forget()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
-        sr = host.sr_create('iso', "ISO-CIFS-SR-test", cifs_iso_device_config, shared=True, verify=True)
-        sr.forget()
-
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("cifs_iso_sr")
 class TestCIFSISOSR:

--- a/tests/storage/iso/test_create_destroy_cifs_iso_sr.py
+++ b/tests/storage/iso/test_create_destroy_cifs_iso_sr.py
@@ -1,0 +1,32 @@
+import pytest
+
+import logging
+
+from lib.host import Host
+
+# Requirements:
+# From --hosts parameter:
+# - host: a XCP-ng host
+# From data.py or --sr-device-config parameter: configuration to create a new CIFS (SAMBA) ISO SR.
+
+class TestCIFSISOSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction
+    """
+
+    def test_create_sr_with_bad_location(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
+        sr = None
+        try:
+            wrong_device_config = cifs_iso_device_config.copy()
+            wrong_device_config['location'] += r'\wrongpath'
+            sr = host.sr_create('iso', "ISO-CIFS-SR-test", wrong_device_config, verify=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.forget()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(self, host: Host, cifs_iso_device_config: dict[str, str]) -> None:
+        sr = host.sr_create('iso', "ISO-CIFS-SR-test", cifs_iso_device_config, shared=True, verify=True)
+        sr.forget()

--- a/tests/storage/iso/test_create_destroy_local_iso_sr.py
+++ b/tests/storage/iso/test_create_destroy_local_iso_sr.py
@@ -1,0 +1,41 @@
+import pytest
+
+import logging
+
+from lib.host import Host
+
+from .conftest import create_local_iso_sr
+
+# Requirements:
+# From --hosts parameter:
+# - host: a XCP-ng host, with:
+#   - the default SR being either a shared SR, or a local SR on the master host
+#   - an additional unused disk for the SR
+# From --vm parameter:
+# - A VM to import
+
+class TestLocalISOSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction
+    """
+
+    def test_create_sr_with_bad_location(self, host: Host) -> None:
+        sr = None
+        try:
+            device_config = {
+                'location': '/this/does/not/exist',
+                'legacy_mode': 'true'
+            }
+            sr = host.sr_create('iso', "ISO-local-SR-test", device_config, verify=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(self, host: Host, formatted_and_mounted_ext4_disk: str) -> None:
+        location = formatted_and_mounted_ext4_disk + '/iso_sr'
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = create_local_iso_sr(host, location)
+        sr.destroy(verify=True)

--- a/tests/storage/iso/test_create_destroy_nfs_iso_sr.py
+++ b/tests/storage/iso/test_create_destroy_nfs_iso_sr.py
@@ -1,0 +1,33 @@
+import pytest
+
+import logging
+
+from lib.host import Host
+
+# Requirements:
+# From --hosts parameter:
+# - host: a XCP-ng host
+# From data.py or --sr-device-config parameter: configuration to create a new NFS ISO SR.
+
+class TestNFSISOSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction
+    """
+
+    def test_create_sr_with_bad_location(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
+        sr = None
+        try:
+            wrong_device_config = nfs_iso_device_config.copy()
+            wrong_device_config['location'] += '/wrongpath'
+            sr = host.sr_create('iso', "ISO-NFS-SR-test", wrong_device_config, verify=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.forget()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('iso', "ISO-NFS-SR-test", nfs_iso_device_config, shared=True, verify=True)
+        sr.forget()

--- a/tests/storage/iso/test_local_iso_sr.py
+++ b/tests/storage/iso/test_local_iso_sr.py
@@ -22,32 +22,6 @@ from .conftest import (
 # From --vm parameter:
 # - A VM to import
 
-class TestLocalISOSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction
-    """
-
-    def test_create_sr_with_bad_location(self, host: Host) -> None:
-        sr = None
-        try:
-            device_config = {
-                'location': '/this/does/not/exist',
-                'legacy_mode': 'true'
-            }
-            sr = host.sr_create('iso', "ISO-local-SR-test", device_config, verify=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(self, host: Host, formatted_and_mounted_ext4_disk: str) -> None:
-        location = formatted_and_mounted_ext4_disk + '/iso_sr'
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = create_local_iso_sr(host, location)
-        sr.destroy(verify=True)
-
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("local_iso_sr")
 class TestLocalISOSR:

--- a/tests/storage/iso/test_nfs_iso_sr.py
+++ b/tests/storage/iso/test_nfs_iso_sr.py
@@ -16,30 +16,6 @@ from .conftest import check_iso_mount_and_read_from_vm, copy_tools_iso_to_iso_sr
 # - A VM to import
 # From data.py or --sr-device-config parameter: configuration to create a new NFS ISO SR.
 
-class TestNFSISOSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction
-    """
-
-    def test_create_sr_with_bad_location(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
-        sr = None
-        try:
-            wrong_device_config = nfs_iso_device_config.copy()
-            wrong_device_config['location'] += '/wrongpath'
-            sr = host.sr_create('iso', "ISO-NFS-SR-test", wrong_device_config, verify=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.forget()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(self, host: Host, nfs_iso_device_config: dict[str, str]) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('iso', "ISO-NFS-SR-test", nfs_iso_device_config, shared=True, verify=True)
-        sr.forget()
-
-
 @pytest.mark.small_vm
 @pytest.mark.usefixtures("nfs_iso_sr")
 class TestNFSISOSR:

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -20,7 +20,7 @@ def largeblock_sr(host: Host,
                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
                   image_format: ImageFormat) -> Generator[SR, None, None]:
     """ A LARGEBLOCK SR on first host. """
-    sr_disk = unused_4k_disks[host][0]["name"]
+    sr_disk = unused_4k_disks[host][0].name
     sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/largeblock/conftest.py
+++ b/tests/storage/largeblock/conftest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from lib.vdi import VDI
     from lib.vm import VM
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def largeblock_sr(host: Host,
                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
                   image_format: ImageFormat) -> Generator[SR, None, None]:

--- a/tests/storage/largeblock/test_create_destroy_largeblock_sr.py
+++ b/tests/storage/largeblock/test_create_destroy_largeblock_sr.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.common import vm_image
+from lib.vdi import ImageFormat
+from tests.storage import try_to_create_sr_with_missing_device
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lib.host import Host
+
+# Requirements:
+# - one XCP-ng host with an additional unused 4KiB disk for the SR
+
+class TestLARGEBLOCKSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
+        try_to_create_sr_with_missing_device('largeblock', 'LARGEBLOCK-local-SR-test', host)
+
+    def test_create_and_destroy_sr(self, host: Host,
+                                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
+                                   image_format: ImageFormat) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr_disk = unused_4k_disks[host][0].name
+        sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
+                            {'device': '/dev/' + sr_disk,
+                             'preferred-image-formats': image_format}, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_largeblock_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/largeblock/test_largeblock_sr.py
+++ b/tests/storage/largeblock/test_largeblock_sr.py
@@ -31,7 +31,7 @@ class TestLARGEBLOCKSRCreateDestroy:
                                    unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
                                    image_format: ImageFormat) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_4k_disks[host][0]["name"]
+        sr_disk = unused_4k_disks[host][0].name
         sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
                             {'device': '/dev/' + sr_disk,
                              'preferred-image-formats': image_format}, verify=True)

--- a/tests/storage/largeblock/test_largeblock_sr.py
+++ b/tests/storage/largeblock/test_largeblock_sr.py
@@ -17,30 +17,6 @@ if TYPE_CHECKING:
 # Requirements:
 # - one XCP-ng host with an additional unused 4KiB disk for the SR
 
-class TestLARGEBLOCKSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_sr_with_missing_device(self, host: Host) -> None:
-        try_to_create_sr_with_missing_device('largeblock', 'LARGEBLOCK-local-SR-test', host)
-
-    def test_create_and_destroy_sr(self, host: Host,
-                                   unused_4k_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                                   image_format: ImageFormat) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr_disk = unused_4k_disks[host][0].name
-        sr = host.sr_create('largeblock', "LARGEBLOCK-local-SR-test",
-                            {'device': '/dev/' + sr_disk,
-                             'preferred-image-formats': image_format}, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("largeblock_sr")
 class TestLARGEBLOCKSR:
     @pytest.mark.quicktest

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -60,7 +60,7 @@ def lvm_disks(
 
     @functools.cache
     def host_devices(host: Host) -> list[str]:
-        return [os.path.join("/dev", disk["name"]) for disk in unused_512B_disks[host][0:1]]
+        return [disk.path for disk in unused_512B_disks[host][0:1]]
 
     for host in hosts:
         devices = host_devices(host)

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -15,8 +15,6 @@ try:
 except ImportError:
     LINSTOR_REDUNDANCY = 2
 
-# explicit import for package-scope fixtures
-from pkgfixtures import pool_with_saved_yum_state
 
 from typing import TYPE_CHECKING, Generator
 
@@ -36,11 +34,11 @@ LINSTOR_PACKAGE = 'xcp-ng-linstor'
 class LinstorConfig:
     uninstall_linstor: bool = True
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def _linstor_config() -> LinstorConfig:
     return LinstorConfig()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def lvm_disks(
     pool_with_unused_512B_disk: Pool,
     unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
@@ -97,15 +95,14 @@ def storage_pool_name(provisioning_type: str) -> str:
 def provisioning_type(request: pytest.FixtureRequest) -> str:
     return request.param
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_with_linstor(
     hostA2: Host,
     lvm_disks: None,
-    pool_with_saved_yum_state: Pool,
     _linstor_config: LinstorConfig
 ) -> Generator[Pool, None, None]:
     import concurrent.futures
-    pool = pool_with_saved_yum_state
+    pool = hostA2.pool
 
     def check_linstor_installed(host: Host) -> None:
         if host.is_package_installed(LINSTOR_PACKAGE):
@@ -115,6 +112,9 @@ def pool_with_linstor(
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         executor.map(check_linstor_installed, pool.hosts)
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        executor.map(lambda h: h.yum_save_state(), pool.hosts)
 
     def install_linstor(host: Host) -> None:
         logging.info(f"Installing {LINSTOR_PACKAGE} on host {host}...")
@@ -130,28 +130,17 @@ def pool_with_linstor(
 
     yield pool
 
-    def _disable_yum_rollback(host: Host) -> None:
-        host.saved_rollback_id = None
-
     if not _linstor_config.uninstall_linstor:
-        pool.exec_on_hosts_on_error_continue(_disable_yum_rollback)
         return
 
-    # Need to remove this package as we have separate run of `test_create_sr_without_linstor`
-    # for `thin` and `thick` `provisioning_type`.
-    def remove_linstor(host: Host) -> None:
-        logging.info(f"Cleaning up python-linstor from host {host}...")
-        host.yum_remove(["python-linstor"])
-        host.restart_toolstack(verify=True)
-
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(remove_linstor, pool.hosts)
+        executor.map(lambda h: h.yum_restore_saved_state(), pool.hosts)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def linstor_redundancy(pool_with_linstor: Pool) -> int:
     return min(len(pool_with_linstor.hosts), LINSTOR_REDUNDANCY)
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def linstor_sr(
     pool_with_linstor: Pool,
     linstor_redundancy: int,

--- a/tests/storage/linstor/test_create_destroy_linstor_sr.py
+++ b/tests/storage/linstor/test_create_destroy_linstor_sr.py
@@ -1,0 +1,55 @@
+import pytest
+
+import logging
+
+from lib.commands import SSHCommandFailed
+from lib.common import vm_image
+from lib.host import Host
+from lib.pool import Pool
+
+# Requirements:
+# - two or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR
+# - access to XCP-ng RPM repository from the host
+
+class TestLinstorSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_sr_without_linstor(
+        self, host: Host, lvm_disks: None, provisioning_type: str, storage_pool_name: str
+    ) -> None:
+        # This test must be the first in the series in this module
+        assert not host.is_package_installed('python-linstor'), \
+            "linstor must not be installed on the host at the beginning of the tests"
+        try:
+            sr = host.sr_create('linstor', 'LINSTOR-SR-test', {
+                'group-name': storage_pool_name,
+                'redundancy': '1',
+                'provisioning': provisioning_type
+            }, shared=True)
+            try:
+                sr.destroy()
+            except Exception:
+                pass
+            assert False, "SR creation should not have succeeded!"
+        except SSHCommandFailed as e:
+            logging.info("SR creation failed, as expected: {}".format(e))
+
+    def test_create_and_destroy_sr(
+        self, pool_with_linstor: Pool, provisioning_type: str, storage_pool_name: str
+    ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        master = pool_with_linstor.master
+        sr = master.sr_create('linstor', 'LINSTOR-SR-test', {
+            'group-name': storage_pool_name,
+            'redundancy': '1',
+            'provisioning': provisioning_type
+        }, shared=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_linstor_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = master.import_vm(vm_image('mini-linux-x86_64-bios'), sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -18,49 +18,6 @@ from .conftest import LINSTOR_PACKAGE
 # - two or more XCP-ng hosts >= 8.2 with additional unused disk(s) for the SR
 # - access to XCP-ng RPM repository from the host
 
-class TestLinstorSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_sr_without_linstor(
-        self, host: Host, lvm_disks: None, provisioning_type: str, storage_pool_name: str
-    ) -> None:
-        # This test must be the first in the series in this module
-        assert not host.is_package_installed('python-linstor'), \
-            "linstor must not be installed on the host at the beginning of the tests"
-        try:
-            sr = host.sr_create('linstor', 'LINSTOR-SR-test', {
-                'group-name': storage_pool_name,
-                'redundancy': '1',
-                'provisioning': provisioning_type
-            }, shared=True)
-            try:
-                sr.destroy()
-            except Exception:
-                pass
-            assert False, "SR creation should not have succeeded!"
-        except SSHCommandFailed as e:
-            logging.info("SR creation failed, as expected: {}".format(e))
-
-    def test_create_and_destroy_sr(
-        self, pool_with_linstor: Pool, provisioning_type: str, storage_pool_name: str
-    ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        master = pool_with_linstor.master
-        sr = master.sr_create('linstor', 'LINSTOR-SR-test', {
-            'group-name': storage_pool_name,
-            'redundancy': '1',
-            'provisioning': provisioning_type
-        }, shared=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_linstor_sr fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = master.import_vm(vm_image('mini-linux-x86_64-bios'), sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("linstor_sr")
 class TestLinstorSR:
     @pytest.mark.quicktest

--- a/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
+++ b/tests/storage/linstor/test_linstor_sr_intrapool_migration.py
@@ -18,7 +18,7 @@ from typing import Generator
 # And:
 # - access to XCP-ng RPM repository from hostA1
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs_sr(host: Host, image_format: ImageFormat) -> Generator[SR, None, None]:
     """
     A NFS SR on first host.

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -18,7 +18,7 @@ def lvm_sr(host: Host,
            image_format: ImageFormat
            ) -> Generator[SR, None, None]:
     """ An LVM SR on first host. """
-    sr_disk = unused_512B_disks[host][0]["name"]
+    sr_disk = unused_512B_disks[host][0].name
     sr = host.sr_create('lvm', "LVM-local-SR-test",
                         {'device': '/dev/' + sr_disk,
                          'preferred-image-formats': image_format})

--- a/tests/storage/lvm/conftest.py
+++ b/tests/storage/lvm/conftest.py
@@ -12,7 +12,7 @@ from lib.vm import VM
 
 from typing import Generator
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def lvm_sr(host: Host,
            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
            image_format: ImageFormat

--- a/tests/storage/lvm/test_create_destroy_lvm_sr.py
+++ b/tests/storage/lvm/test_create_destroy_lvm_sr.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.vdi import ImageFormat
+from tests.storage import try_to_create_sr_with_missing_device
+
+# Requirements:
+# - one XCP-ng host with an additional unused disk for the SR
+
+class TestLVMSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_sr_with_missing_device(self, host: Host) -> None:
+        try_to_create_sr_with_missing_device('lvm', 'LVM-local-SR-test', host)
+
+    def test_create_and_destroy_sr(self, host: Host,
+                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+                                   image_format: ImageFormat
+                                   ) -> None:
+        sr_disk = unused_512B_disks[host][0].name
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('lvm', "LVM-local-SR-test", {
+            'device': '/dev/' + sr_disk,
+            'preferred-image-formats': image_format
+        }, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_lvm_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -41,7 +41,7 @@ class TestLVMSRCreateDestroy:
                                    unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
                                    image_format: ImageFormat
                                    ) -> None:
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         sr = host.sr_create('lvm', "LVM-local-SR-test", {
             'device': '/dev/' + sr_disk,

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -27,32 +27,6 @@ from tests.storage import (
 # Requirements:
 # - one XCP-ng host with an additional unused disk for the SR
 
-class TestLVMSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_sr_with_missing_device(self, host: Host) -> None:
-        try_to_create_sr_with_missing_device('lvm', 'LVM-local-SR-test', host)
-
-    def test_create_and_destroy_sr(self, host: Host,
-                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                                   image_format: ImageFormat
-                                   ) -> None:
-        sr_disk = unused_512B_disks[host][0].name
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('lvm', "LVM-local-SR-test", {
-            'device': '/dev/' + sr_disk,
-            'preferred-image-formats': image_format
-        }, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("lvm_sr")
 @pytest.mark.thick_provisioned
 class TestLVMSR:

--- a/tests/storage/lvmohba/conftest.py
+++ b/tests/storage/lvmohba/conftest.py
@@ -10,7 +10,7 @@ from lib.vdi import ImageFormat
 def lvmohba_device_config():
     return config.sr_device_config("LVMOHBA_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def lvmohba_sr(host, lvmohba_device_config, image_format: ImageFormat):
     """ A lvmohba SR on first host. """
     sr = host.sr_create('lvmohba', "lvmohba-SR-test",

--- a/tests/storage/lvmohba/test_create_destroy_lvmohba_sr.py
+++ b/tests/storage/lvmohba/test_create_destroy_lvmohba_sr.py
@@ -1,0 +1,26 @@
+import pytest
+
+from lib.common import vm_image
+from lib.vdi import ImageFormat
+
+# Requirements:
+# - one XCP-ng host >= 8.2
+# - a valid lvmohba config
+
+class TestLVMOHBASRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_and_destroy_sr(self, host, lvmohba_device_config, image_format: ImageFormat):
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('lvmohba', "lvmohba-SR-test",
+                            lvmohba_device_config | {'preferred-image-formats': image_format},
+                            shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_lvmohba_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/lvmohba/test_lvmohba_sr.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr.py
@@ -21,24 +21,6 @@ from tests.storage import (
 # - one XCP-ng host >= 8.2
 # - a valid lvmohba config
 
-class TestLVMOHBASRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_and_destroy_sr(self, host, lvmohba_device_config, image_format: ImageFormat):
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('lvmohba', "lvmohba-SR-test",
-                            lvmohba_device_config | {'preferred-image-formats': image_format},
-                            shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures('image_format')
 @pytest.mark.usefixtures("lvmohba_sr")
 @pytest.mark.thick_provisioned

--- a/tests/storage/lvmoiscsi/conftest.py
+++ b/tests/storage/lvmoiscsi/conftest.py
@@ -10,11 +10,11 @@ from lib.vm import VM
 
 from typing import Generator
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def lvmoiscsi_device_config() -> dict[str, str]:
     return config.sr_device_config("LVMOISCSI_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def lvmoiscsi_sr(host: Host, lvmoiscsi_device_config: dict[str, str], image_format: ImageFormat) \
         -> Generator[SR, None, None]:
     """ A lvmoiscsi SR on first host. """

--- a/tests/storage/lvmoiscsi/test_create_destroy_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_create_destroy_lvmoiscsi_sr.py
@@ -1,0 +1,28 @@
+import pytest
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.vdi import ImageFormat
+
+# Requirements:
+# - one XCP-ng host >= 8.2
+# - a valid lvmoiscsi config
+
+class TestLVMOISCSISRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_and_destroy_sr(self, host: Host, lvmoiscsi_device_config: dict[str, str],
+                                   image_format: ImageFormat) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test",
+                            lvmoiscsi_device_config | {'preferred-image-formats': image_format},
+                            shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_lvmoiscsi_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -22,25 +22,6 @@ from tests.storage import (
 # - one XCP-ng host >= 8.2
 # - a valid lvmoiscsi config
 
-class TestLVMOISCSISRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_and_destroy_sr(self, host: Host, lvmoiscsi_device_config: dict[str, str],
-                                   image_format: ImageFormat) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('lvmoiscsi', "lvmoiscsi-SR-test",
-                            lvmoiscsi_device_config | {'preferred-image-formats': image_format},
-                            shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures('image_format')
 @pytest.mark.usefixtures("lvmoiscsi_sr")
 @pytest.mark.thick_provisioned

--- a/tests/storage/moosefs/conftest.py
+++ b/tests/storage/moosefs/conftest.py
@@ -12,7 +12,6 @@ from lib.pool import Pool
 from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
-from pkgfixtures import pool_with_saved_yum_state
 
 from typing import Generator
 
@@ -32,14 +31,16 @@ def enable_moosefs(host: Host) -> None:
 def disable_moosefs(host: Host) -> None:
     host.deactivate_smapi_driver('moosefs')
 
-@pytest.fixture(scope='package')
-def pool_with_moosefs_installed(pool_with_saved_yum_state: Pool) -> Generator[Pool, None, None]:
-    pool = pool_with_saved_yum_state
+@pytest.fixture(scope='module')
+def pool_with_moosefs_installed(host: Host) -> Generator[Pool, None, None]:
+    pool = host.pool
+    pool.exec_on_hosts_on_error_continue(lambda h: h.yum_save_state())
     pool.exec_on_hosts_on_error_rollback(install_moosefs, uninstall_moosefs_repo)
     yield pool
     pool.exec_on_hosts_on_error_continue(uninstall_moosefs_repo)
+    pool.exec_on_hosts_on_error_continue(lambda h: h.yum_restore_saved_state())
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def pool_with_moosefs_enabled(pool_with_moosefs_installed: Pool) -> Generator[Pool, None, None]:
     pool = pool_with_moosefs_installed
     pool.exec_on_hosts_on_error_rollback(enable_moosefs, disable_moosefs)
@@ -50,7 +51,7 @@ def pool_with_moosefs_enabled(pool_with_moosefs_installed: Pool) -> Generator[Po
 def moosefs_device_config() -> dict[str, str]:
     return config.sr_device_config("MOOSEFS_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def moosefs_sr(moosefs_device_config: dict[str, str], pool_with_moosefs_enabled: Pool) -> Generator[SR, None, None]:
     """ MooseFS SR on a specific host. """
     sr = pool_with_moosefs_enabled.master.sr_create('moosefs', "MooseFS-SR-test", moosefs_device_config, shared=True)

--- a/tests/storage/moosefs/test_create_destroy_moosefs_sr.py
+++ b/tests/storage/moosefs/test_create_destroy_moosefs_sr.py
@@ -1,0 +1,46 @@
+import pytest
+
+import logging
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.pool import Pool
+
+# Requirements:
+# - one XCP-ng host >= 8.2
+# - running MooseFS cluster
+# - access to MooseFS packages repository: ppa.moosefs.com
+
+class TestMooseFSSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_moosefs_sr_without_mfsmount(self, host: Host, moosefs_device_config: dict[str, str]) -> None:
+        # This test must be the first in the series in this module
+        assert not host.file_exists('/usr/sbin/mount.moosefs'), \
+            "MooseFS client should not be installed on the host"
+        sr = None
+        try:
+            sr = host.sr_create('moosefs', "MooseFS-SR-test1", moosefs_device_config, shared=True)
+        except Exception:
+            logging.info("MooseFS SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "MooseFS SR creation should failed!"
+
+    # MooseFS doesn't support IPv6
+    @pytest.mark.usefixtures("host_no_ipv6")
+    def test_create_and_destroy_sr(
+        self, moosefs_device_config: dict[str, str], pool_with_moosefs_enabled: Pool
+    ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        master = pool_with_moosefs_enabled.master
+        sr = master.sr_create('moosefs', "MooseFS-SR-test2", moosefs_device_config, shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_moosefs_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = master.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/moosefs/test_moosefs_sr.py
+++ b/tests/storage/moosefs/test_moosefs_sr.py
@@ -17,40 +17,6 @@ from tests.storage import vdi_is_open
 # - running MooseFS cluster
 # - access to MooseFS packages repository: ppa.moosefs.com
 
-class TestMooseFSSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_moosefs_sr_without_mfsmount(self, host: Host, moosefs_device_config: dict[str, str]) -> None:
-        # This test must be the first in the series in this module
-        assert not host.file_exists('/usr/sbin/mount.moosefs'), \
-            "MooseFS client should not be installed on the host"
-        sr = None
-        try:
-            sr = host.sr_create('moosefs', "MooseFS-SR-test1", moosefs_device_config, shared=True)
-        except Exception:
-            logging.info("MooseFS SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "MooseFS SR creation should failed!"
-
-    # MooseFS doesn't support IPv6
-    @pytest.mark.usefixtures("host_no_ipv6")
-    def test_create_and_destroy_sr(
-        self, moosefs_device_config: dict[str, str], pool_with_moosefs_enabled: Pool
-    ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        master = pool_with_moosefs_enabled.master
-        sr = master.sr_create('moosefs', "MooseFS-SR-test2", moosefs_device_config, shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_moosefs_sr used in
-        # the next tests, because errors in fixtures break teardown
-        vm = master.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 # MooseFS doesn't support IPv6
 @pytest.mark.usefixtures("moosefs_sr", "host_no_ipv6")
 class TestMooseFSSR:

--- a/tests/storage/nfs/conftest.py
+++ b/tests/storage/nfs/conftest.py
@@ -24,7 +24,7 @@ def dispatch_nfs(request: pytest.FixtureRequest) -> Generator[SR | VDI | VM, Non
 def nfs_device_config() -> dict[str, str]:
     return config.sr_device_config("NFS_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs_sr(host: Host, image_format: ImageFormat, nfs_device_config: dict[str, str]) -> Generator[SR, None, None]:
     """ A NFS SR on first host. """
     sr = host.sr_create(
@@ -54,7 +54,7 @@ def vm_on_nfs_sr(host: Host, nfs_sr: SR, vm_ref: str) -> Generator[VM, None, Non
 def nfs4_device_config() -> dict[str, str]:
     return config.sr_device_config("NFS4_DEVICE_CONFIG")
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def nfs4_sr(host: Host, image_format: ImageFormat, nfs4_device_config: dict[str, str]) -> Generator[SR, None, None]:
     """ A NFS4+ SR on first host. """
     sr = host.sr_create(

--- a/tests/storage/nfs/test_create_destroy_nfs_sr.py
+++ b/tests/storage/nfs/test_create_destroy_nfs_sr.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.common import vm_image
+from lib.host import Host
+
+# Requirements:
+# - one XCP-ng host >= 8.0 with an additional unused disk for the SR
+
+class TestNFSSRCreateDestroy:
+    @pytest.mark.parametrize('dispatch_nfs', ['nfs_device_config', 'nfs4_device_config'], indirect=True)
+    def test_create_and_destroy_sr(self, host: Host, dispatch_nfs: dict[str, str]) -> None:
+        device_config = dispatch_nfs
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('nfs', "NFS-SR-test", device_config, shared=True, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_nfs fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/nfs/test_nfs_sr.py
+++ b/tests/storage/nfs/test_nfs_sr.py
@@ -24,18 +24,6 @@ from tests.storage import (
 # Requirements:
 # - one XCP-ng host >= 8.0 with an additional unused disk for the SR
 
-class TestNFSSRCreateDestroy:
-    @pytest.mark.parametrize('dispatch_nfs', ['nfs_device_config', 'nfs4_device_config'], indirect=True)
-    def test_create_and_destroy_sr(self, host: Host, dispatch_nfs: dict[str, str]) -> None:
-        device_config = dispatch_nfs
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('nfs', "NFS-SR-test", device_config, shared=True, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_nfs fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 # Make sure this fixture is called before the parametrized one
 @pytest.mark.usefixtures('image_format')
 class TestNFSSR:

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -44,7 +44,7 @@ def xfs_sr(
     _xfs_config: XfsConfig,
 ) -> Generator[SR, None, None]:
     """ A XFS SR on first host. """
-    sr_disk = unused_512B_disks[host_with_xfsprogs][0]["name"]
+    sr_disk = unused_512B_disks[host_with_xfsprogs][0].name
     sr = host_with_xfsprogs.sr_create('xfs', "XFS-local-SR-test",
                                       {'device': '/dev/' + sr_disk,
                                        'preferred-image-formats': image_format})

--- a/tests/storage/xfs/conftest.py
+++ b/tests/storage/xfs/conftest.py
@@ -17,7 +17,7 @@ from typing import Generator
 class XfsConfig:
     uninstall_xfs: bool = True
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def _xfs_config() -> XfsConfig:
     return XfsConfig()
 
@@ -25,7 +25,7 @@ def _xfs_config() -> XfsConfig:
 # To recreate host_with_xfsprogs for each image_format value, accept
 # image_format in the fixture arguments.
 # ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_xfsprogs(host: Host, image_format: ImageFormat, _xfs_config: XfsConfig) -> Generator[Host, None, None]:
     assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
         "xfsprogs must not be installed on the host at the beginning of the tests"
@@ -36,7 +36,7 @@ def host_with_xfsprogs(host: Host, image_format: ImageFormat, _xfs_config: XfsCo
     if _xfs_config.uninstall_xfs:
         host.yum_restore_saved_state()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def xfs_sr(
     unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
     host_with_xfsprogs: Host,

--- a/tests/storage/xfs/test_create_destroy_xfs_sr.py
+++ b/tests/storage/xfs/test_create_destroy_xfs_sr.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+import logging
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.sr import SR
+from lib.vdi import ImageFormat
+
+# Requirements:
+# - one XCP-ng host >= 8.2 with an additional unused disk for the SR
+# - access to XCP-ng RPM repository from the host
+
+class TestXFSSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_xfs_sr_without_xfsprogs(self,
+                                            host: Host,
+                                            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+                                            image_format: ImageFormat
+                                            ) -> None:
+        # This test must be the first in the series in this module
+        assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
+            "xfsprogs must not be installed on the host at the beginning of the tests"
+        sr_disk = unused_512B_disks[host][0].name
+        sr: SR | None = None
+        try:
+            sr = host.sr_create('xfs', "XFS-local-SR-test", {
+                'device': '/dev/' + sr_disk,
+                'preferred-image-formats': image_format
+            })
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"
+
+    def test_create_and_destroy_sr(self,
+                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
+                                   host_with_xfsprogs: Host
+                                   ) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        host = host_with_xfsprogs
+        sr_disk = unused_512B_disks[host][0].name
+        sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -42,7 +42,7 @@ class TestXFSSRCreateDestroy:
         # This test must be the first in the series in this module
         assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
             "xfsprogs must not be installed on the host at the beginning of the tests"
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr: SR | None = None
         try:
             sr = host.sr_create('xfs', "XFS-local-SR-test", {
@@ -61,7 +61,7 @@ class TestXFSSRCreateDestroy:
                                    ) -> None:
         # Create and destroy tested in the same test to leave the host as unchanged as possible
         host = host_with_xfsprogs
-        sr_disk = unused_512B_disks[host][0]["name"]
+        sr_disk = unused_512B_disks[host][0].name
         sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
         # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
         # the next tests, because errors in fixtures break teardown

--- a/tests/storage/xfs/test_xfs_sr.py
+++ b/tests/storage/xfs/test_xfs_sr.py
@@ -27,48 +27,6 @@ from tests.storage import (
 # - one XCP-ng host >= 8.2 with an additional unused disk for the SR
 # - access to XCP-ng RPM repository from the host
 
-class TestXFSSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_xfs_sr_without_xfsprogs(self,
-                                            host: Host,
-                                            unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                                            image_format: ImageFormat
-                                            ) -> None:
-        # This test must be the first in the series in this module
-        assert not host.file_exists('/usr/sbin/mkfs.xfs'), \
-            "xfsprogs must not be installed on the host at the beginning of the tests"
-        sr_disk = unused_512B_disks[host][0].name
-        sr: SR | None = None
-        try:
-            sr = host.sr_create('xfs', "XFS-local-SR-test", {
-                'device': '/dev/' + sr_disk,
-                'preferred-image-formats': image_format
-            })
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
-    def test_create_and_destroy_sr(self,
-                                   unused_512B_disks: dict[Host, list[Host.BlockDeviceInfo]],
-                                   host_with_xfsprogs: Host
-                                   ) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        host = host_with_xfsprogs
-        sr_disk = unused_512B_disks[host][0].name
-        sr = host.sr_create('xfs', "XFS-local-SR-test", {'device': '/dev/' + sr_disk}, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("xfs_sr")
 class TestXFSSR:
     @pytest.mark.quicktest

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -44,6 +44,7 @@ def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None,
     yield
     # teardown
     host_with_zfs.ssh(f'zpool destroy {POOL_NAME}')
+    host_with_zfs.ssh(f'wipefs -a /dev/{sr_disk_wiped}')
 
 @pytest.fixture(scope='package')
 def zfs_sr(host: Host, image_format: ImageFormat, zpool_vol0: None) -> Generator[SR, None, None]:

--- a/tests/storage/zfs/conftest.py
+++ b/tests/storage/zfs/conftest.py
@@ -11,14 +11,14 @@ from lib.vdi import VDI, ImageFormat
 from lib.vm import VM
 
 # Explicitly import package-scoped fixtures (see explanation in pkgfixtures.py)
-from pkgfixtures import host_with_saved_yum_state, sr_disk_wiped
+from pkgfixtures import sr_disk_wiped
 
 from typing import Generator
 
 POOL_NAME = 'pool0'
 POOL_PATH = '/' + POOL_NAME
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_without_zfs(host: Host) -> Generator[Host, None, None]:
     assert not host.file_exists('/usr/sbin/zpool'), \
         "zfs must not be installed on the host at the beginning of the tests"
@@ -28,17 +28,18 @@ def host_without_zfs(host: Host) -> Generator[Host, None, None]:
 # To recreate host_with_zfs for each image_format value, accept
 # image_format in the fixture arguments.
 # ref https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_zfs(host_without_zfs: Host,
-                  host_with_saved_yum_state: Host,
                   image_format: ImageFormat
                   ) -> Generator[Host, None, None]:
-    host = host_with_saved_yum_state
+    host = host_without_zfs
+    host.yum_save_state()
     host.yum_install(['zfs'])
     host.ssh('modprobe zfs')
     yield host
+    host.yum_restore_saved_state()
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None, None]:
     host_with_zfs.ssh(f'zpool create -f {POOL_NAME} /dev/{sr_disk_wiped}')
     yield
@@ -46,7 +47,7 @@ def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None,
     host_with_zfs.ssh(f'zpool destroy {POOL_NAME}')
     host_with_zfs.ssh(f'wipefs -a /dev/{sr_disk_wiped}')
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def zfs_sr(host: Host, image_format: ImageFormat, zpool_vol0: None) -> Generator[SR, None, None]:
     """ A ZFS SR on first host. """
     sr = host.sr_create('zfs', "ZFS-local-SR-test", {

--- a/tests/storage/zfs/test_create_destroy_zfs_sr.py
+++ b/tests/storage/zfs/test_create_destroy_zfs_sr.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+import logging
+
+from lib.common import vm_image
+from lib.host import Host
+from lib.vdi import ImageFormat
+
+from .conftest import POOL_PATH
+
+# Requirements:
+# - one XCP-ng host >= 8.2 with an additional unused disk for the SR
+# - access to XCP-ng RPM repository from the host
+
+@pytest.mark.usefixtures("sr_disk_wiped")
+class TestZFSSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_zfs_sr_without_zfs(self, host: Host, image_format: ImageFormat) -> None:
+        # This test must be the first in the series in this module
+        assert not host.file_exists('/usr/sbin/zpool'), \
+            "zfs must not be installed on the host at the beginning of the tests"
+        sr = None
+        try:
+            sr = host.sr_create('zfs', "ZFS-local-SR-test", {
+                'location': POOL_PATH,
+                'preferred-image-formats': image_format
+            }, verify=True)
+        except Exception:
+            logging.info("SR creation failed, as expected.")
+        if sr is not None:
+            sr.destroy()
+            assert False, "SR creation should not have succeeded!"
+
+    @pytest.mark.usefixtures("zpool_vol0")
+    def test_create_and_destroy_sr(self, host: Host, image_format: ImageFormat) -> None:
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('zfs', "ZFS-local-SR-test", {
+            'location': POOL_PATH,
+            'preferred-image-formats': image_format
+        }, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_zfs_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/zfs/test_zfs_sr.py
+++ b/tests/storage/zfs/test_zfs_sr.py
@@ -29,43 +29,6 @@ from .conftest import POOL_NAME, POOL_PATH
 # - one XCP-ng host >= 8.2 with an additional unused disk for the SR
 # - access to XCP-ng RPM repository from the host
 
-@pytest.mark.usefixtures("sr_disk_wiped")
-class TestZFSSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_zfs_sr_without_zfs(self, host: Host, image_format: ImageFormat) -> None:
-        # This test must be the first in the series in this module
-        assert not host.file_exists('/usr/sbin/zpool'), \
-            "zfs must not be installed on the host at the beginning of the tests"
-        sr = None
-        try:
-            sr = host.sr_create('zfs', "ZFS-local-SR-test", {
-                'location': POOL_PATH,
-                'preferred-image-formats': image_format
-            }, verify=True)
-        except Exception:
-            logging.info("SR creation failed, as expected.")
-        if sr is not None:
-            sr.destroy()
-            assert False, "SR creation should not have succeeded!"
-
-    @pytest.mark.usefixtures("zpool_vol0")
-    def test_create_and_destroy_sr(self, host: Host, image_format: ImageFormat) -> None:
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('zfs', "ZFS-local-SR-test", {
-            'location': POOL_PATH,
-            'preferred-image-formats': image_format
-        }, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("zpool_vol0")
 class TestZFSSR:
     @pytest.mark.quicktest

--- a/tests/storage/zfsvol/conftest.py
+++ b/tests/storage/zfsvol/conftest.py
@@ -15,14 +15,14 @@ from pkgfixtures import host_with_saved_yum_state_toolstack_restart, sr_disk_wip
 
 from typing import Generator
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_zfsvol(host_with_saved_yum_state_toolstack_restart: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state_toolstack_restart
     host.yum_install(['xcp-ng-xapi-storage-volume-zfsvol'])
     host.restart_toolstack(verify=True)
     yield host
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def zfsvol_sr(host: Host, sr_disk_wiped: str, host_with_zfsvol: Host) -> Generator[SR, None, None]:
     """ A ZFS Volume SR on first host. """
     device = '/dev/' + sr_disk_wiped

--- a/tests/storage/zfsvol/test_create_destroy_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_create_destroy_zfsvol_sr.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.common import vm_image
+from lib.host import Host
+
+# Requirements:
+# - one XCP-ng host >= 8.3 with an additional unused disk for the SR
+# - access to XCP-ng RPM repository from the host
+
+pytestmark = pytest.mark.usefixtures("host_at_least_8_3")
+
+
+class TestZfsvolSRCreateDestroy:
+    """
+    Tests that do not use fixtures that setup the SR or import VMs,
+    because they precisely need to test SR creation and destruction,
+    and VM import.
+    """
+
+    def test_create_and_destroy_sr(self, sr_disk_wiped: str, host_with_zfsvol: Host) -> None:
+        host = host_with_zfsvol
+        # Create and destroy tested in the same test to leave the host as unchanged as possible
+        sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': '/dev/' + sr_disk_wiped}, verify=True)
+        # import a VM in order to detect vm import issues here rather than in the vm_on_zfsvol_sr fixture used in
+        # the next tests, because errors in fixtures break teardown
+        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
+        vm.destroy(verify=True)
+        sr.destroy(verify=True)

--- a/tests/storage/zfsvol/test_zfsvol_sr.py
+++ b/tests/storage/zfsvol/test_zfsvol_sr.py
@@ -29,23 +29,6 @@ from tests.storage import (
 pytestmark = pytest.mark.usefixtures("host_at_least_8_3")
 
 
-class TestZfsvolSRCreateDestroy:
-    """
-    Tests that do not use fixtures that setup the SR or import VMs,
-    because they precisely need to test SR creation and destruction,
-    and VM import.
-    """
-
-    def test_create_and_destroy_sr(self, sr_disk_wiped: str, host_with_zfsvol: Host) -> None:
-        host = host_with_zfsvol
-        # Create and destroy tested in the same test to leave the host as unchanged as possible
-        sr = host.sr_create('zfs-vol', "ZFS-local-SR-test", {'device': '/dev/' + sr_disk_wiped}, verify=True)
-        # import a VM in order to detect vm import issues here rather than in the vm_on_xfs_fixture used in
-        # the next tests, because errors in fixtures break teardown
-        vm = host.import_vm(vm_image('mini-linux-x86_64-bios'), sr_uuid=sr.uuid)
-        vm.destroy(verify=True)
-        sr.destroy(verify=True)
-
 @pytest.mark.usefixtures("zfsvol_sr")
 class TestZfsvolVm:
 

--- a/tests/unit/rescan_block_devices_info.py
+++ b/tests/unit/rescan_block_devices_info.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+# flake8: noqa: E501 - lsblk output lines are intentionally long
+from unittest.mock import MagicMock
+
+from lib.common import KiB
+from lib.host import Host
+
+# ---------------------------------------------------------------------------
+# lsblk fixtures
+# ---------------------------------------------------------------------------
+
+# Full real-world output with multipath (multiple paths per device).
+# Two mpath devices:
+#   dm-0  (3600507681381022548000000000001ec)  - in use: mounted partitions
+#   dm-8  (3600507638081046dd800000000000043)  - free: one lvm child (unused)
+# Plain disks:
+#   sdf / sdb / sdm / sde / sdc / sdj / sdr  - free (no children, no mpath)
+#   sdd / sdk / sdg / sdh / sdl / sdp / sdq / sdt - paths for dm-0 (in use)
+#   sdo / sds / sdi / sda                         - paths for dm-8 (free)
+LSBLK_FULL = """\
+NAME="sdf" KNAME="sdf" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdo" KNAME="sdo" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sdo" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdd" KNAME="sdd" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd2" KNAME="sdd2" PKNAME="sdd" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd5" KNAME="sdd5" PKNAME="sdd" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd3" KNAME="sdd3" PKNAME="sdd" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd1" KNAME="sdd1" PKNAME="sdd" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd6" KNAME="sdd6" PKNAME="sdd" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdd4" KNAME="sdd4" PKNAME="sdd" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdd" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdm" KNAME="sdm" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdk" KNAME="sdk" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk5" KNAME="sdk5" PKNAME="sdk" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk3" KNAME="sdk3" PKNAME="sdk" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk1" KNAME="sdk1" PKNAME="sdk" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk6" KNAME="sdk6" PKNAME="sdk" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk4" KNAME="sdk4" PKNAME="sdk" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdk2" KNAME="sdk2" PKNAME="sdk" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdk" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sds" KNAME="sds" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sds" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdi" KNAME="sdi" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sdi" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdq" KNAME="sdq" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq4" KNAME="sdq4" PKNAME="sdq" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq2" KNAME="sdq2" PKNAME="sdq" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq5" KNAME="sdq5" PKNAME="sdq" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq3" KNAME="sdq3" PKNAME="sdq" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq1" KNAME="sdq1" PKNAME="sdq" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdq6" KNAME="sdq6" PKNAME="sdq" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdq" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdg" KNAME="sdg" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg5" KNAME="sdg5" PKNAME="sdg" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg3" KNAME="sdg3" PKNAME="sdg" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg1" KNAME="sdg1" PKNAME="sdg" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg6" KNAME="sdg6" PKNAME="sdg" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg4" KNAME="sdg4" PKNAME="sdg" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdg2" KNAME="sdg2" PKNAME="sdg" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdg" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sde" KNAME="sde" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdn" KNAME="sdn" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdc" KNAME="sdc" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdl" KNAME="sdl" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl5" KNAME="sdl5" PKNAME="sdl" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl3" KNAME="sdl3" PKNAME="sdl" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl1" KNAME="sdl1" PKNAME="sdl" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl6" KNAME="sdl6" PKNAME="sdl" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl4" KNAME="sdl4" PKNAME="sdl" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdl2" KNAME="sdl2" PKNAME="sdl" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdl" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdt" KNAME="sdt" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdt" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="54975581388800" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x600507638081046d"
+NAME="3600507638081046dd800000000000043" KNAME="dm-8" PKNAME="sda" SIZE="54975581388800" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="VG_XenStorage--aed646f9--4764--81b7--9675--e79c19ce0a41-MGT" KNAME="dm-9" PKNAME="dm-8" SIZE="4194304" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="" WWN=""
+NAME="sdj" KNAME="sdj" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdr" KNAME="sdr" PKNAME="" SIZE="21990232555520" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"
+NAME="sdh" KNAME="sdh" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh5" KNAME="sdh5" PKNAME="sdh" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh3" KNAME="sdh3" PKNAME="sdh" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh1" KNAME="sdh1" PKNAME="sdh" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh6" KNAME="sdh6" PKNAME="sdh" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh4" KNAME="sdh4" PKNAME="sdh" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdh2" KNAME="sdh2" PKNAME="sdh" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdh" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+NAME="sdp" KNAME="sdp" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp4" KNAME="sdp4" PKNAME="sdp" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp2" KNAME="sdp2" PKNAME="sdp" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp5" KNAME="sdp5" PKNAME="sdp" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp3" KNAME="sdp3" PKNAME="sdq" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp1" KNAME="sdp1" PKNAME="sdp" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="sdp6" KNAME="sdp6" PKNAME="sdp" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="0x6005076813810225"
+NAME="3600507681381022548000000000001ec" KNAME="dm-0" PKNAME="sdp" SIZE="536870912000" LOG-SEC="512" TYPE="mpath" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec1" KNAME="dm-1" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="3600507681381022548000000000001ec6" KNAME="dm-6" PKNAME="dm-0" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+NAME="3600507681381022548000000000001ec4" KNAME="dm-4" PKNAME="dm-0" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="3600507681381022548000000000001ec2" KNAME="dm-2" PKNAME="dm-0" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="3600507681381022548000000000001ec5" KNAME="dm-5" PKNAME="dm-0" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="3600507681381022548000000000001ec3" KNAME="dm-3" PKNAME="dm-0" SIZE="492309560832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--3816bde9--226b--5f15--640c--121ffa6bc20b-3816bde9--226b--5f15--640c--121ffa6bc20b" KNAME="dm-7" PKNAME="dm-3" SIZE="492293849088" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/3816bde9-226b-5f15-640c-121ffa6bc20b" WWN=""
+"""
+
+# Minimal: single plain disk, no children
+# Minimal: md array across two disks, not mounted
+LSBLK_MD_FREE = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+"""
+
+
+# ---------------------------------------------------------------------------
+# helper
+# ---------------------------------------------------------------------------
+
+def _rescan(lsblk_output: str) -> list[Host.BlockDeviceInfo]:
+    host = MagicMock(spec=Host)
+    host.ssh.return_value = lsblk_output
+    Host.rescan_block_devices_info(host)
+    return host.block_devices_info
+
+
+def _by_name(devices: list[Host.BlockDeviceInfo], name: str) -> Host.BlockDeviceInfo:
+    matches = [d for d in devices if d.name == name]
+    assert len(matches) == 1, f"{name!r} found {len(matches)} times in {[d.name for d in devices]}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# focused tests
+# ---------------------------------------------------------------------------
+
+def test_plain_disk_no_children():
+    devices = _rescan(
+        'NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""\n'
+    )
+    assert len(devices) == 1
+    d = devices[0]
+    assert d.name == 'sda'
+    assert d.path == '/dev/sda'
+    assert d.type == 'disk'
+    assert d.size == 500107862016
+    assert d.log_sec == 512
+    assert d.available is True
+    assert d.wwn == ''
+
+
+def test_plain_disk_wwn_stripped():
+    devices = _rescan(
+        'NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0x6005076813810286"\n'
+    )
+    assert devices[0].wwn == '6005076813810286'
+
+
+def test_disk_with_free_partitions_is_available():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+""")
+    assert len(devices) == 1
+    d = devices[0]
+    assert d.name == 'sda'
+    assert d.type == 'disk'
+    assert d.available is True
+
+
+def test_disk_with_mounted_partition_is_unavailable():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+""")
+    assert len(devices) == 1
+    assert devices[0].available is False
+
+
+def test_disk_with_partition_in_raid_is_unavailable():
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="sda1" SIZE="536739586048" LOG-SEC="512" TYPE="raid1" MOUNTPOINT="" WWN=""
+""")
+    # sda is a disk (unavailable), md0 is the raid array
+    disk = _by_name(devices, 'sda')
+    assert disk.available is False
+
+
+def test_md_array_detected():
+    devices = _rescan(LSBLK_MD_FREE)
+    md = _by_name(devices, 'md0')
+    assert md.type == 'md'
+    assert md.path == '/dev/md0'
+    assert md.size == 30721630535680
+
+
+def test_md_array_deduplicated():
+    # md0 appears twice in the lsblk output (once per member disk)
+    devices = _rescan(LSBLK_MD_FREE)
+    md_devices = [d for d in devices if d.name == 'md0']
+    assert len(md_devices) == 1
+
+
+def test_md_array_free_is_available():
+    devices = _rescan(LSBLK_MD_FREE)
+    assert _by_name(devices, 'md0').available is True
+
+
+def test_md_array_mounted_is_unavailable():
+    devices = _rescan("""\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="/mnt/data" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="/mnt/data" WWN=""
+""")
+    assert _by_name(devices, 'md0').available is False
+
+
+def test_md_member_disks_are_unavailable():
+    devices = _rescan(LSBLK_MD_FREE)
+    assert _by_name(devices, 'nvme0n1').available is False
+    assert _by_name(devices, 'nvme1n1').available is False
+
+
+# ---------------------------------------------------------------------------
+# full real-world output tests
+# ---------------------------------------------------------------------------
+
+def test_full_output_device_count():
+    devices = _rescan(LSBLK_FULL)
+    disks = [d for d in devices if d.type == 'disk']
+    mpaths = [d for d in devices if d.type == 'mpath']
+    # 3 unique WWNs across all disks:
+    #   sdf  (WWN 0x6005076813810286) - representative of 8 free plain disks
+    #   sdd  (WWN 0x6005076813810225) - representative of 8 paths for dm-0
+    #   sdo  (WWN 0x600507638081046d) - representative of 4 paths for dm-8
+    assert len(disks) == 3
+    # 2 mpath devices: dm-0 and dm-8
+    assert len(mpaths) == 2
+
+
+def test_full_output_mpath_deduplicated():
+    devices = _rescan(LSBLK_FULL)
+    mpaths = [d for d in devices if d.type == 'mpath']
+    names = {d.name for d in mpaths}
+    assert names == {'dm-0', 'dm-8'}
+
+
+def test_full_output_mpath_paths():
+    devices = _rescan(LSBLK_FULL)
+    dm0 = _by_name(devices, 'dm-0')
+    dm8 = _by_name(devices, 'dm-8')
+    assert dm0.path == '/dev/mapper/3600507681381022548000000000001ec'
+    assert dm8.path == '/dev/mapper/3600507638081046dd800000000000043'
+
+
+def test_full_output_mpath_availability():
+    devices = _rescan(LSBLK_FULL)
+    # dm-0 has mounted partitions (/, [SWAP], /boot/efi, /var/log) -> unavailable
+    assert _by_name(devices, 'dm-0').available is False
+    # dm-8 has an lvm child (dm-9) -> unavailable
+    assert _by_name(devices, 'dm-8').available is False
+
+
+def test_full_output_mpath_path_disks_unavailable():
+    devices = _rescan(LSBLK_FULL)
+    # First-seen path disk for dm-0 and dm-8 must be unavailable (mpath child)
+    assert _by_name(devices, 'sdd').available is False
+    assert _by_name(devices, 'sdo').available is False
+
+
+def test_full_output_free_plain_disks_available():
+    devices = _rescan(LSBLK_FULL)
+    # sdf is the first-seen representative of the 8 free disks sharing the same WWN
+    assert _by_name(devices, 'sdf').available is True
+
+
+def test_full_output_disk_wwn():
+    devices = _rescan(LSBLK_FULL)
+    # only the first-seen representative per WWN group is present after deduplication
+    assert _by_name(devices, 'sdf').wwn == '6005076813810286'
+    assert _by_name(devices, 'sdd').wwn == '6005076813810225'
+    assert _by_name(devices, 'sdo').wwn == '600507638081046d'
+
+
+def test_full_output_mpath_wwn():
+    devices = _rescan(LSBLK_FULL)
+    # mpath NAME is the T10 NAA identifier; strip the leading '3' and truncate to 16 hex chars
+    assert _by_name(devices, 'dm-0').wwn == '6005076813810225'
+    assert _by_name(devices, 'dm-8').wwn == '600507638081046d'
+
+
+def test_disk_with_lvm_child_is_unavailable():
+    # part -> lvm (mounted): unavailability must propagate up through the partition to the disk
+    devices = _rescan("""\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="536870912000" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="536334039040" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="myvg-mylv" KNAME="dm-0" PKNAME="sda1" SIZE="536220073984" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/data" WWN=""
+""")
+    assert _by_name(devices, 'sda').available is False
+
+
+# Full lsblk --pairs output from a host with:
+#   - sda: boot disk (mounted partitions, lvm child)
+#   - sdb: free disk with unused partitions
+#   - nvme0n1, nvme1n1: members of md0 (raid0)
+LSBLK_RAID1_HOST = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme0n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="240057409536" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sdb9" KNAME="sdb9" PKNAME="sdb" SIZE="8388608" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sdb1" KNAME="sdb1" PKNAME="sdb" SIZE="240047357952" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="15360950534144" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="md0" KNAME="md0" PKNAME="nvme1n1" SIZE="30721630535680" LOG-SEC="512" TYPE="raid0" MOUNTPOINT="" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="240057409536" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda4" KNAME="sda4" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda5" KNAME="sda5" PKNAME="sda" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="sda3" KNAME="sda3" PKNAME="sda" SIZE="195496058368" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--9cf600ab--221b--8deb--a1f6--51354b56fb85-9cf600ab--221b--8deb--a1f6--51354b56fb85" KNAME="dm-0" PKNAME="sda3" SIZE="195483926528" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/9cf600ab-221b-8deb-a1f6-51354b56fb85" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda6" KNAME="sda6" PKNAME="sda" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+"""
+
+
+def test_raid1_host_sdb_free():
+    # sdb has only unused partitions -> available
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'sdb').available is True
+
+
+def test_raid1_host_sda_unavailable():
+    # sda has mounted partitions and an lvm child -> unavailable
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'sda').available is False
+
+
+def test_raid1_host_md0_detected_and_deduplicated():
+    devices = _rescan(LSBLK_RAID1_HOST)
+    md_devices = [d for d in devices if d.name == 'md0']
+    assert len(md_devices) == 1
+    assert md_devices[0].type == 'md'
+    assert md_devices[0].available is True
+
+
+def test_raid1_host_nvme_members_unavailable():
+    devices = _rescan(LSBLK_RAID1_HOST)
+    assert _by_name(devices, 'nvme0n1').available is False
+    assert _by_name(devices, 'nvme1n1').available is False
+
+
+# Full lsblk --pairs output from a simple host with no mpath or raid:
+#   - nvme0n1: free disk, no children
+#   - sda: boot disk (mounted partitions, lvm child)
+LSBLK_SIMPLE_HOST = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="512110190592" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda" KNAME="sda" PKNAME="" SIZE="120034123776" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN=""
+NAME="sda4" KNAME="sda4" PKNAME="sda" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN=""
+NAME="sda2" KNAME="sda2" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="sda5" KNAME="sda5" PKNAME="sda" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN=""
+NAME="sda3" KNAME="sda3" PKNAME="sda" SIZE="75499053056" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN=""
+NAME="XSLocalEXT--1fa367e3--84ac--b13d--7dc1--6c5ec5ad1808-1fa367e3--84ac--b13d--7dc1--6c5ec5ad1808" KNAME="dm-1" PKNAME="sda3" SIZE="75485585408" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/1fa367e3-84ac-b13d-7dc1-6c5ec5ad1808" WWN=""
+NAME="sda1" KNAME="sda1" PKNAME="sda" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN=""
+NAME="sda6" KNAME="sda6" PKNAME="sda" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN=""
+"""
+
+
+def test_simple_host_nvme_free():
+    devices = _rescan(LSBLK_SIMPLE_HOST)
+    assert _by_name(devices, 'nvme0n1').available is True
+
+
+def test_simple_host_sda_unavailable():
+    devices = _rescan(LSBLK_SIMPLE_HOST)
+    assert _by_name(devices, 'sda').available is False
+
+
+# Full lsblk --pairs output from a host with:
+#   - nvme0n1: 4K logical sector size, free disk (no children)
+#   - nvme1n1: 512B logical sector size, boot disk (mounted partitions, lvm child)
+LSBLK_4K_BLOCK_DEVICE = """\
+NAME="nvme0n1" KNAME="nvme0n1" PKNAME="" SIZE="1000204886016" LOG-SEC="4096" TYPE="disk" MOUNTPOINT="" WWN="eui.e8238fa6bf530001001b444a41dd2519"
+NAME="nvme1n1" KNAME="nvme1n1" PKNAME="" SIZE="512110190592" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p4" KNAME="nvme1n1p4" PKNAME="nvme1n1" SIZE="536870912" LOG-SEC="512" TYPE="part" MOUNTPOINT="/boot/efi" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p2" KNAME="nvme1n1p2" PKNAME="nvme1n1" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p5" KNAME="nvme1n1p5" PKNAME="nvme1n1" SIZE="4294967296" LOG-SEC="512" TYPE="part" MOUNTPOINT="/var/log" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p3" KNAME="nvme1n1p3" PKNAME="nvme1n1" SIZE="467548839424" LOG-SEC="512" TYPE="part" MOUNTPOINT="" WWN="eui.000000000000001000080d0300274f1e"
+NAME="XSLocalEXT--1465252c--889c--e87a--b490--8a9f1dc848b0-1465252c--889c--e87a--b490--8a9f1dc848b0" KNAME="dm-1" PKNAME="nvme1n1p3" SIZE="467534872576" LOG-SEC="512" TYPE="lvm" MOUNTPOINT="/run/sr-mount/1465252c-889c-e87a-b490-8a9f1dc848b0" WWN=""
+NAME="nvme1n1p1" KNAME="nvme1n1p1" PKNAME="nvme1n1" SIZE="19327352832" LOG-SEC="512" TYPE="part" MOUNTPOINT="/" WWN="eui.000000000000001000080d0300274f1e"
+NAME="nvme1n1p6" KNAME="nvme1n1p6" PKNAME="nvme1n1" SIZE="1073741824" LOG-SEC="512" TYPE="part" MOUNTPOINT="[SWAP]" WWN="eui.000000000000001000080d0300274f1e"
+"""
+
+
+def test_4k_block_device_detected():
+    devices = _rescan(LSBLK_4K_BLOCK_DEVICE)
+    d = _by_name(devices, 'nvme0n1')
+    assert d.path == '/dev/nvme0n1'
+    assert d.type == 'disk'
+    assert d.size == 1000204886016
+    assert d.log_sec == 4 * KiB
+    assert d.available is True
+
+
+# Two paths to the same LUN (same WWN), no multipath configured → deduplicate to one disk entry
+LSBLK_NO_MPATH_SAME_WWN = """\
+NAME="sda" KNAME="sda" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0xAABBCCDD00112233"
+NAME="sdb" KNAME="sdb" PKNAME="" SIZE="500107862016" LOG-SEC="512" TYPE="disk" MOUNTPOINT="" WWN="0xAABBCCDD00112233"
+"""
+
+
+def test_no_mpath_same_wwn_deduplicated():
+    devices = _rescan(LSBLK_NO_MPATH_SAME_WWN)
+    assert len(devices) == 1
+    assert devices[0].name == 'sda'
+
+
+def test_no_mpath_same_wwn_available():
+    devices = _rescan(LSBLK_NO_MPATH_SAME_WWN)
+    assert devices[0].available is True

--- a/tests/xapi_plugins/plugin_zfs/conftest.py
+++ b/tests/xapi_plugins/plugin_zfs/conftest.py
@@ -13,14 +13,14 @@ def host_without_zfs(host: Host) -> Generator[None, None, None]:
         "zfs must not be installed on the host at the beginning of the tests"
     yield
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def host_with_zfs(host_without_zfs: Host, host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host.yum_install(['zfs'])
     host.ssh('modprobe zfs')
     yield host
 
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='module')
 def zpool_vol0(sr_disk_wiped: str, host_with_zfs: Host) -> Generator[None, None, None]:
     host_with_zfs.ssh(f'zpool create -f vol0 /dev/{sr_disk_wiped}')
     yield

--- a/tests/xen/conftest.py
+++ b/tests/xen/conftest.py
@@ -31,7 +31,7 @@ def host_with_dynamically_disabled_ept_sp(host: Host) -> Generator[Host, None, N
     logging.info("Switching back EPT superpages to fast")
     host.ssh('xl set-parameters ept=exec-sp')
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_with_git_and_gcc_and_py3(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host_less_8_3 = host.xcp_version < version.parse("8.3")
@@ -44,7 +44,7 @@ def host_with_git_and_gcc_and_py3(host_with_saved_yum_state: Host) -> Generator[
     if host_less_8_3:
         host.ssh('rm /usr/bin/python3')
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def xtf_runner(host_with_git_and_gcc_and_py3: Host) -> Generator[str, None, None]:
     host = host_with_git_and_gcc_and_py3
     logging.info("Download and build XTF")
@@ -65,7 +65,7 @@ make -j$(nproc)
     logging.info("Delete XTF")
     host.ssh(f'rm -rf {tmp_dir}')
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_with_dom0_tests(host_with_saved_yum_state: Host) -> Generator[Host, None, None]:
     host = host_with_saved_yum_state
     host.yum_install(['xen-dom0-tests'])

--- a/tests/xen/test_ring0.py
+++ b/tests/xen/test_ring0.py
@@ -18,7 +18,7 @@ from typing import Generator
 # Only XST tests with pass/fail results, and that don't crash the host were included.
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def host_with_ring0_tests(
     host_with_saved_yum_state: Host,
 ) -> Generator[Host, None, None]:


### PR DESCRIPTION
Replace the BlockDeviceInfo TypedDict with a typed dataclass that includes
availability as a field, computed once at scan time from lsblk output
(mountpoint and device type).
Extend enumeration beyond local disks to also cover mdadm arrays and multipath
devices, using a single lsblk call.
Mark disk with unused partitions as available.
Update all callers to use attribute access instead of dict subscript.
Add a unit test suite and a CI workflow to run it.

This version is making the run much slower (5h20 vs 3h30), so I'm testing an alternative version where the create/destroy sr tests are moved in their own module.