### PR TITLE
prek: run autopep8 isolated from locally user configure files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         name: "autopep8"
         language: "system"
         require_serial: true
-        entry: "uv run autopep8 -i"
+        entry: "uv run autopep8 --global-config /dev/null -i"
         types: ["python"]
       - id: "flake8"
         name: "flake8"


### PR DESCRIPTION
it should avoid the tools to pick a local configuration files and alter the tests.

found as I have a local `~/.config/pycodestyle`