### PR TITLE
Add test for VDI resize support on LINSTOR SR

### DIFF
--- a/tests/storage/ext/test_ext_sr.py
+++ b/tests/storage/ext/test_ext_sr.py
@@ -106,7 +106,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_resize(self, vm_on_ext_sr: VM) -> None:
+    def test_resize_vdi(self, vm_on_ext_sr: VM) -> None:
         vm = vm_on_ext_sr
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
         old_size = vdi.get_virtual_size()
@@ -118,7 +118,7 @@ class TestEXTSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize(self, host: Host, ext_sr: SR, vm_on_ext_sr: VM, exit_on_fistpoint: None) -> None:
+    def test_failing_resize_vdi(self, host: Host, ext_sr: SR, vm_on_ext_sr: VM, exit_on_fistpoint: None) -> None:
         vm = vm_on_ext_sr
         vdi = VDI(vm.vdi_uuids()[0], host=vm.host)
         old_size = vdi.get_virtual_size()

--- a/tests/storage/linstor/conftest.py
+++ b/tests/storage/linstor/conftest.py
@@ -118,14 +118,14 @@ def pool_with_linstor(
     import concurrent.futures
     pool = pool_with_saved_yum_state
 
-    def check_linstor_installed(host: Host) -> None:
+    def ensure_linstor_not_installed(host: Host) -> None:
         if host.is_package_installed(LINSTOR_PACKAGE):
             raise Exception(
                 f'{LINSTOR_PACKAGE} is already installed on host {host}. This should not be the case.'
             )
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(check_linstor_installed, pool.hosts)
+        executor.map(ensure_linstor_not_installed, pool.hosts)
 
     def install_linstor(host: Host) -> None:
         logging.info(f"Installing {LINSTOR_PACKAGE} on host {host}...")

--- a/tests/storage/linstor/test_linstor_sr.py
+++ b/tests/storage/linstor/test_linstor_sr.py
@@ -189,6 +189,23 @@ class TestLinstorSR:
         finally:
             vm.shutdown(verify=True)
 
+    @pytest.mark.small_vm
+    @pytest.mark.big_vm
+    def test_resize_vdi(self, vm_on_linstor_sr: VM) -> None:
+        vm = vm_on_linstor_sr
+        if vm.is_running():
+            vm.shutdown(verify=True)
+
+        for vdi in vm.vdis:
+            size = vdi.get_virtual_size()
+            vdi.resize(size * 2)
+            assert vdi.get_virtual_size() == size * 2
+
+        # Make sure the VM still starts up successfully after resizing
+        vm.start()
+        vm.wait_for_os_booted()
+        vm.shutdown(verify=True)
+
     # *** tests with reboots (longer tests).
 
     @pytest.mark.reboot

--- a/tests/storage/lvm/test_lvm_sr.py
+++ b/tests/storage/lvm/test_lvm_sr.py
@@ -65,7 +65,7 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize_on_inflate_after_setSize(
+    def test_failing_resize_vdi_on_inflate_after_setSize(
         self, host: Host, lvm_sr: SR, vm_on_lvm_sr: VM, exit_on_fistpoint: None
     ) -> None:
         vm = vm_on_lvm_sr
@@ -93,7 +93,7 @@ class TestLVMSR:
 
     @pytest.mark.small_vm
     @pytest.mark.big_vm
-    def test_failing_resize_on_inflate_after_setSizePhys(
+    def test_failing_resize_vdi_on_inflate_after_setSizePhys(
         self, host: Host, lvm_sr: SR, vm_on_lvm_sr: VM, exit_on_fistpoint: None
     ) -> None:
         vm = vm_on_lvm_sr


### PR DESCRIPTION
This adds the `test_resize_vdi` test in the LINSTOR SR storage test suite. This tests the VDI resize feature on this SR, and makes sure the VM can still start up successfully afterwards.

This also unifies the names of the tests for VDI resizing on the EXT and LVM SRs so that they follow the naming convention established by the related test for the LINSTOR SR.

This is a rebase of #273.