### PR TITLE
Disable autofix on default make invocation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,24 @@ repos:
         name: "ruff"
         language: "system"
         require_serial: true
+        entry: "uv run ruff check"
+        types: ["python"]
+        stages: ["manual"]
+      - id: "ruff-fix"
+        name: "ruff-fix"
+        language: "system"
+        require_serial: true
         entry: "uv run ruff check --fix --show-fixes"
         types: ["python"]
       - id: "autopep8"
         name: "autopep8"
+        language: "system"
+        require_serial: true
+        entry: "uv run autopep8 --global-config /dev/null --diff --exit-code"
+        types: ["python"]
+        stages: ["manual"]
+      - id: "autopep8-fix"
+        name: "autopep8-fix"
         language: "system"
         require_serial: true
         entry: "uv run autopep8 --global-config /dev/null -i"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 # Makefile to run static code checkers locally
 # Equivalent to the GitHub Actions workflow in .github/workflows/code-checkers.yml
 
-.PHONY: all mypy pyright ruff flake8
+.PHONY: all mypy pyright ruff ruff-fix flake8 autopep8 autopep8-fix
 
-all: ruff autopep8 flake8 mypy pyright
+# By default, only run the non-fix version of the hooks so it doesn't modify any files
+# It runs on all files managed by git (untracked files are not checked)
+check: ruff autopep8 flake8 mypy pyright
+
+# Use the `fix` directive to let autopep8 auto-format the code and ruff sort the imports
+# It runs on all files managed by git (untracked files are not modified)
+fix: ruff-fix autopep8-fix
 
 data.py:
 	@test -r data.py || echo "File 'data.py' does not exist. Refer to https://github.com/xcp-ng/xcp-ng-tests#configuration." && exit 1
 
 mypy pyright ruff: data.py
 
-ruff autopep8 flake8 mypy pyright:
+ruff ruff-fix autopep8 autopep8-fix flake8 mypy pyright:
 	uv run prek -a $@

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ flake8
 
 > [!NOTE]
 > There is also a `Makefile` to run checks, just launch `make` command at root level project.
+> If `make` fails with formatting or linting issues that can be fixed automatically (such as ordering imports), you can run `make fix` to automatically fix those.
+> Note that `make` and `make fix` run on all files managed by git (untracked files won't be checked or modified, respectively)
 
 The code checker diagnostics can also be shown directly in your IDE or text editor, by using plugins or language
 servers (LSP).


### PR DESCRIPTION
Here's a proposal, following up @stormi's comment:
> Please offer a simple way to verify your files without altering them automatically

```shell
# Run all checks without modifications
$ make                                               
uv run prek -a ruff
ruff.....................................................................Passed
uv run prek -a autopep8
autopep8.................................................................Passed
uv run prek -a flake8
flake8...................................................................Passed
uv run prek -a mypy
mypy.....................................................................Passed
uv run prek -a pyright
pyright..................................................................Passed


# Run all the auto-fix hooks
± make fix
uv run prek -a ruff-fix
ruff-fix.................................................................Passed
uv run prek -a autopep8-fix
autopep8-fix.............................................................Passed
```
Note: the pre-commit hook behavior hasn't changed:
```shell
$ git commit
ruff-fix.................................................................Passed
autopep8-fix.............................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
pyright..................................................................Passed
```
