### PR TITLE
lib/host: improve repr for debugger readability

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -90,6 +90,9 @@ class Host:
     def __str__(self) -> str:
         return self.hostname_or_ip
 
+    def __repr__(self) -> str:
+        return f"Host('{self.hostname_or_ip}')"
+
     def name(self) -> str:
         return self.param_get('name-label')
 


### PR DESCRIPTION
Add a `__repr__` method to Host so pytest debugger shows the type and hostname instead of a generic object address.