### PR TITLE
Fix automated install tests to be compatible with the postinstall job

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -163,7 +163,7 @@ def _ssh(
 
     # Even if check is False, we still raise in case of return code 255, which means a SSH error.
     if res.returncode == 255:
-        return SSHCommandFailed(255, "SSH Error: %s" % ssherr, cmd, ssherr=ssherr)
+        return SSHCommandFailed(255, "SSH Error: %s" % output_for_errors, cmd, ssherr=ssherr)
 
     output: bytes = res.stdout
     if banner_res:

--- a/lib/installer.py
+++ b/lib/installer.py
@@ -4,7 +4,7 @@ import logging
 import time
 import xml.etree.ElementTree as ET
 
-from lib.commands import SSHCommandFailed, ssh
+from lib.commands import ssh
 from lib.common import wait_for
 
 from typing import Any, Self
@@ -82,16 +82,7 @@ class AnswerFile:
         return element
 
 def poweroff(ip: str) -> None:
-    try:
-        # disable multiplexing to get proper info in SSHCommandFailed
-        ssh(ip, "poweroff", multiplexing=False)
-    except SSHCommandFailed as e:
-        # ignore connection closed by reboot
-        if e.returncode == 255 and "closed by remote host" in e.stdout:
-            logging.info("sshd closed the connection")
-            pass
-        else:
-            raise
+    ssh(ip, "nohup sh -c 'sleep 2 && poweroff' >/dev/null 2>&1 &")
 
 def monitor_install(*, ip: str) -> None:
     # wait for "yum install" phase to finish

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -78,7 +78,10 @@ class TestNested:
                 ),
                 "bios": (),
             }[firmware],
-            vdis=[dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0")],
+            vdis=[
+                dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0"),
+                dict(name="vm1 extra disk", size="50GiB", device="xvdb", userdevice="1")
+            ],
             cd_vbd=dict(device="xvdd", userdevice="3"),
             vifs=[dict(index=0, network_name=NETWORKS["MGMT"])],
         ))

--- a/tests/install/test.py
+++ b/tests/install/test.py
@@ -272,19 +272,11 @@ class TestNested:
                 raise
 
             logging.info("Powering off pool master")
-            try:
-                # use "poweroff" because "reboot" would cause ARP and
-                # SSH to be checked before host is down, and require
-                # ssh retries
-                # disable multiplexing to get proper info in SSHCommandFailed
-                pool.master.ssh("poweroff", multiplexing=False)
-            except commands.SSHCommandFailed as e:
-                # ignore connection closed by reboot
-                if e.returncode == 255 and "closed by remote host" in e.stdout:
-                    logging.info("sshd closed the connection")
-                    pass
-                else:
-                    raise
+
+            # use "poweroff" because "reboot" would cause ARP and
+            # SSH to be checked before host is down, and require
+            # ssh retries
+            pool.master.ssh("nohup sh -c 'sleep 2 && poweroff' >/dev/null 2>&1 &")
 
             wait_for(host_vm.is_halted, "Wait for host VM halted")
 


### PR DESCRIPTION
The `postinstall` job requires those three tests which depends on the `unused_512B_disks` fixture:
```
tests/misc/test_export.py::TestExport::test_export_zstd[mini-linux-x86_64-bios]
tests/misc/test_export.py::TestExport::test_export_gzip[mini-linux-x86_64-bios]
tests/misc/test_export.py::TestExport::test_export_uncompressed[mini-linux-x86_64-bios]
```

In order to create nested hosts that are compliant with the requirements of the `postinstall` job, an extra disk has to be added.

Also fixes the regression described in #602 