### PR TITLE
t/m/test_host_evacuate.py: Support pool of more than 2 hosts

### DIFF
--- a/tests/migration/test_host_evacuate.py
+++ b/tests/migration/test_host_evacuate.py
@@ -23,7 +23,7 @@ from tests.storage.nfs.conftest import nfs_device_config, nfs_sr, vm_on_nfs_sr
 #   Must NOT be the network used to access the NFS SR.
 #   This network will be disconnected at some point during the tests
 
-def _host_evacuate_test(source_host: Host, dest_host: Host, network_uuid: str | None,
+def _host_evacuate_test(source_host: Host, network_uuid: str | None,
                         vm: VM, expect_error: bool = False, error: str = "") -> None:
     vm.start(on=source_host.uuid)
     vm.wait_for_os_booted()
@@ -37,9 +37,11 @@ def _host_evacuate_test(source_host: Host, dest_host: Host, network_uuid: str | 
         else:
             logging.info(f"Attempt evacuating host {source_host}. This should fail.")
         source_host.xe('host-evacuate', args)
-        wait_for(lambda: vm.all_vdis_on_host(dest_host), "Wait for all VDIs on destination host")
-        wait_for(lambda: vm.is_running_on_host(dest_host), "Wait for VM to be running on destination host")
         vm.wait_for_os_booted()
+        dest_host = vm.get_residence_host()
+        logging.info(f"VM migrated from {source_host} to {dest_host}")
+        assert dest_host != source_host, "Destination host should differ from source"
+        assert vm.all_vdis_on_host(dest_host), "Check for all VDIs on destination host"
         assert not expect_error, "host-evacuate should have raised: %s" % error
     except SSHCommandFailed as e:
         if not (expect_error and e.stdout.find(error) > -1):
@@ -66,14 +68,14 @@ def _save_ip_configuration_mode(host: Host, pif_uuid: str) -> dict[str, str | bo
 @pytest.mark.small_vm # what we test here is that evacuate works, the goal is not to test with various VMs
 class TestHostEvacuate:
     def test_host_evacuate(self, host: Host, hostA2: Host, vm_on_nfs_sr: VM) -> None:
-        _host_evacuate_test(host, hostA2, None, vm_on_nfs_sr)
+        _host_evacuate_test(host, None, vm_on_nfs_sr)
 
 @pytest.mark.complex_prerequisites # requires a special network setup.
 @pytest.mark.small_vm # what we test here is the network-uuid option, the goal is not to test with various VMs
 @pytest.mark.usefixtures("host_at_least_8_3")
 class TestHostEvacuateWithNetwork:
     def test_host_evacuate_with_network(self, host: Host, hostA2: Host, second_network: str, vm_on_nfs_sr: VM) -> None:
-        _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr)
+        _host_evacuate_test(host, second_network, vm_on_nfs_sr)
 
     def test_host_evacuate_with_network_no_ip(
         self, host: Host, hostA2: Host, second_network: str, vm_on_nfs_sr: VM
@@ -86,7 +88,7 @@ class TestHostEvacuateWithNetwork:
         host.xe(reconfigure_method, {'uuid': pif_uuid, 'mode': 'none'})
         try:
             no_ip_error = 'The specified interface cannot be used because it has no IP address'
-            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, no_ip_error)
+            _host_evacuate_test(host, second_network, vm_on_nfs_sr, True, no_ip_error)
         finally:
             logging.info(f"Restore the configuration of PIF {pif_uuid}")
             host.xe(reconfigure_method, args)
@@ -100,7 +102,7 @@ class TestHostEvacuateWithNetwork:
         try:
             not_attached_error = \
                 'The operation you requested cannot be performed because the specified PIF is currently unplugged'
-            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_attached_error)
+            _host_evacuate_test(host, second_network, vm_on_nfs_sr, True, not_attached_error)
         finally:
             logging.info(f"Re-plug PIF {pif_uuid}")
             host.xe('pif-plug', {'uuid': pif_uuid})
@@ -116,7 +118,7 @@ class TestHostEvacuateWithNetwork:
         host.xe('pif-forget', {'uuid': pif_uuid})
         try:
             not_present_error = 'This host has no PIF on the given network'
-            _host_evacuate_test(host, hostA2, second_network, vm_on_nfs_sr, True, not_present_error)
+            _host_evacuate_test(host, second_network, vm_on_nfs_sr, True, not_present_error)
         finally:
             host.xe('pif-scan', {'host-uuid': hostA2.uuid})
             pif_uuid = host.xe('pif-list', {'host-uuid': hostA2.uuid, 'network-uuid': second_network}, minimal=True)


### PR DESCRIPTION
t/m/test_host_evacuate.py: Support pool of more than 2 hosts
This test only worked with pool contains 2 hosts, since the
destination host is known before using host_evacuate (as there is no
other option).

When running with more hosts in pool, the dest host will be selected
dynamically, there is no options to force the destination host.  So on
3 hosts pool there are 50% chances the desired one will be used.

The test is now waiting the VM to be running and then checking that
the destination host is different than the source one.

The VDI check is also preserved but may be unnecessary since all hosts
in pool are expected to have references to VDIs.

There is no need to set the destination host in parameter anymore, but
second host still appear as a requirement (since pool should at least
contain 2 pools to use the evacuate feature).
