### PR TITLE
limits/vif_limit: Run 'apt update' before installing iperf3

### DIFF
--- a/tests/limits/test_vif_limit.py
+++ b/tests/limits/test_vif_limit.py
@@ -69,6 +69,9 @@ class TestVIFLimit:
             if vm.ssh_with_result('systemctl restart networking').returncode != 0:
                 assert False, "Failed to configure networking"
 
+            # Open needed ports in the firewall
+            host.ssh(f'iptables -I INPUT -p tcp --match multiport --dports 5100:{5100+VIF_LIMIT-1} -j ACCEPT')
+
             # Test iperf on all interfaces in parallel
             # Clean up on exceptions
             logging.info('Create separate iperf servers on the host')
@@ -83,10 +86,12 @@ class TestVIFLimit:
 
             logging.info('Start multiple iperfs on separate interfaces on the VM')
             with tempfile.NamedTemporaryFile('w') as vm_script:
-                iperf_configs = [f'iperf3 --no-delay -c {host.hostname_or_ip} '
-                                 f'-p {5100 + i} --bind-dev {interface_name}{i} '
-                                 f'--interval 0 --parallel 1 --time 30 &'
-                                 for i in range(0, VIF_LIMIT)]
+                iperf_configs = ['set -e']
+                iperf_configs += [f'iperf3 --no-delay -c {host.hostname_or_ip} '
+                                  f'-p {5100 + i} --bind-dev {interface_name}{i} '
+                                  f'--interval 0 --parallel 1 --time 30 &'
+                                  for i in range(0, VIF_LIMIT)]
+                iperf_configs += ['wait -n']
                 vm_script.write('\n'.join(iperf_configs))
                 vm_script.flush()
                 vm.scp(vm_script.name, vm_script.name)
@@ -100,3 +105,5 @@ class TestVIFLimit:
             for vif in vifs:
                 vif.destroy()
             host.ssh('killall iperf3 || true')
+            # Restore firewall
+            host.ssh('iptables -D INPUT 1')

--- a/tests/limits/test_vif_limit.py
+++ b/tests/limits/test_vif_limit.py
@@ -59,6 +59,8 @@ class TestVIFLimit:
             vm.ssh(f'echo "{config}" >> /etc/network/interfaces')
 
             logging.info('Install iperf3 on VM and host')
+            if vm.ssh_with_result('apt update').returncode != 0:
+                assert False, "Failed to update apt cache on the VM"
             if vm.ssh_with_result('apt install iperf3 --assume-yes').returncode != 0:
                 assert False, "Failed to install iperf3 on the VM"
             host.yum_install(['iperf3'])

--- a/tests/limits/test_vif_limit.py
+++ b/tests/limits/test_vif_limit.py
@@ -59,15 +59,12 @@ class TestVIFLimit:
             vm.ssh(f'echo "{config}" >> /etc/network/interfaces')
 
             logging.info('Install iperf3 on VM and host')
-            if vm.ssh_with_result('apt update').returncode != 0:
-                assert False, "Failed to update apt cache on the VM"
-            if vm.ssh_with_result('apt install iperf3 --assume-yes').returncode != 0:
-                assert False, "Failed to install iperf3 on the VM"
+            vm.ssh('apt update')
+            vm.ssh('apt install iperf3 --assume-yes')
             host.yum_install(['iperf3'])
 
             logging.info('Reconfigure VM networking')
-            if vm.ssh_with_result('systemctl restart networking').returncode != 0:
-                assert False, "Failed to configure networking"
+            vm.ssh('systemctl restart networking')
 
             # Open needed ports in the firewall
             host.ssh(f'iptables -I INPUT -p tcp --match multiport --dports 5100:{5100+VIF_LIMIT-1} -j ACCEPT')


### PR DESCRIPTION
Otherwise stale caches will be used and iperf3 installation will fail, on some VMs.

Tested this by running the following command, which passes with this fix:
```
pytest tests/limits/test_vif_limit.py::TestVIFLimit::test_vif_limit --vm=http://10.1.0.6/images/debian-12-created_8.2-zstd.xva
```