### PR TITLE
Exclude installimg directories from versioning and type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data.py
 vm_data.py
 /scripts/guests/windows/id_rsa.pub
 .envrc
+installimg.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,17 @@ dev = [
 
 [tool.pyright]
 typeCheckingMode = "standard"
+# Pyright doesn't support excluding files from .gitignore like mypy does.
+# So we need to append 'installimg.*' to the default 'exclude' configuration
+# which is ["**/node_modules", "**/__pycache__", "**/.*"]
+exclude = [
+  "**/__pycache__",
+  "**/.*",
+  "installimg.*",
+]
+
+[tool.mypy]
+exclude_gitignore = true
 
 [tool.ruff]
 preview = true
@@ -86,7 +97,7 @@ ignore = [
 pydocstyle.convention = "pep257"
 
 [tool.ruff.lint.extend-per-file-ignores]
-# Pytest fixtures are often flagged as unused imports (F401) or 
+# Pytest fixtures are often flagged as unused imports (F401) or
 # redefined variables (F811) because they are injected by name.
 "tests/**/*.py" = [
   "F401",  # F401 unused-import


### PR DESCRIPTION
Follow up after https://github.com/xcp-ng/xcp-ng-tests/pull/604#issuecomment-4915916318

The `installimg.XXXXXX` directories are created at the root of the repository by `iso-remaster.sh` which is used by the `remastered_iso` fixture in the context of the automated installation tests. Those directories contain python2 files so they have to be excluded from type checking. It's not necessary to exclude them for the other checks (ruff, flake8, autopep8) since those checks explicitly run on versioned python files. The `installimg.*` pattern is also added to `.gitignore`.