### PR TITLE
Fix test_checkpoint on Windows

### DIFF
--- a/lib/vm.py
+++ b/lib/vm.py
@@ -818,17 +818,19 @@ class VM(BaseVM):
             f"Write-Output (Start-Process -Wait -PassThru {program} -ArgumentList '{args}').ExitCode")
         return int(output)
 
-    def start_background_powershell(self, cmd: str) -> None:
+    def start_background_powershell(self, cmd: str) -> str:
         """
-        Run command under powershell in the background.
+        Run command under powershell in the background. Return the PID as string.
 
         Backslash-safe.
         """
         assert self.is_windows
         encoded_command = commands.encode_powershell_command(cmd)
-        self.ssh(
-            "powershell.exe -noprofile -noninteractive Invoke-WmiMethod -Class Win32_Process -Name Create "
+        return self.ssh(
+            "powershell.exe -noprofile -noninteractive -command \\("
+            "Invoke-WmiMethod -Class Win32_Process -Name Create "
             f"-ArgumentList \\'powershell.exe -noprofile -noninteractive -encodedcommand {encoded_command}\\'"
+            "\\).ProcessId"
         )
 
     def is_windows_pv_device_installed(self) -> bool:

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -443,8 +443,19 @@ class VM(BaseVM):
             self.ssh(f'rm -f {pidfile}')
             return str(pid)
 
-    def pid_exists(self, pid: str) -> bool:
-        return self.ssh_with_result(f'kill -s 0 {pid}').returncode == 0
+    def pid_exists(self, pid: str, winpid: bool = False) -> bool:
+        if self.is_windows and winpid:
+            return strtobool(
+                self.execute_powershell_script(f"$null -ne (Get-Process -Id {pid} -ErrorAction SilentlyContinue)")
+            )
+        else:
+            return self.ssh_with_result(f'kill -s 0 {pid}').returncode == 0
+
+    def kill_pid(self, pid: str, winpid: bool = False) -> None:
+        if self.is_windows and winpid:
+            self.execute_powershell_script(f"Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue")
+        else:
+            self.ssh(f'kill {pid}')
 
     @overload
     def execute_script(self, script_contents: str, *, simple_output: Literal[True] = True) -> str:

--- a/lib/vm.py
+++ b/lib/vm.py
@@ -412,6 +412,8 @@ class VM(BaseVM):
         return self.host.pool.get_host_by_uuid(host_uuid)
 
     def start_background_process(self, cmd: str) -> str:
+        if self.is_windows:
+            logging.warning('start_background_process is not reliable on Windows')
         script = "/tmp/bg_process.sh"
         pidfile = "/tmp/bg_process.pid"
         with tempfile.NamedTemporaryFile('w') as f:

--- a/tests/misc/test_vm_basic_operations.py
+++ b/tests/misc/test_vm_basic_operations.py
@@ -23,13 +23,17 @@ class Test:
         vm = running_vm
         vm.test_snapshot_on_running_vm()
 
-    # When using a windows VM the background ssh process is never terminated
+    # When running the tests on Windows, the background ssh process is never terminated
     # This results in a ResourceWarning
     @pytest.mark.filterwarnings("ignore::ResourceWarning")
     def test_checkpoint(self, running_vm: VM) -> None:
         vm = running_vm
         logging.info("Start a 'sleep' process on VM through SSH")
-        pid = vm.start_background_process('sleep 10000')
+        if vm.is_windows:
+            pid = vm.start_background_powershell('Start-Sleep -Seconds 10000')
+        else:
+            pid = vm.start_background_process('sleep 10000')
+        logging.info(f"Background task PID: {pid}")
         snapshot = vm.checkpoint()
         filepath = '/tmp/%s' % snapshot.uuid
         vm.ssh_touch_file(filepath)
@@ -39,8 +43,8 @@ class Test:
         logging.info("Check file does not exist anymore")
         vm.ssh(f'test ! -f {filepath}')
         logging.info("Check 'sleep' process is still running")
-        assert vm.pid_exists(pid)
+        assert vm.pid_exists(pid, winpid=True)
         logging.info("Kill background process")
-        vm.ssh(f'kill {pid}')
-        wait_for_not(lambda: vm.pid_exists(pid), "Wait for process %s not running anymore" % pid)
+        vm.kill_pid(pid, winpid=True)
+        wait_for_not(lambda: vm.pid_exists(pid, winpid=True), "Wait for process %s not running anymore" % pid)
         snapshot.destroy(verify=True)


### PR DESCRIPTION
The series of failures of start_background_process on Windows has shown that this function is particularly unreliable on this platform.

The symptom is the test timing out on `test -f /tmp/bg_process.pid`.

Replace with the Windows equivalents for better reliability.