### PR TITLE
lib/installer: fail early when installation fails

### DIFF
--- a/lib/installer.py
+++ b/lib/installer.py
@@ -7,7 +7,10 @@ import xml.etree.ElementTree as ET
 from lib.commands import ssh
 from lib.common import wait_for
 
-from typing import Any, Self
+from typing import Any, Callable, Self
+
+class InstallationFailed(Exception):
+    pass
 
 class AnswerFile:
     def __init__(self, kind: str, /):
@@ -84,76 +87,81 @@ class AnswerFile:
 def poweroff(ip: str) -> None:
     ssh(ip, "nohup sh -c 'sleep 2 && poweroff' >/dev/null 2>&1 &")
 
+def wait_for_install_failure_or(ip: str, cmd: Callable[[], bool], msg: str | None = None, timeout_secs=2 * 60) -> None:
+    def inner():
+        # Scans the logs for a failure entry formatted as: INFO [<timestamp>] INSTALL FAILED.
+        # If found, it returns that line and the rest of the file (to capture stack traces/errors).
+        # If not found, it returns an empty string.
+        failed = ssh(ip, r"sed -En '/INFO[[:space:]]+\[[-0-9 :]+\] INSTALL FAILED\./,$p' /tmp/install-log")
+        if failed:
+            raise InstallationFailed(failed)
+        return cmd()
+    return wait_for(inner, msg, timeout_secs=timeout_secs)
+
 def monitor_install(*, ip: str) -> None:
     # wait for "yum install" phase to finish
-    wait_for(lambda: ssh(ip, "grep 'DISPATCH: NEW PHASE: Completing installation' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for rpm installation to succeed",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'DISPATCH: NEW PHASE: Completing installation' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for rpm installation to succeed", timeout_secs=40 * 60)  # FIXME too big
 
     # wait for install to finish
-    wait_for(lambda: ssh(ip, "grep 'The installation completed successfully' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for system installation to succeed",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'The installation completed successfully' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for system installation to succeed", timeout_secs=40 * 60)  # FIXME too big
 
-    wait_for(lambda: ssh(ip, "ps a|grep '[0-9]. python /opt/xensource/installer/init'",
-                         check=False, simple_output=False,
-                         ).returncode == 1,
-             "Wait for installer to terminate")
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "ps a|grep '[0-9]. python /opt/xensource/installer/init'",
+                        check=False, simple_output=False).returncode == 1,
+        "Wait for installer to terminate")
+
 
 def monitor_upgrade(*, ip: str) -> None:
     # wait for "yum install" phase to start
-    wait_for(lambda: ssh(ip, "grep 'DISPATCH: NEW PHASE: Reading package information' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for upgrade preparations to finish",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip,
+                        "grep 'DISPATCH: NEW PHASE: Reading package information' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for upgrade preparations to finish", timeout_secs=40 * 60)  # FIXME too big
 
     # wait for "yum install" phase to finish
-    wait_for(lambda: ssh(ip, "grep 'DISPATCH: NEW PHASE: Completing installation' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for rpm installation to succeed",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'DISPATCH: NEW PHASE: Completing installation' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for rpm installation to succeed", timeout_secs=40 * 60)  # FIXME too big
 
     # wait for install to finish
-    wait_for(lambda: ssh(ip, "grep 'The installation completed successfully' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for system installation to succeed",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'The installation completed successfully' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for system installation to succeed", timeout_secs=40 * 60)  # FIXME too big
 
-    wait_for(lambda: ssh(ip, "ps a|grep '[0-9]. python /opt/xensource/installer/init'",
-                         check=False, simple_output=False,
-                         ).returncode == 1,
-             "Wait for installer to terminate")
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "ps a|grep '[0-9]. python /opt/xensource/installer/init'",
+                        check=False, simple_output=False).returncode == 1,
+        "Wait for installer to terminate")
 
 def monitor_restore(*, ip: str) -> None:
     # wait for "yum install" phase to start
-    wait_for(lambda: ssh(ip, "grep 'Restoring backup' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for data restoration to start",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'Restoring backup' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for data restoration to start", timeout_secs=40 * 60)  # FIXME too big
 
     # wait for "yum install" phase to finish
-    wait_for(lambda: ssh(ip, "grep 'Data restoration complete.  About to re-install bootloader.' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for data restoration to complete",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'Data restoration complete.  About to re-install bootloader.' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for data restoration to complete", timeout_secs=40 * 60)  # FIXME too big
 
     # The installer will not terminate in restore mode, it
     # requires human interaction and does not even log it, so
     # wait for last known action log (tested with 8.3b2)
-    wait_for(lambda: ssh(ip, "grep 'ran .*swaplabel.*rc 0' /tmp/install-log",
-                         check=False, simple_output=False,
-                         ).returncode == 0,
-             "Wait for installer to hopefully finish",
-             timeout_secs=40 * 60) # FIXME too big
+    wait_for_install_failure_or(
+        ip, lambda: ssh(ip, "grep 'ran .*swaplabel.*rc 0' /tmp/install-log",
+                        check=False, simple_output=False).returncode == 0,
+        "Wait for installer to hopefully finish", timeout_secs=40 * 60)  # FIXME too big
 
     # "wait a bit to be extra sure".  Yuck.
     time.sleep(30)


### PR DESCRIPTION
Introduce wait_for_install_failure_or helper that checks the install
log for INSTALL FAILED before waiting for the next phase. Replaces
all bare wait_for calls in monitor_install, monitor_upgrade, and
monitor_restore so that a failed installation is detected promptly
instead of timing out after 40 minutes.

Here is how it looks in case of failure:

```
=========================== short test summary info ============================
FAILED tests/install/test.py::TestNested::test_install[uefi-xs8-net-lvm] - Exception: INFO     [2026-07-21 09:19:46] INSTALL FAILED.
INFO     [2026-07-21 09:19:46] A fatal exception occurred:
INFO     [2026-07-21 09:19:46] Traceback (most recent call last):
  File "/opt/xensource/installer/install.py", line 262, in go
    backend.performInstallation(results, ui, interactive)
  File "/opt/xensource/installer/backend.py", line 364, in performInstallation
    executeSequence(prep_seq, "Preparing for installation...", answers, ui_package, False)
  File "/opt/xensource/installer/backend.py", line 277, in executeSequence
    updated_state = item.execute(answers, progressCallback)
  File "/opt/xensource/installer/backend.py", line 78, in execute
    rv = apply(self.fn, args)
  File "/opt/xensource/installer/backend.py", line 1708, in verifyRepos
    raise RuntimeError("Unable to access repository (%s, %s)" % (i['media'], i['address']))
RuntimeError: Unable to access repository (url, fake)
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
================ 1 failed, 143 deselected in 198.73s (0:03:18) =================
```

Note that it failed at 3m18s, not 40+ minutes