### PR TITLE
Add clean tool to remove all VMs and local VDIs

### DIFF
--- a/lib/tools/cli.py
+++ b/lib/tools/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from lib.common import HostAddress
 from lib.tools import logger
 from lib.tools.inventory import into_inventory, load_inventory
+from lib.tools.tasks.clean import clean_pools
 from lib.tools.tasks.update import update_pools
 
 def _command_update(args: argparse.Namespace) -> None:
@@ -20,6 +21,15 @@ def _command_update(args: argparse.Namespace) -> None:
         inventory = into_inventory(args.hosts, args.repos, args.hosting_pool)
 
     update_pools(inventory)
+
+
+def _command_clean(args: argparse.Namespace) -> None:
+    if args.inventory:
+        inventory = load_inventory(args.inventory)
+    else:
+        inventory = into_inventory(args.hosts, [], args.hosting_pool)
+
+    clean_pools(inventory, dry_run=args.dry_run)
 
 
 def cli() -> None:
@@ -60,6 +70,31 @@ def cli() -> None:
         help="Address (hostname|ip) of hosting pool's master host (nested context)",
     )
     subparser_cmd_update.set_defaults(func=_command_update)
+
+    # subparser - command: clean
+    subparser_cmd_clean = subparsers.add_parser(
+        name="clean",
+        description="Remove all VMs and all VDIs on local storage from target pools",
+        help="Remove all VMs and all VDIs on local storage from target pools",
+    )
+    cmd_clean_excl_grp = subparser_cmd_clean.add_mutually_exclusive_group(required=True)
+    cmd_clean_excl_grp.add_argument(
+        "-H",
+        "--hosts",
+        type=HostAddress,
+        metavar="HOST",
+        nargs="+",
+        help="Address (hostname|ip) of the master host in pool",
+    )
+    cmd_clean_excl_grp.add_argument("-i", "--inventory", type=Path, help="Use an hosts inventory file")
+    subparser_cmd_clean.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Only display what would be removed, without deleting anything",
+    )
+    subparser_cmd_clean.set_defaults(func=_command_clean)
 
     args = parser.parse_args()
 

--- a/lib/tools/tasks/clean.py
+++ b/lib/tools/tasks/clean.py
@@ -1,0 +1,87 @@
+"""Cleanup tasks.
+
+This module is intended for removing all VMs and all VDIs on local storage
+from existing remote targets.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from lib.common import safe_split, wait_for_not
+from lib.pool import NotAMasterHostError, Pool
+from lib.sr import SR
+from lib.tools.inventory import Inventory
+from lib.vdi import VDI
+from lib.vm import VM
+
+from .. import logger
+
+def clean_pools(inventory: Inventory, dry_run: bool = False) -> None:
+    """Remove all VMs and all orphan VDIs on local storage from pool(s).
+
+    .. note::
+
+        Every non-master hosts in inventory will be ignored
+
+    *For each pool's master host declared in inventory, destroy all its VMs
+    (with all their VDIs, regardless of their location), then destroy all the
+    orphan VDIs left on the local (non-shared) SRs.*
+
+    :param Inventory inventory:
+        Each host (key) holds its own config data (values, eg: `enablerepos`).
+    :param bool dry_run:
+        When True, only log what would be removed without actually deleting.
+    """
+    inventory_hosts = inventory["hosts"]
+    pools: list[Pool] = []
+    for host in inventory_hosts:
+        try:
+            pools.append(Pool(host))
+        except NotAMasterHostError:
+            logger.warning(f"[{host}] Skipping: not a master host")
+
+    with ThreadPoolExecutor() as executor:
+        futures = {executor.submit(clean_pool, p, dry_run): p for p in pools}
+        for future in futures:
+            pool = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                logger.error(f"Cleaning pool has failed! The master {pool.master} cannot be cleaned.")
+                raise exc
+
+def clean_pool(pool: Pool, dry_run: bool) -> None:
+    """Remove all VMs and all orphan VDIs on local SRs from a single pool."""
+    master = pool.master
+    log_prefix = 'Would remove' if dry_run else 'Removing'
+
+    vm_uuids = safe_split(master.xe(
+        'vm-list',
+        {'is-control-domain': False, 'is-a-template': False},
+        minimal=True,
+    ))
+    for vm_uuid in vm_uuids:
+        vm = VM(vm_uuid, master)
+        logger.info(f"[{master}] {log_prefix} VM {vm.uuid} ({vm.name()})")
+        if not dry_run:
+            vm.destroy(verify=True)
+
+    sr_uuids = local_sr_uuids(pool)
+    for sr_uuid in sr_uuids:
+        for vdi_uuid in SR(sr_uuid, pool).vdi_uuids(managed=True):
+            vdi = VDI(vdi_uuid, sr=SR(sr_uuid, pool))
+            logger.info(f"[{master}] {log_prefix} orphan VDI {vdi.uuid} from local SR {sr_uuid}")
+            if not dry_run:
+                vdi.destroy()
+
+    if not dry_run:
+        for sr_uuid in sr_uuids:
+            wait_for_not(
+                lambda: len(SR(sr_uuid, pool).vdi_uuids(managed=True)) > 0,
+                f"Wait for local SR {sr_uuid} to be empty",
+            )
+
+def local_sr_uuids(pool: Pool) -> list[str]:
+    """Return the UUIDs of the pool's local (non-shared, user) SRs."""
+    uuids = safe_split(pool.master.xe('sr-list', {'content-type': 'user'}, minimal=True))
+    return [uuid for uuid in uuids if not SR(uuid, pool).is_shared()]


### PR DESCRIPTION
Add a new 'clean' subcommand to tools.py that removes all VMs (with all
their VDIs, regardless of storage location) from the target pools and
then clears the remaining orphan VDIs on the local (non-shared) storage
SRs. Supports a --dry-run mode, and verifies that VMs and local SRs are
actually empty before returning so downstream scripts can rely on a
clean state.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>