### PR TITLE
Better error when importing a VM using clone:// but the provided base VM does not exist

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -302,8 +302,7 @@ def hosts(pytestconfig: pytest.Config) -> Generator[list[Host], None, None]:
             nest = Pool(nest_hostname).master
 
             protocol, rest = hostname_or_ip.split(":", 1)
-            host_vm = nest.import_vm(f"clone:{rest}", nest.main_sr_uuid(),
-                                     use_cache=True)
+            host_vm = nest.import_vm(f"clone:{rest}", nest.main_sr_uuid())
             nested_list.append(host_vm)
 
             vif = host_vm.vifs()[0]

--- a/lib/host.py
+++ b/lib/host.py
@@ -393,7 +393,6 @@ class Host:
         vm: VM | None = None
 
         if uri.startswith("clone://") or uri.startswith("clone+start://"):
-            assert use_cache, "clone URIs require cache enabled"
             assert sr_uuid is not None
             protocol, filename = uri.split("://", maxsplit=1)
             base_vm = self.cached_vm(filename, sr_uuid)

--- a/lib/host.py
+++ b/lib/host.py
@@ -392,8 +392,7 @@ class Host:
     def import_vm(self, uri: str, sr_uuid: str | None = None, use_cache: bool = False) -> VM:
         vm: VM | None = None
 
-        # Handling of 'clone://' and 'clone+start://' URI
-        if '://' in uri and uri.startswith("clone"):
+        if uri.startswith("clone://") or uri.startswith("clone+start://"):
             assert use_cache, "clone URIs require cache enabled"
             assert sr_uuid is not None
             protocol, filename = uri.split("://", maxsplit=1)
@@ -402,7 +401,7 @@ class Host:
                 raise RuntimeError(f"VM {filename!r} not in cache (in SR {sr_uuid})")
             vm = base_vm.clone()
             vm.param_clear('name-description')
-            if protocol.startswith("clone+start"):
+            if protocol == "clone+start":
                 vm.start()
                 wait_for(vm.is_running, f"[{self}] Wait for VM running ({vm.uuid})")
             return vm

--- a/lib/host.py
+++ b/lib/host.py
@@ -391,27 +391,27 @@ class Host:
 
     def import_vm(self, uri: str, sr_uuid: str | None = None, use_cache: bool = False) -> VM:
         vm: VM | None = None
+
+        # Handling of 'clone://' and 'clone+start://' URI
+        if '://' in uri and uri.startswith("clone"):
+            assert use_cache, "clone URIs require cache enabled"
+            assert sr_uuid is not None
+            protocol, filename = uri.split("://", maxsplit=1)
+            base_vm = self.cached_vm(filename, sr_uuid)
+            if base_vm is None:
+                raise RuntimeError(f"VM {filename!r} not in cache (in SR {sr_uuid})")
+            vm = base_vm.clone()
+            vm.param_clear('name-description')
+            if protocol.startswith("clone+start"):
+                vm.start()
+                wait_for(vm.is_running, f"[{self}] Wait for VM running ({vm.uuid})")
+            return vm
+
         if use_cache:
             assert sr_uuid is not None
-            if '://' in uri and uri.startswith("clone"):
-                protocol, rest = uri.split(":", 1)
-                assert rest.startswith("//")
-                filename = rest[2:] # strip "//"
-                base_vm = self.cached_vm(filename, sr_uuid)
-                if base_vm:
-                    vm = base_vm.clone()
-                    vm.param_clear('name-description')
-                    if uri.startswith("clone+start"):
-                        vm.start()
-                        wait_for(vm.is_running, f"[{self}] Wait for VM running ({vm.uuid})")
-                else:
-                    raise RuntimeError(f"VM {filename!r} not in cache (in SR {sr_uuid})")
-            else:
-                vm = self.cached_vm(uri, sr_uuid)
+            vm = self.cached_vm(uri, sr_uuid)
             if vm:
                 return vm
-        else:
-            assert not ('://' in uri and uri.startswith("clone")), "clone URIs require cache enabled"
 
         params: dict[str, str | bool | dict[str, str]] = {}
         msg = f"[{self}] Import VM {uri}"

--- a/lib/host.py
+++ b/lib/host.py
@@ -404,6 +404,8 @@ class Host:
                     if uri.startswith("clone+start"):
                         vm.start()
                         wait_for(vm.is_running, f"[{self}] Wait for VM running ({vm.uuid})")
+                else:
+                    raise RuntimeError(f"VM {filename!r} not in cache (in SR {sr_uuid})")
             else:
                 vm = self.cached_vm(uri, sr_uuid)
             if vm:


### PR DESCRIPTION
A confusing error is shown when one tries to run a test on a nested host using a "cached" VM to be cloned as reference (typically produced by the auto install procedure in `tests/install`) but the reference VM does not exist:

```shell
$ uv run pytest --hosts "cache://some-non-existing-nested-host" --nest 10.30.36.1
[...]
E           lib.commands.SSHCommandFailed: SSH command (xe vm-import url=clone://some-non-existing-nested-host sr-uuid=61b22c4f-35f3-234a-e94a-96e5a4a0b696) failed with return code 1: The server failed to handle your request, due to an internal error. The given message may give details useful for debugging the problem.
E           message: Failure("Unsupported URI scheme: clone")
```

With this fix applied, the following error is produced instead:
```shell
$ uv run pytest --hosts "cache://some-non-existing-nested-host" --nest 10.30.36.1
[...]
E                   RuntimeError: VM 'some-non-existing-nested-host' not in cache (in SR 61b22c4f-35f3-234a-e94a-96e5a4a0b696)
```