### PR TITLE
t/g/u/test_xen_guest_agent.py: Use yum on older distros or dnf if available

### DIFF
--- a/tests/guest_tools/unix/test_xen_guest_agent.py
+++ b/tests/guest_tools/unix/test_xen_guest_agent.py
@@ -53,7 +53,7 @@ class TestXenGuestAgent:
             rpm_repo = xen_guest_agent_urls['rpm_repo']
             vm.ssh(f"echo -e '[xen-guest-agent]\\nbaseurl={rpm_repo}main/\\ngpgcheck=0'"
                    f" > /etc/yum.repos.d/xen-guest-agent.repo")
-            vm.ssh('dnf install -y xen-guest-agent')
+            vm.ssh('app=yum && which dnf && app=dnf ; $app install -y xen-guest-agent')
         elif pkg_mgr == PackageManagerEnum.APT_GET:
             # DEB packages are published to a stable APT repo in the GitLab
             # Generic Package Registry after each push to main.


### PR DESCRIPTION
On modern systems that uses dnf, there is a compatibility yum wrapper, some refactoring can be considered to support more package managers.

Observed issue was:

    tests/guest_tools/unix/test_xen_guest_agent.py::TestXenGuestAgent::test_agent_running_after_reboot[...]
    lib.commands.SSHCommandFailed: SSH command (dnf install -y xen-guest-agent) failed with return code 127: bash: dnf: command not found