### PR TITLE
Add colored logging to tools CLI

### DIFF
--- a/lib/logger.py
+++ b/lib/logger.py
@@ -1,0 +1,39 @@
+"""Colored logging utilities."""
+
+import logging
+
+class ColoredFormatter(logging.Formatter):
+    """A logging formatter that adds ANSI color codes to log levels."""
+
+    # ANSI color codes matching pytest's colors
+    COLORS = {
+        logging.CRITICAL: "\033[91m",  # Red
+        logging.ERROR: "\033[91m",     # Red
+        logging.WARNING: "\033[93m",   # Yellow
+        logging.INFO: "\033[92m",      # Green
+        logging.DEBUG: "\033[95m",     # Magenta/Purple
+    }
+    RESET = "\033[0m"
+
+    def format(self, record: logging.LogRecord) -> str:
+        color = self.COLORS.get(record.levelno, "")
+        original_levelname = record.levelname
+        if color:
+            record.levelname = f'{color}{record.levelname}{self.RESET}'
+        result = super().format(record)
+        record.levelname = original_levelname
+        return result
+
+
+def setup_colored_logging(level: int = logging.INFO) -> None:
+    """Set up logging with colored formatter."""
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+    handler = logging.StreamHandler()
+    formatter = ColoredFormatter(
+        fmt="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%b %d %H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/lib/tools/__init__.py
+++ b/lib/tools/__init__.py
@@ -7,7 +7,7 @@ Code is sometimes too long to be written as a standalone script
 
 import logging
 
+from lib.logger import setup_colored_logging
+
 logger = logging.getLogger()
-logging.basicConfig(
-    format="%(asctime)s.%(msecs)03d %(levelname)s %(message)s", datefmt="%b %d %H:%M:%S", level=logging.INFO
-)
+setup_colored_logging()


### PR DESCRIPTION
Apply the colored logger used in the compat kit to the tools package,
so logs emitted by scripts/tools.py are shown with per-level ANSI colors.
Replaces the plain basicConfig logging setup with a ColoredFormatter.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>