### PR TITLE
Add TESTC-3X test sequences to produce nested hosts from different 8.X upgrades

### DIFF
--- a/tests/install/test-sequences/TESTC-33-bios.lst
+++ b/tests/install/test-sequences/TESTC-33-bios.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[bios-81-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-bios-81-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[bios-81-host2-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[bios-81-83nightly-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[bios-81-83nightly-host2-iso-ext]

--- a/tests/install/test-sequences/TESTC-33-uefi.lst
+++ b/tests/install/test-sequences/TESTC-33-uefi.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[uefi-81-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-uefi-81-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[uefi-81-host1-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[uefi-81-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[uefi-81-83nightly-host1-iso-ext]

--- a/tests/install/test-sequences/TESTC-34-bios.lst
+++ b/tests/install/test-sequences/TESTC-34-bios.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[bios-821.1-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-bios-821.1-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[bios-821.1-host2-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[bios-821.1-83nightly-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[bios-821.1-83nightly-host2-iso-ext]

--- a/tests/install/test-sequences/TESTC-34-uefi.lst
+++ b/tests/install/test-sequences/TESTC-34-uefi.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[uefi-821.1-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-uefi-821.1-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[uefi-821.1-host1-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[uefi-821.1-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[uefi-821.1-83nightly-host1-iso-ext]

--- a/tests/install/test-sequences/TESTC-35-bios.lst
+++ b/tests/install/test-sequences/TESTC-35-bios.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[bios-830-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-bios-830-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[bios-830-host2-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[bios-830-83nightly-host2-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[bios-830-83nightly-host2-iso-ext]

--- a/tests/install/test-sequences/TESTC-35-uefi.lst
+++ b/tests/install/test-sequences/TESTC-35-uefi.lst
@@ -1,0 +1,5 @@
+tests/install/test.py::TestNested::test_install[uefi-830-iso-ext]
+tests/install/test.py::TestNested::test_tune_firstboot[None-uefi-830-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_inst[uefi-830-host1-iso-ext]
+tests/install/test.py::TestNested::test_upgrade[uefi-830-83nightly-host1-iso-ext]
+tests/install/test.py::TestNested::test_boot_upg[uefi-830-83nightly-host1-iso-ext]


### PR DESCRIPTION
Draft PR to document the install sequences corresponding to the cards TESTC-33, TESTC-34, and TESTC-35.

More specifically, they produce the following cache keys:
```shell
UEFI_830_83NIGHTLY='install.test::Nested::boot_upg[uefi-830-83nightly-host1-iso-ext]-vm1-$COMMIT_SHA'
BIOS_830_83NIGHTLY='install.test::Nested::boot_upg[bios-830-83nightly-host2-iso-ext]-vm1-$COMMIT_SHA'
UEFI_821_83NIGHTLY='install.test::Nested::boot_upg[uefi-821.1-83nightly-host1-iso-ext]-vm1-$COMMIT_SHA'
BIOS_821_83NIGHTLY='install.test::Nested::boot_upg[bios-821.1-83nightly-host2-iso-ext]-vm1-$COMMIT_SHA'
UEFI_81_83NIGHTLY='install.test::Nested::boot_upg[uefi-81-83nightly-host1-iso-ext]-vm1-$COMMIT_SHA'
BIOS_81_83NIGHTLY='install.test::Nested::boot_upg[bios-81-83nightly-host2-iso-ext]-vm1-$COMMIT_SHA'
```

They can then be used with commands such as:
```shell
uv run pytest --nest $L0_HOST --hosts="cache://$UEFI_81_83NIGHTLY" tests/misc/test_access_links.py
```
or:
```shell
uv run jobs.py run postinstall-with-tls "cache://$UEFI_81_83NIGHTLY,cache://$BIOS_81_83NIGHTLY" --nest $L0_HOST
```