### PR TITLE
Create tests for `vdi_revert` on lvm based SRs

### DIFF
--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -23,6 +23,12 @@ from tests.storage import (
     vdi_is_open,
     xva_export_import,
 )
+from tests.storage.storage import (
+    check_vdi_revert,
+    check_vdi_revert_cbt,
+    check_vdi_revert_journal,
+    check_vdi_revert_journal_cbt,
+)
 
 # Requirements:
 # - one XCP-ng host with an additional unused disk for the SR
@@ -149,6 +155,34 @@ class TestLVMSR:
     def test_vdi_export_import(self, storage_test_vm: VM, lvm_sr: SR, image_format: ImageFormat, temp_large_dir: str,
                                defer: Defer) -> None:
         vdi_export_import(storage_test_vm, lvm_sr, image_format, temp_large_dir, defer)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert(self, vm_on_lvm_sr: VM, defer: Defer) -> None:
+        check_vdi_revert(defer, vm_on_lvm_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_cbt(self, vm_on_lvm_sr: VM, defer: Defer) -> None:
+        check_vdi_revert_cbt(defer, vm_on_lvm_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_journal_cbt(self, vm_on_lvm_sr: VM, defer: Defer, exit_on_fistpoint: None):
+        check_vdi_revert_journal_cbt(defer, vm_on_lvm_sr, "LVM_revert_create_src")
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    @pytest.mark.parametrize(
+        "fistpoint",
+        [
+            "LVM_revert_create_insert",
+            "LVM_revert_create_src",
+            "LVM_revert_create_dest",
+        ]
+    )
+    def test_revert_journal(self, vm_on_lvm_sr: VM, defer: Defer, exit_on_fistpoint: None, fistpoint: str):
+        check_vdi_revert_journal(defer, vm_on_lvm_sr, fistpoint)
 
     # *** tests with reboots (longer tests).
 

--- a/tests/storage/lvmohba/test_lvmohba_sr.py
+++ b/tests/storage/lvmohba/test_lvmohba_sr.py
@@ -2,6 +2,7 @@ import pytest
 
 from lib.commands import SSHCommandFailed
 from lib.common import Defer, vm_image, wait_for
+from lib.host import Host
 from lib.sr import SR
 from lib.vdi import VDI, ImageFormat
 from lib.vm import VM
@@ -15,6 +16,13 @@ from tests.storage import (
     vdi_export_import,
     vdi_is_open,
     xva_export_import,
+)
+from tests.storage.storage import (
+    check_critical_journal_revert,
+    check_vdi_revert,
+    check_vdi_revert_cbt,
+    check_vdi_revert_journal,
+    check_vdi_revert_journal_cbt,
 )
 
 # Requirements:
@@ -81,6 +89,43 @@ class TestLVMOHBASR:
     def test_vdi_export_import(self, storage_test_vm: VM, lvmohba_sr: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer):
         vdi_export_import(storage_test_vm, lvmohba_sr, image_format, temp_large_dir, defer)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert(self, vm_on_lvmohba_sr: VM, defer: Defer) -> None:
+        check_vdi_revert(defer, vm_on_lvmohba_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_cbt(self, vm_on_lvmohba_sr: VM, defer: Defer) -> None:
+        check_vdi_revert_cbt(defer, vm_on_lvmohba_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_journal_cbt(self, vm_on_lvmohba_sr: VM, defer: Defer, exit_on_fistpoint: None):
+        check_vdi_revert_journal_cbt(
+            defer, vm_on_lvmohba_sr, "LVM_revert_create_src", vm_on_lvmohba_sr.host.pool.master
+        )
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    @pytest.mark.parametrize(
+        "fistpoint",
+        [
+            "LVM_revert_create_insert",
+            "LVM_revert_create_src",
+            "LVM_revert_create_dest",
+        ]
+    )
+    def test_revert_journal(self, vm_on_lvmohba_sr: VM, defer: Defer, exit_on_fistpoint: None, fistpoint: str):
+        check_vdi_revert_journal(defer, vm_on_lvmohba_sr, fistpoint, vm_on_lvmohba_sr.host.pool.master)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_critical_journal_revert(
+        self, vm_on_lvmohba_sr: VM, defer: Defer, exit_on_fistpoint: None, hostA2: Host
+    ) -> None:
+        check_critical_journal_revert(defer, vm_on_lvmohba_sr, hostA2, "LVM_revert_create_src")
 
     # *** tests with reboots (longer tests).
 

--- a/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
+++ b/tests/storage/lvmoiscsi/test_lvmoiscsi_sr.py
@@ -17,6 +17,13 @@ from tests.storage import (
     vdi_is_open,
     xva_export_import,
 )
+from tests.storage.storage import (
+    check_critical_journal_revert,
+    check_vdi_revert,
+    check_vdi_revert_cbt,
+    check_vdi_revert_journal,
+    check_vdi_revert_journal_cbt,
+)
 
 # Requirements:
 # - one XCP-ng host >= 8.2
@@ -83,6 +90,43 @@ class TestLVMOISCSISR:
     def test_vdi_export_import(self, storage_test_vm: VM, lvmoiscsi_sr: SR, image_format: ImageFormat,
                                temp_large_dir: str, defer: Defer) -> None:
         vdi_export_import(storage_test_vm, lvmoiscsi_sr, image_format, temp_large_dir, defer)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert(self, vm_on_lvmoiscsi_sr: VM, defer: Defer) -> None:
+        check_vdi_revert(defer, vm_on_lvmoiscsi_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_cbt(self, vm_on_lvmoiscsi_sr: VM, defer: Defer) -> None:
+        check_vdi_revert_cbt(defer, vm_on_lvmoiscsi_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert_journal_cbt(self, vm_on_lvmoiscsi_sr: VM, defer: Defer, exit_on_fistpoint: None):
+        check_vdi_revert_journal_cbt(
+            defer, vm_on_lvmoiscsi_sr, "LVM_revert_create_src", vm_on_lvmoiscsi_sr.host.pool.master
+        )
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    @pytest.mark.parametrize(
+        "fistpoint",
+        [
+            "LVM_revert_create_insert",
+            "LVM_revert_create_src",
+            "LVM_revert_create_dest",
+        ]
+    )
+    def test_revert_journal(self, vm_on_lvmoiscsi_sr: VM, defer: Defer, exit_on_fistpoint: None, fistpoint: str):
+        check_vdi_revert_journal(defer, vm_on_lvmoiscsi_sr, fistpoint, vm_on_lvmoiscsi_sr.host.pool.master)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_critical_journal_revert(
+        self, vm_on_lvmoiscsi_sr: VM, defer: Defer, exit_on_fistpoint: None, hostA2: Host
+    ) -> None:
+        check_critical_journal_revert(defer, vm_on_lvmoiscsi_sr, hostA2, "LVM_revert_create_src")
 
     # *** tests with reboots (longer tests).
 


### PR DESCRIPTION
This implements tests for `vdi_revert` on lvm SRs

Required smapi changes https://github.com/xcp-ng/sm/pull/128

Stacked PR review

* https://github.com/xcp-ng/xcp-ng-tests/pull/627
* https://github.com/xcp-ng/xcp-ng-tests/pull/631 <- current
* https://github.com/xcp-ng/xcp-ng-tests/pull/632