### PR TITLE
Exclude the local disks of nested hosts from the used WWNs set

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -450,11 +450,23 @@ def disks(pytestconfig: pytest.Config, pools_hosts_by_name_or_ip: dict[HostAddre
            }
     # Cross-host deduplication: a LUN in use on any host (same WWN) is unavailable on all hosts.
     # This matters for shared FC/iSCSI LUNs visible on multiple hosts simultaneously.
+    # Note that local disks on nested hosts end up with the following WWNs:
+    # - uuid.00000000-0000-0000-0000-000000000001
+    # - uuid.00000000-0000-0000-0000-000000000002
+    # - and so on
+    # Those are obviously not shared among hosts, so we need to exclude them from `used_wwns`.
+    # This is especially important for tests where one host has its system installed on disk 1,
+    # and another host has its system installed on disk 1 and 2 using RAID1 (in this case, disk 2
+    # of the first host **is** available although it shares the same WWN with disk 2 of host 2
+    # which **is not** available). We can safely assume that any disk with a WWN starting with
+    # "uuid.00000000-0000-0000-0000-" comes from a local disk on a nested host, and consequently
+    # are never shared with other hosts. As such, we can exclude them from `used_wwns` so that
+    # they are not incorrectly detected as shared.
     used_wwns = {
         disk.wwn
         for host_disks in ret.values()
         for disk in host_disks
-        if disk.wwn and not disk.available
+        if disk.wwn and not disk.available and not disk.wwn.startswith("uuid.00000000-0000-0000-0000-")
     }
     if used_wwns:
         logging.debug("cross-host used WWNs: %s", used_wwns)


### PR DESCRIPTION
A proposal to fix some tests where one host uses RAID1 and another does not.

For instance, let's say `10.30.36.10` is a nested host configured using RAID1:
```shell
$ lsblk -o +wwn | grep disk
nvme0n1  259:0    0   80G  0 disk  uuid.00000000-0000-0000-0000-000000000001
nvme0n2  259:7    0   80G  0 disk  uuid.00000000-0000-0000-0000-000000000002
nvme0n3  259:14   0   70G  0 disk  uuid.00000000-0000-0000-0000-000000000003
```
And `10.30.36.1` is a regular nested host:
```
$ lsblk -o +wwn | grep disk
nvme0n1  259:0    0   80G  0 disk  uuid.00000000-0000-0000-0000-000000000001
nvme0n2  259:7    0   70G  0 disk  uuid.00000000-0000-0000-0000-000000000002
```
Then running `test_list_zfs_pools` fails with:
```
± uv run pytest --hosts 10.30.36.1,10.30.36.10 -k test_list_zfs_pools
[...]
E       AssertionError: No 512B disk available on host 10.30.36.1
[...]
Jun 05 18:44:34.048 DEBUG cross-host used WWNs: {'uuid.00000000-0000-0000-0000-000000000001', 'uuid.00000000-0000-0000-0000-000000000002'}
Jun 05 18:44:34.048 DEBUG available disks collected: {'10.30.36.1': [], '10.30.36.3': [], '10.30.36.10': [Host.BlockDeviceInfo(name='nvme0n3', path='/dev/nvme0n3', size=75161927680, log_sec=512, type='disk', available=True, wwn='uuid.00000000-0000-0000-0000-000000000003')]}
```
More explanations in the commit:
```python
    # Note that local disks on nested hosts end up with the following WWNs:
    # - uuid.00000000-0000-0000-0000-000000000001
    # - uuid.00000000-0000-0000-0000-000000000002
    # - and so on
    # Those are obviously not shared among hosts, so we need to exclude them from `used_wwns`.
    # This is especially important for tests where one host has its system installed on disk 1,
    # and another host has its system installed on disk 1 and 2 using RAID1 (in this case, disk 2
    # of the first host **is** available although it shares the same WWN with disk 2 of host 2
    # which **is not** available). We can safely assume that any disk with a WWN starting with
    # "uuid.00000000-0000-0000-0000-" comes from a local disk on a nested host, and consequently
    # are never shared with other hosts. As such, we can exclude them from `used_wwns` so that
    # they are not incorrectly detected as shared.
```

