### PR TITLE
Run iso-remaster in temporary iso directory 

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -316,13 +316,22 @@ def sftp(
     return res
 
 @overload
-def local_cmd(cmd: List[str], *, check: bool = True, decode: Literal[True] = True) -> LocalCommandResult[str]:
-    ...
-@overload
-def local_cmd(cmd: List[str], *, check: bool = True, decode: Literal[False]) -> LocalCommandResult[bytes]:
-    ...
 def local_cmd(
-    cmd: List[str], *, check: bool = True, decode: bool = True
+    cmd: List[str], *, check: bool = True, decode: Literal[True] = True,
+    cwd: str | os.PathLike[str] | None = None,
+) -> LocalCommandResult[str]:
+    ...
+
+@overload
+def local_cmd(
+    cmd: List[str], *, check: bool = True, decode: Literal[False],
+    cwd: str | os.PathLike[str] | None = None,
+) -> LocalCommandResult[bytes]:
+    ...
+
+def local_cmd(
+    cmd: List[str], *, check: bool = True, decode: bool = True,
+    cwd: str | os.PathLike[str] | None = None,
 ) -> LocalCommandResult[str] | LocalCommandResult[bytes]:
     """ Run a command locally on tester end. """
     logging.debug("[local] %s", (cmd,))
@@ -330,7 +339,8 @@ def local_cmd(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        check=False
+        check=False,
+        cwd=cwd,
     )
 
     # get a decoded version of the output in any case, replacing potential errors

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -268,7 +268,7 @@ sed -i "${{SED_COMMANDS[@]}}" \
                    "--install-patcher", img_patcher_script,
                    "--iso-patcher", iso_patcher_script,
                    iso_file, remastered_iso
-                   ])
+                   ], cwd=isotmp)
 
         yield remastered_iso
 

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -129,7 +129,7 @@ def remastered_iso(installer_iso: dict[str, str | bool], answerfile: AnswerFile 
     iso_remaster = TOOLS["iso-remaster"]
     assert os.access(iso_remaster, os.X_OK)
 
-    with tempfile.TemporaryDirectory() as isotmp:
+    with tempfile.TemporaryDirectory(prefix="remastered-iso-") as isotmp:
         remastered_iso = os.path.join(isotmp, "image.iso")
         img_patcher_script = os.path.join(isotmp, "img-patcher")
         iso_patcher_script = os.path.join(isotmp, "iso-patcher")


### PR DESCRIPTION
Supersede #628

Without this change, the following temporary files and directories are created at the root of the repository:
- fakerootsave.XXXXXX
- installimg.XXXXXX
- isorw.XXXXXX

They get removed in most cases, but they might remain when an error occurs during the remastering. This is especially a problem for type checking tools that might fail due to the python2 files in `installimg`. Since the `remastered_iso` fixture already creates a temporary directory in `/tmp` for other files used or produced by `iso-remaster.sh`, it makes sense to run it in this directory so those temporary files are created in there.

Also, this PR adds a `remastered-iso-` prefix to the corresponding temporary directory. This way, the temporary directory created by the `remastered_iso` fixture can be found more easily in the `/tmp` directory.