### PR TITLE
[PoC] Automated regression testing of manual XCP-ng installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pytest-dependency",
     "requests",
     "ipdb",
+    "paramiko",
 ]
 
 [dependency-groups]
@@ -38,6 +39,7 @@ dev = [
     "prek",
     "autopep8",
     "types-passlib",
+    "types-paramiko",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "requests",
     "ipdb",
     "paramiko",
+    "pyte",
 ]
 
 [dependency-groups]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,3 +11,4 @@ pytest-dependency
 requests
 ipdb
 paramiko
+pyte

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ pytest>=9.1.1
 pytest-dependency
 requests
 ipdb
+paramiko

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,4 +16,5 @@ zizmor
 prek
 autopep8
 types-passlib
+types-paramiko
 -r base.txt

--- a/tests/install/test-pingpxe.sh
+++ b/tests/install/test-pingpxe.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+set -eE
+set -o pipefail
+
+ether_of () {
+    ifconfig "$1" | grep ether | sed 's/.*ether \\([^ ]*\\).*/\\1/'
+}
+
+# on installed system, avoid xapi-project/xen-api#5799
+if ! [ -e /opt/xensource/installer ]; then
+    eth_mac=$(ether_of eth0)
+    br_mac=$(ether_of xenbr0)
+
+    # wait for bridge MAC to be fixed
+    test "$eth_mac" = "$br_mac"
+fi
+
+if [ "$(readlink /bin/ping)" = busybox ]; then
+    # XS before 7.0
+    PINGARGS=""
+else
+    PINGARGS="-c1"
+fi
+
+ping $PINGARGS "$1"

--- a/tests/install/with_tui.py
+++ b/tests/install/with_tui.py
@@ -4,12 +4,14 @@ import pytest
 
 import hashlib
 import logging
+import sys
 import tempfile
 import time
 from pathlib import Path
 from uuid import uuid4
 
 import paramiko
+import pyte
 
 from lib.common import Defer, wait_for
 from lib.host import Host
