### PR TITLE
changes on empty_network fixture

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -53,7 +53,14 @@ def vm_with_tcpdump_scope_function(vm_with_tcpdump_scope_module: VM):
 @pytest.fixture(scope='function')
 def empty_network(host: Host) -> Generator[Network, None, None]:
     net = host.create_network(label="empty_network for tests")
+
     yield net
+
+    for vif_uuid in net.vif_uuids():
+        host.xe("vif-unplug", {
+            'uuid': vif_uuid,
+        })
+
     net.destroy()
 
 @pytest.fixture(scope='function')

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -50,7 +50,7 @@ def vm_with_tcpdump_scope_function(vm_with_tcpdump_scope_module: VM):
     yield vm
     vm.destroy()
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def empty_network(host: Host) -> Generator[Network, None, None]:
     net = host.create_network(label="empty_network for tests")
     yield net


### PR DESCRIPTION
the `empty_network` fixture is used in network tests (mostly for bond tests).

this PR modifies it for:
- better tear down : it will unplug VIF from the network before destroying it (it fails else)
- change the scope to `function` is order to permit to reuse the fixture easily

The scope changes doesn't affect others fixtures using it (they are already at `function` scope) and the network creation is cheap.