### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,29 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     cooldown:
       default-days: 7
+    groups:
+      ci-deps:
+        patterns:
+          - "*"
+
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      base-deps:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      dev-deps:
+        dependency-type: "development"
+        patterns:
+          - "*"


### PR DESCRIPTION
- target branch: dependabot-staging, so that we can merge dependabot PRs faster while still having a buffer on which to run CI first before merging to master branch.
- regroup PRs into one per ecosystem to reduce the noise.

I don't really know how to test the configuration without merging it first and triggering a dependabot update.