@@ -139,6 +141,9 @@ def test_install_with_tui(
     channel.settimeout(30.0)
     stdout = channel.makefile('rb', -1)
 
+    screen = pyte.Screen(columns=80, lines=24)
+    stream = pyte.ByteStream(screen)
+
     # Wait for grub to finish
     for line in stdout:
         if b"Booting `install'" in line:
@@ -146,11 +151,15 @@ def test_install_with_tui(
 
     # Wait for TUI to appear
     for line in stdout:
-        if b"Welcome to XCP-ng" in line:
-            logging.info(f"Entering TUI: {line}")
-            break
         assert isinstance(line, bytes)
-        if b"\x1b" in line:
+
+        # Start feeding the terminal emulator from here
+        stream.feed(line)
+
+        if b"Welcome to XCP-ng" in line:
+            logging.info(f"Entering TUI: {line!r}")
+            break
+        elif b"\x1b" in line:
             logging.info(f"! {line!r}")
         else:
             decoded = line.decode(errors="ignore").rstrip()
@@ -159,60 +168,190 @@ def test_install_with_tui(
     # Maybe some data already got extracted in the stdout buffer
     extra_data = getattr(stdout, "_rbuffer")
     assert isinstance(extra_data, bytes)
+    stream.feed(extra_data)
 
-    _select_keymap_dialog = wait_for_dialog(channel, b"Select Keymap")
-    channel.send(b"\t\r")  # Validate US
-    _welcome_dialog = wait_for_dialog(channel, b"Welcome to XCP-ng Setup")
-    channel.send(b"\r")  # Do not reboot, continue
-    _end_user_agreement_dialog = wait_for_dialog(channel, b"End User Agreement")
-    channel.send(b"\t\r")  # Accept the end user agreement
-    _select_primary_disk_dialog = wait_for_dialog(channel, b"Select Primary Disk")
-    channel.send(b"\t\r")  # Select first disk
-    _virtual_machine_storage_dialog = wait_for_dialog(channel, b"Virtual Machine Storage")
-    channel.send(b"\t\r")  # Select first disk
-    _virtual_machine_storage_type_dialog = wait_for_dialog(channel, b"Virtual Machine Storage Type")
-    channel.send(b"\t\t\r")  # Select EXT
-    _select_installation_source_dialog = wait_for_dialog(channel, b"Select Installation Source")
-    channel.send(b"\t\r")  # Select Local Media
-    _verify_installation_source_dialog = wait_for_dialog(channel, b"Verify Installation Source")
-    channel.send(b"\x1b[A\t\r")  # Skip the verification
-    _set_password_dialog = wait_for_dialog(channel, b"Set Password")
-    channel.send(f"{HOST_DEFAULT_PASSWORD}\t{HOST_DEFAULT_PASSWORD}\t\r".encode())  # Type root password
-    _networking_1_dialog = wait_for_dialog(channel, b"Networking")
-    channel.send(b"\t\t\t\r")  # IPv4
-    _networking_2_dialog = wait_for_dialog(channel, b"Networking")
-    channel.send(b"\t\t\t\r")  # DHCP
-    _hostname_and_dns_configuration_dialog = wait_for_dialog(channel, b"Hostname and DNS Configuration")
-    channel.send(b"\t\t\t\t\t\r")  # Random hostname and DNS set by DHCP
-    _select_time_zone_1_dialog = wait_for_dialog(channel, b"Select Time Zone")
-    channel.send(b"\x1b[6~\r")  # Page down to select Europe
-    _select_time_zone_2_dialog = wait_for_dialog(channel, b"Select Time Zone")
-    channel.send(b"\x1b[6~\x1b[6~\x1b[6~\x1b[6~\r")  # 4 Page down to select Paris
-    _system_time_dialog = wait_for_dialog(channel, b"System Time")
-    channel.send(b"\t\r")
-    _confirm_installation_dialog = wait_for_dialog(channel, b"Confirm Installation")
-    channel.send(b"\t\r")
+    def wait_for_dialog(
+        title: str,
+        discriminant: str = "",
+        delay: float = 1.0,
+    ) -> None:
+        wrapped_title = f"─┤ {title} ├─"
+        logging.info(f"Wait for {title!r} dialog title")
+        while not (
+            any(wrapped_title in line for line in screen.display)
+            and any(discriminant in line for line in screen.display)
+        ):
+            stream.feed(channel.recv(1024))
+        logging.info(f"Wait for {title!r} dialog to stabilize")
+        time.sleep(delay)
+        while channel.recv_ready():
+            stream.feed(channel.recv(1024))
+        logging.info(f"{title!r} dialog reached\n{show_screen(screen)}")
+
+    def send_tab(n: int = 1, delay: float = 1.0) -> None:
+        channel.send(b"\t" * n)
+        time.sleep(delay)
+        while channel.recv_ready():
+            stream.feed(channel.recv(1024))
+        logging.info(f"Selection updated with {n} tab(s)\n{show_screen(screen)}")
+
+    def send_up(n: int = 1, delay: float = 1.0) -> None:
+        channel.send(b"\x1b[A" * n)
+        time.sleep(delay)
+        while channel.recv_ready():
+            stream.feed(channel.recv(1024))
+        logging.info(f"Selection updated with {n} up(s)\n{show_screen(screen)}")
+
+    def send_password(n: int = 1, delay: float = 1.0) -> None:
+        channel.send(f"{HOST_DEFAULT_PASSWORD}\t".encode() * 2)
+        time.sleep(delay)
+        while channel.recv_ready():
+            stream.feed(channel.recv(1024))
+        logging.info(f"Selection updated with {n} password(s)\n{show_screen(screen)}")
+
+    def send_pagedown(n: int = 1, delay: float = 1.0) -> None:
+        channel.send(b"\x1b[6~" * n)
+        time.sleep(delay)
+        while channel.recv_ready():
+            stream.feed(channel.recv(1024))
+        logging.info(f"Selection updated with {n} pagedown(s)\n{show_screen(screen)}")
+
+    def validate(expected_selection: str | None = None, expected_validation: str = "Ok") -> None:
+        highlighted = get_highlighted(screen)
+        if expected_selection is None:
+            validation, = highlighted
+        else:
+            selected, validation = highlighted
+            assert expected_selection in selected
+        assert validation == f" {expected_validation} "
+        if expected_selection is None:
+            logging.info(f"Validate dialog using {expected_validation!r}")
+        else:
+            logging.info(f"Validate {expected_selection!r} selection using {expected_validation!r}")
+        channel.send(b"\r")
+
+    wait_for_dialog("Select Keymap")
+    send_tab()
+    validate(expected_selection="[qwerty] us")
+
+    wait_for_dialog("Welcome to XCP-ng Setup")
+    validate()
+
+    wait_for_dialog("End User Agreement")
+    send_tab()
+    validate(expected_validation="Accept EUA")
+
+    wait_for_dialog("Select Primary Disk")
+    send_tab()
+    validate(expected_selection="nvme0n1")
+
+    wait_for_dialog("Virtual Machine Storage")
+    send_tab()
+    validate(expected_selection="nvme0n1")
+
+    wait_for_dialog("Virtual Machine Storage Type")
+    send_tab(n=2)
+    validate()
+
+    wait_for_dialog("Select Installation Source")
+    send_tab()
+    validate(expected_selection="Local media")
+
+    wait_for_dialog("Verify Installation Source")
+    send_up()
+    send_tab()
+    validate(expected_selection="Skip verification")
+
+    wait_for_dialog("Set Password")
+    send_password(n=2)
+    validate()
+
+    wait_for_dialog("Networking", discriminant="IPv4")
+    send_tab(n=3)
+    validate()
+
+    wait_for_dialog("Networking", discriminant="DHCP")
+    send_tab(n=3)
+    validate()
+
+    wait_for_dialog("Hostname and DNS Configuration")
+    send_tab(n=5)
+    validate()
+
+    wait_for_dialog("Select Time Zone", discriminant="Africa")
+    send_pagedown()
+    send_tab()
+    validate(expected_selection="Europe")
+
+    wait_for_dialog("Select Time Zone", discriminant="Amsterdam")
+    send_pagedown(n=4)
+    send_tab()
+    validate(expected_selection="Paris")
+
+    wait_for_dialog("System Time")
+    send_tab()
+    validate(expected_selection="Use DHCP NTP servers")
+
+    wait_for_dialog("Confirm Installation")
+    send_tab()
+    validate(expected_validation="Install XCP-ng")
 
     channel.settimeout(600)
-    _installation_complete_dialog = wait_for_dialog(channel, b"Installation Complete")
+    wait_for_dialog("Installation Complete")
 
+def show_screen(screen: pyte.Screen) -> str:
+    ANSI_RESET = "\033[0m"
+    ANSI_BOLD = "\033[1m"
+    ANSI_REVERSE = "\033[7m"
 
-def wait_for_dialog(
-    channel: paramiko.Channel, title: bytes,
-    dialog: bytes = b"", delay: float = 1.0,
-) -> bytes:
-    logging.info(f"Wait for {title!r} dialog title")
-    while title not in dialog:
-        dialog += channel.recv(1024)
-    logging.info(f"Wait for {title!r} dialog to stabilize")
-    time.sleep(delay)
-    while channel.recv_ready():
-        dialog += channel.recv(1024)
-    return dialog
+    columns = screen.columns
 
-def show_dialog(dialog: bytes) -> None:
-    """Helper to use when debugging the dialogs"""
-    print("\x1b[2J\x1b[H" + dialog.decode() + "\x1b[24H\n")
+    # 1. Draw the top border
+    result = ["┌" + "─" * columns + "┐"]
+
+    # 2. Draw each row with left and right borders
+    for row_idx in range(screen.lines):
+        row = screen.buffer[row_idx]
+
+        # Start with the left border wall
+        row_str = "│"
+
+        for col_idx in range(columns):
+            char = row[col_idx]
+
+            fmt = ""
+            if char.bold:
+                fmt += ANSI_BOLD
+            if char.reverse:
+                fmt += ANSI_REVERSE
+
+            if fmt:
+                row_str += f"{fmt}{char.data}{ANSI_RESET}"
+            else:
+                row_str += char.data
+
+        # Cap the line with the right border wall
+        row_str += "│"
+
+        result.append(row_str)
+
+    # 3. Draw the bottom border
+    result.append("└" + "─" * columns + "┘")
+    return "\n".join(result)
+
+def get_highlighted(screen: pyte.Screen) -> list[str]:
+    highlighted = []
+    for i in range(screen.lines):
+        row = screen.buffer[i]
+        previously_reversed = False
+        for j in range(screen.columns):
+            char = row[j]
+            if char.reverse and not previously_reversed:
+                highlighted.append("")
+            if char.reverse:
+                highlighted[-1] += char.data
+            previously_reversed = char.reverse
+    return highlighted
 
 
 @pytest.mark.dependency()

--- a/tests/install/with_tui.py
+++ b/tests/install/with_tui.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import pytest
+
+import hashlib
+import logging
+import tempfile
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import paramiko
+
+from lib.common import Defer, wait_for
+from lib.host import Host
+from lib.vm import VM
+
+from .test import helper_vm_with_plugged_disk
+
+from typing import Generator
+
+def sha256(path: Path) -> str:
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "sha256").hexdigest()
+
+
+def vm_definition(firmware: str) -> dict:
+    from data import NETWORKS
+
+    return dict(
+        name="vm1",
+        template="Other install media",
+        params=(
+            # dict(param_name="", value=""),
+            dict(param_name="memory-static-max", value="4GiB"),
+            dict(param_name="memory-dynamic-max", value="4GiB"),
+            dict(param_name="memory-dynamic-min", value="4GiB"),
+            dict(param_name="VCPUs-max", value="2"),
+            dict(param_name="VCPUs-at-startup", value="2"),
+            dict(param_name="platform", key="exp-nested-hvm", value="true"), # FIXME < 8.3 host?
+            dict(param_name="platform", key="nested-virt", value="true"), # FIXME >= 8.3 host?
+            dict(param_name="HVM-boot-params", key="order", value="dc"),
+        ) + {
+            "uefi": (
+                dict(param_name="HVM-boot-params", key="firmware", value="uefi"),
+                dict(param_name="platform", key="device-model", value="qemu-upstream-uefi"),
+            ),
+            "bios": (),
+        }[firmware],
+        vdis=[
+            dict(name="vm1 system disk", size="100GiB", device="xvda", userdevice="0"),
+            dict(name="vm1 extra disk", size="50GiB", device="xvdb", userdevice="1")
+        ],
+        cd_vbd=dict(device="xvdd", userdevice="3"),
+        vifs=[dict(index=0, network_name=NETWORKS["MGMT"])],
+    )
+
+@pytest.fixture(scope='function')
+def remote_installer_iso(host: Host, installer_iso: dict[str, str | bool]) -> Generator[str]:
+    from data import OBJECTS_NAME_PREFIX
+
+    assert isinstance(installer_iso['iso'], str)
+    base_iso_file = Path(installer_iso['iso'])
+    base_iso_name = base_iso_file.stem
+    base_iso_hash = sha256(base_iso_file)[:8]
+    base_iso_key = f"{base_iso_name}-{base_iso_hash}"
+    remote_filename = f"{OBJECTS_NAME_PREFIX}tests-install-cache-{base_iso_key}.iso"
+
+    iso_sr = host.pool.get_iso_sr()
+    if not host.xe(
+        "vdi-list", {"sr-uuid": iso_sr.uuid, "name-label": remote_filename},
+        minimal=True,
+    ):
+        mountpoint = f"/run/sr-mount/{iso_sr.uuid}"
+        destination = f"{mountpoint}/{remote_filename}"
+        host.pool.push_iso(str(base_iso_file), destination)
+
+    yield remote_filename
+
+@pytest.fixture
+def vm_booted_with_original_installer(
+    host: Host, create_vms: list[VM], remote_installer_iso: str
+) -> Generator[VM, None, None]:
+
+    host_vm, = create_vms # one single VM
+
+    vif = host_vm.vifs()[0]
+    mac_address = vif.param_get('MAC')
+    assert mac_address is not None
+    logging.info("Host VM has MAC %s", mac_address)
+
+    host_vm.insert_cd(remote_installer_iso)
+    host_vm.start()
+    wait_for(host_vm.is_running, "Wait for host VM running")
+
+    yield host_vm
+
+    logging.info("Shutting down Host VM")
+    host_vm.shutdown(force=True)
+
+    host_vm.eject_cd()
+
+@pytest.mark.dependency()
+@pytest.mark.parametrize("local_sr", ("ext",)) # TODO: "nosr" and "lvm"
+@pytest.mark.parametrize("package_source", ("iso",)) # TODO: "net"
+@pytest.mark.parametrize("iso_version", ("83nightly",)) # TODO: support other ISOs?
+@pytest.mark.parametrize("firmware", ("uefi",)) # TODO: "bios"
+@pytest.mark.vm_definitions(lambda firmware: vm_definition(firmware))
+def test_install_with_tui(
+    vm_booted_with_original_installer: VM,
+    firmware: str, iso_version: str, package_source: str, local_sr: str,
+    defer: Defer,
+):
+    from data import HOST_DEFAULT_PASSWORD
+
+    vm = vm_booted_with_original_installer
+    residence_host = vm.get_residence_host()
+    dom_id = residence_host.xe(
+        'vm-param-get',
+        {'uuid': vm.uuid, 'param-name': 'dom-id'},
+    )
+
+    class IgnorePolicy(paramiko.MissingHostKeyPolicy):
+        def missing_host_key(self, client, hostname, key):
+            pass
+
+    client = paramiko.SSHClient()
+    defer(client.close)
+    client.set_missing_host_key_policy(IgnorePolicy())
+    logging.info(f"Connecting to {residence_host.hostname_or_ip}")
+    client.connect(residence_host.hostname_or_ip, username='root')
+    transport = client.get_transport()
+    assert transport is not None
+    channel = transport.open_session()
+    channel.get_pty(term='vt100', width=80, height=24)
+    command = f"xl console -t serial {dom_id}"
+    logging.info(f"Connecting to serial line with {command!r}")
+    channel.exec_command(command.encode())
+    channel.settimeout(30.0)
+    stdout = channel.makefile('rb', -1)
+
+    # Wait for grub to finish
+    for line in stdout:
+        if b"Booting `install'" in line:
+            break
+
+    # Wait for TUI to appear
+    for line in stdout:
+        if b"Welcome to XCP-ng" in line:
+            logging.info(f"Entering TUI: {line}")
+            break
+        assert isinstance(line, bytes)
+        if b"\x1b" in line:
+            logging.info(f"! {line!r}")
+        else:
+            decoded = line.decode(errors="ignore").rstrip()
+            logging.info(f"> {decoded}")
+
+    # Maybe some data already got extracted in the stdout buffer
+    extra_data = getattr(stdout, "_rbuffer")
+    assert isinstance(extra_data, bytes)
+
+    _select_keymap_dialog = wait_for_dialog(channel, b"Select Keymap")
+    channel.send(b"\t\r")  # Validate US
+    _welcome_dialog = wait_for_dialog(channel, b"Welcome to XCP-ng Setup")
+    channel.send(b"\r")  # Do not reboot, continue
+    _end_user_agreement_dialog = wait_for_dialog(channel, b"End User Agreement")
+    channel.send(b"\t\r")  # Accept the end user agreement
+    _select_primary_disk_dialog = wait_for_dialog(channel, b"Select Primary Disk")
+    channel.send(b"\t\r")  # Select first disk
+    _virtual_machine_storage_dialog = wait_for_dialog(channel, b"Virtual Machine Storage")
+    channel.send(b"\t\r")  # Select first disk
+    _virtual_machine_storage_type_dialog = wait_for_dialog(channel, b"Virtual Machine Storage Type")
+    channel.send(b"\t\t\r")  # Select EXT
+    _select_installation_source_dialog = wait_for_dialog(channel, b"Select Installation Source")
+    channel.send(b"\t\r")  # Select Local Media
+    _verify_installation_source_dialog = wait_for_dialog(channel, b"Verify Installation Source")
+    channel.send(b"\x1b[A\t\r")  # Skip the verification
+    _set_password_dialog = wait_for_dialog(channel, b"Set Password")
+    channel.send(f"{HOST_DEFAULT_PASSWORD}\t{HOST_DEFAULT_PASSWORD}\t\r".encode())  # Type root password
+    _networking_1_dialog = wait_for_dialog(channel, b"Networking")
+    channel.send(b"\t\t\t\r")  # IPv4
+    _networking_2_dialog = wait_for_dialog(channel, b"Networking")
+    channel.send(b"\t\t\t\r")  # DHCP
+    _hostname_and_dns_configuration_dialog = wait_for_dialog(channel, b"Hostname and DNS Configuration")
+    channel.send(b"\t\t\t\t\t\r")  # Random hostname and DNS set by DHCP
+    _select_time_zone_1_dialog = wait_for_dialog(channel, b"Select Time Zone")
+    channel.send(b"\x1b[6~\r")  # Page down to select Europe
+    _select_time_zone_2_dialog = wait_for_dialog(channel, b"Select Time Zone")
+    channel.send(b"\x1b[6~\x1b[6~\x1b[6~\x1b[6~\r")  # 4 Page down to select Paris
+    _system_time_dialog = wait_for_dialog(channel, b"System Time")
+    channel.send(b"\t\r")
+    _confirm_installation_dialog = wait_for_dialog(channel, b"Confirm Installation")
+    channel.send(b"\t\r")
+
+    channel.settimeout(600)
+    _installation_complete_dialog = wait_for_dialog(channel, b"Installation Complete")
+
+
+def wait_for_dialog(
+    channel: paramiko.Channel, title: bytes,
+    dialog: bytes = b"", delay: float = 1.0,
+) -> bytes:
+    logging.info(f"Wait for {title!r} dialog title")
+    while title not in dialog:
+        dialog += channel.recv(1024)
+    logging.info(f"Wait for {title!r} dialog to stabilize")
+    time.sleep(delay)
+    while channel.recv_ready():
+        dialog += channel.recv(1024)
+    return dialog
+
+def show_dialog(dialog: bytes) -> None:
+    """Helper to use when debugging the dialogs"""
+    print("\x1b[2J\x1b[H" + dialog.decode() + "\x1b[24H\n")
+
+
+@pytest.mark.dependency()
+@pytest.mark.usefixtures("xcpng_chained")
+@pytest.mark.parametrize("local_sr", ("ext",))
+@pytest.mark.parametrize("package_source", ("iso",))
+@pytest.mark.parametrize("machine", ("host1", "host2"))
+@pytest.mark.parametrize("version", ("83nightly",))
+@pytest.mark.parametrize("firmware", ("uefi",))
+@pytest.mark.continuation_of.with_args(
+    lambda version, firmware, local_sr, package_source: [dict(
+        vm="vm1",
+        image_test=f"test_install_with_tui[{firmware}-{version}-{package_source}-{local_sr}]")])
+@pytest.mark.small_vm
+def test_tune_firstboot(create_vms: list[VM], helper_vm_with_plugged_disk: VM,
+                        firmware: str, version: str, machine: str, local_sr: str, package_source: str) -> None:
+    from data import TEST_SSH_PUBKEY
+
+    helper_vm = helper_vm_with_plugged_disk
+
+    helper_vm.ssh("mount /dev/xvdb1 /mnt")
+    try:
+        # hostname
+        logging.info("Setting hostname to %r", machine)
+        helper_vm.ssh(f'echo {machine} > /mnt/etc/hostname')
+        # UUIDs
+        logging.info("Randomizing UUIDs")
+        helper_vm.ssh(
+            f'''sed -i -e "/^INSTALLATION_UUID=/ s/.*/INSTALLATION_UUID='{uuid4()}'/" -e "/^CONTROL_DOMAIN_UUID=/ s/.*/CONTROL_DOMAIN_UUID='{uuid4()}'/" /mnt/etc/xensource-inventory''' # noqa
+        )
+        helper_vm.ssh("grep UUID /mnt/etc/xensource-inventory")
+        logging.info("Add the CI SSH key")
+        helper_vm.ssh(f'echo "{TEST_SSH_PUBKEY}" >> /mnt/root/.ssh/authorized_keys')
+        logging.info("Configure the test-pingpxe service")
+        configure_pingpxe_service(helper_vm)
+    finally:
+        helper_vm.ssh("umount /dev/xvdb1")
+
+
+def configure_pingpxe_service(helper_vm: VM):
+    from data import ARP_SERVER
+
+    # Copy test-pingpxe script
+    pingpxe_path = Path(__file__).parent / "test-pingpxe.sh"
+    assert pingpxe_path.exists()
+    helper_vm.scp(str(pingpxe_path.absolute()), "/mnt/usr/local/sbin/test-pingpxe.sh")
+
+    # Copy test-pingpxe service
+    service_destination = "/mnt/etc/systemd/system/test-pingpxe.service"
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write(f"""\
+[Unit]
+Description=Ping pxe server to populate its ARP table
+After=network-online.target
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'while ! /usr/local/sbin/test-pingpxe.sh "{ARP_SERVER}"; do sleep 1 ; done'
+[Install]
+WantedBy=default.target
+""")
+        f.flush()
+        helper_vm.scp(f.name, service_destination)
+
+    # Enable test-pingpxe service
+    helper_vm.ssh(
+        f"ln -s {service_destination} /mnt/etc/systemd/system/default.target.wants/test-pingpxe.service"
+    )
+
+
+@pytest.mark.dependency()
+@pytest.mark.usefixtures("xcpng_chained")
+@pytest.mark.parametrize("local_sr", ("ext",))
+@pytest.mark.parametrize("package_source", ("iso",))
+@pytest.mark.parametrize("machine", ("host1", "host2"))
+@pytest.mark.parametrize("version", ("83nightly",))
+@pytest.mark.parametrize("firmware", ("uefi",))
+@pytest.mark.continuation_of.with_args(
+    lambda firmware, version, machine, local_sr, package_source: [
+        dict(vm="vm1",
+                image_test=("test_tune_firstboot"
+                            f"[None-{firmware}-{version}-{machine}-{package_source}-{local_sr}]"))])
+def test_boot_inst(create_vms: list[VM],
+                   firmware: str, version: str, machine: str, package_source: str, local_sr: str) -> None:
+    from .test import TestNested
+
+    test_firstboot = getattr(TestNested(), "_test_firstboot")
+    test_firstboot(create_vms, version, machine=machine)

--- a/uv.lock
+++ b/uv.lock
@@ -1070,6 +1070,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1319,6 +1331,7 @@ dependencies = [
     { name = "passlib" },
     { name = "pluggy" },
     { name = "pydantic" },
+    { name = "pyte" },
     { name = "pytest" },
     { name = "pytest-dependency" },
     { name = "requests" },
@@ -1357,6 +1370,7 @@ requires-dist = [
     { name = "passlib" },
     { name = "pluggy", specifier = ">=1.1.0" },
     { name = "pydantic" },
+    { name = "pyte" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-dependency" },
     { name = "requests" },

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,76 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
+    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -380,6 +450,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
+]
+
+[[package]]
 name = "ipdb"
 version = "0.13.13"
 source = { registry = "https://pypi.org/simple" }
@@ -630,6 +709,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
 ]
 
 [[package]]
@@ -928,6 +1022,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,6 +1213,18 @@ wheels = [
 ]
 
 [[package]]
+name = "types-paramiko"
+version = "5.0.0.20260617"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/89/902652d7b62bb7cd2b73c7f08c8fd03945c223c3814022f0ad305e1018b9/types_paramiko-5.0.0.20260617.tar.gz", hash = "sha256:50a5b0dc68b39d30097cb7d93b4915dbbc97ed740ea633bd492be25ca1f25df4", size = 28474, upload-time = "2026-06-17T06:56:52.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/4d/eab89decb4201dfff665a3b92088f384ff1e165bf6caa447509733bc1bc6/types_paramiko-5.0.0.20260617-py3-none-any.whl", hash = "sha256:83d87c396405666524441710ec59e693bca8b19021861456ac0a2401327812f8", size = 37123, upload-time = "2026-06-17T06:56:51.81Z" },
+]
+
+[[package]]
 name = "types-passlib"
 version = "1.7.7.20260211"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,6 +1315,7 @@ dependencies = [
     { name = "ipdb" },
     { name = "legacycrypt" },
     { name = "packaging" },
+    { name = "paramiko" },
     { name = "passlib" },
     { name = "pluggy" },
     { name = "pydantic" },
@@ -1195,6 +1337,7 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "types-colorama" },
+    { name = "types-paramiko" },
     { name = "types-passlib" },
     { name = "types-pexpect" },
     { name = "types-pygments" },
@@ -1210,6 +1353,7 @@ requires-dist = [
     { name = "ipdb" },
     { name = "legacycrypt" },
     { name = "packaging", specifier = ">=26.2" },
+    { name = "paramiko" },
     { name = "passlib" },
     { name = "pluggy", specifier = ">=1.1.0" },
     { name = "pydantic" },
@@ -1231,6 +1375,7 @@ dev = [
     { name = "pyright" },
     { name = "ruff" },
     { name = "types-colorama" },
+    { name = "types-paramiko" },
     { name = "types-passlib" },
     { name = "types-pexpect" },
     { name = "types-pygments" },


### PR DESCRIPTION
The automated installation tests rely on creating an answerfile with the proper configuration, and remastering the chosen install ISO in order to use that answerfile by default. This is convenient to create all kinds of different configuration, but it does not test the manuel install process since the TUI is completely avoided.

This proof of concept shows that a manual installation can also be automated in order to test for potential regression in the TUI. More specifically, this PR introduces a couple of tests, following the dependency convention introduced in `tests/install/test.py`: 
```
± uv run pytest --hosts 10.1.0.11 tests/install/with_tui.py --co -q
tests/install/with_tui.py::test_install_with_tui[uefi-83nightly-iso-ext]
tests/install/with_tui.py::test_tune_firstboot[None-uefi-83nightly-host1-iso-ext]
tests/install/with_tui.py::test_tune_firstboot[None-uefi-83nightly-host2-iso-ext]
tests/install/with_tui.py::test_boot_inst[uefi-83nightly-host1-iso-ext]
tests/install/with_tui.py::test_boot_inst[uefi-83nightly-host2-iso-ext]
```

The interesting part is the `test_install_with_tui` test. Here's what it does:
- It creates a new VM in an L0 pool, using a configuration similar to what happens in `tests/isntall/test.py`. One notable difference is that it sets `platform:hvm_serial` to `pty`
- It uploads the selected nightly ISO to the ISO SR of the L0 pool (it also caches the ISO, although this part was mainly introduced to speedup the development process). Note that it does not require any remastering.
- It inserts the install ISO and start the VM. Then it connects to the serial line by ssh-ing to the resident host and using `xl console -t serial $domain_id`
- Note that paramiko is used to allocate a `pty`. This allows proper control of the interactive sessions. The test logs the installation message, and then navigate through the dialogs, mostly using the default options.
- It then install XCP-ng, and shutdown once the installation is completed. The nested host is then cached for the upcoming `test_tune_firstboot` test. 

Note that the nested hosts produced by `test_boot_inst` can run the `postinstall` test job:
 ```
 uv run jobs.py run postinstall "cache://install.with_tui::boot_inst[uefi-83nightly-host1-iso-ext]-vm1-c6b8d6ef415549749ed22d0b155a9dc200c55824" --nest 10.1.0.11
 ```