### PR TITLE
[pending feature merge] Create tests for vdi_revert on linstorsr

### DIFF
--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -211,3 +211,16 @@ def vm_on_linstor_sr(host: Host, linstor_sr: SR, vm_ref: str) -> Generator[VM, N
 def vm_on_linstor_sr_function(host: Host, linstor_sr: SR, vm_ref: str) -> Generator[VM]:
     with _vm_on_linstor_sr(host, linstor_sr, vm_ref) as vm:
         yield vm
+
+@pytest.fixture(scope='function')
+def linstor_no_monitor(linstor_sr: SR):
+    """
+    Disable linstor monitor on the linstor SR for
+    the current test to avoid unwanted scans.
+    """
+    hosts = linstor_sr.main_host().pool.hosts
+    for host in hosts:
+        host.ssh("systemctl stop linstor-monitor.service")
+    yield
+    for host in hosts:
+        host.ssh("systemctl start linstor-monitor.service")

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -6,13 +6,14 @@ import shlex
 import time
 
 from lib.commands import SSHCommandFailed
-from lib.common import safe_split, vm_image, wait_for
+from lib.common import Defer, safe_split, vm_image, wait_for
 from lib.host import Host
 from lib.pool import Pool
 from lib.sr import SR
 from lib.vdi import VDI
 from lib.vm import VM
 from tests.storage import vdi_is_open
+from tests.storage.storage import check_critical_journal_revert, check_vdi_revert, check_vdi_revert_journal
 
 from .conftest import GROUP_NAME, LINSTOR_PACKAGE
 
@@ -188,6 +189,37 @@ class TestLinstorSR:
             vm.test_snapshot_on_running_vm()
         finally:
             vm.shutdown(verify=True)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_revert(self, vm_on_linstor_sr: VM, defer: Defer) -> None:
+        check_vdi_revert(defer, vm_on_linstor_sr)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    @pytest.mark.parametrize(
+        "fistpoint",
+        [
+            "LinstorSR_revert_create_insert",
+            "LinstorSR_revert_create_src",
+            "LinstorSR_revert_create_dest",
+        ]
+    )
+    def test_revert_journal(self, vm_on_linstor_sr: VM, defer: Defer, exit_on_fistpoint: None, fistpoint: str):
+        check_vdi_revert_journal(defer, vm_on_linstor_sr, fistpoint, vm_on_linstor_sr.host.pool.master)
+
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_critical_journal_revert(
+        self, vm_on_linstor_sr: VM, defer: Defer, exit_on_fistpoint: None, hostA2: Host
+    ) -> None:
+        # Linstor monitor service might run a scan during critical journal testing
+        # We disable the service while testing
+        for host in vm_on_linstor_sr.host.pool.hosts:
+            host.ssh("systemctl stop linstor-monitor.service")
+            defer(lambda: host.ssh("systemctl start linstor-monitor.service"))
+
+        check_critical_journal_revert(defer, vm_on_linstor_sr, hostA2, "LinstorSR_revert_create_src")
 
     # *** tests with reboots (longer tests).
 

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -211,14 +211,8 @@ class TestLinstorSR:
     @pytest.mark.small_vm
     @pytest.mark.big_vm
     def test_critical_journal_revert(
-        self, vm_on_linstor_sr: VM, defer: Defer, exit_on_fistpoint: None, hostA2: Host
+        self, vm_on_linstor_sr: VM, defer: Defer, exit_on_fistpoint: None, hostA2: Host, linstor_no_monitor: None
     ) -> None:
-        # Linstor monitor service might run a scan during critical journal testing
-        # We disable the service while testing
-        for host in vm_on_linstor_sr.host.pool.hosts:
-            host.ssh("systemctl stop linstor-monitor.service")
-            defer(lambda: host.ssh("systemctl start linstor-monitor.service"))
-
         check_critical_journal_revert(defer, vm_on_linstor_sr, hostA2, "LinstorSR_revert_create_src")
 
     # *** tests with reboots (longer tests).


### PR DESCRIPTION
This implements tests for `vdi_revert` on linstorsr

Required smapi changes: https://github.com/xcp-ng/sm/pull/132

Stacked PR review

* https://github.com/xcp-ng/xcp-ng-tests/pull/627
* https://github.com/xcp-ng/xcp-ng-tests/pull/631
* https://github.com/xcp-ng/xcp-ng-tests/pull/632 <- current
