### PR TITLE
update: warn about installed packages unavailable in selected repos

### DIFF
--- a/lib/host.py
+++ b/lib/host.py
@@ -670,8 +670,8 @@ class Host:
         return self.ssh(f'yum remove -y {" ".join(packages)}')
 
     def packages(self) -> list[str]:
-        """ Returns the list of installed RPMs - with version, release, arch and epoch. """
-        return sorted(self.ssh('rpm -qa --qf "%{NAME}-%{VERSION}-%{RELEASE}-%{ARCH}-%{EPOCH}\n"').splitlines())
+        """Returns the list of installed RPMs - with epoch, version, release, arch."""
+        return sorted(self.ssh('rpm -qa --qf "%{NAME}-%{EPOCHNUM}:%{VERSION}-%{RELEASE}.%{ARCH}\n"').splitlines())
 
     def check_packages_available(self, packages: list[str]) -> bool:
         """ Check if a given package list is available in the YUM repositories. """

--- a/lib/tools/tasks/update.py
+++ b/lib/tools/tasks/update.py
@@ -4,11 +4,12 @@ This module is intended for performing update actions on existing remote targets
 """
 from __future__ import annotations
 
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from lib.host import Host
 from lib.pool import NotAMasterHostError, Pool
-from lib.tools.inventory import Inventory
+from lib.tools.inventory import HostConfig, Inventory
 from lib.tools.tasks.snapshot import create_snapshots
 
 from .. import logger
@@ -22,6 +23,15 @@ def _filter_packages(pkgs: set[str]) -> set[str]:
 
 def _format_packages(pkgs: list[str]) -> str:
     return "\n".join(f"  - {p}" for p in pkgs)
+
+def _nevra_to_nvra(nevra: str) -> str:
+    return re.sub(r'-\d+:', '-', nevra)
+
+def _downgrade_command(host: Host, pkgs: set[str]) -> str:
+    """Return a `yum downgrade` command for the given installed packages."""
+    specs = " ".join(_nevra_to_nvra(p) for p in sorted(pkgs))
+    names = host.ssh(f"rpm -q --qf '%{{NAME}} ' {specs}").split()
+    return "yum downgrade -y " + " ".join(names)
 
 def _report_updated(before: dict[Host, set[str]], after: dict[Host, set[str]]) -> None:
     """Log a summary of the packages that were updated on each host."""
@@ -44,6 +54,51 @@ def _report_updated(before: dict[Host, set[str]], after: dict[Host, set[str]]) -
                 f"Additional packages on [{h}] ({len(extra)}):\n"
                 f"{_format_packages(extra)}"
             )
+
+def _check_packages_available(
+    pools: list[Pool],
+    inventory_hosts: dict[str, HostConfig],
+    packages: dict[Host, set[str]],
+) -> None:
+    """Warn about installed packages not available in the selected repositories."""
+    unavailable: dict[Host, set[str]] = {}
+    for p in pools:
+        master_cfg = inventory_hosts[p.master.hostname_or_ip]
+        repoquery_cmd = "repoquery --all"
+        for r in master_cfg["disabled_repositories"]:
+            repoquery_cmd += f" --disablerepo={r}"
+        for r in master_cfg["repositories"]:
+            repoquery_cmd += f" --enablerepo={r}"
+        available = set(p.master.ssh(repoquery_cmd).splitlines())
+        for h in p.hosts:
+            pkgs = _filter_packages(packages[h]) - available
+            if pkgs:
+                unavailable[h] = pkgs
+
+    if not unavailable:
+        logger.info("All installed packages are available in the selected repositories.")
+        return
+    common = set.intersection(*unavailable.values())
+    lines = []
+    downgrades = {h: _downgrade_command(h, pkgs) for h, pkgs in unavailable.items()}
+    if common:
+        lines.append(
+            f"Installed packages not available in the selected repositories on all hosts "
+            f"({len(common)}):\n{_format_packages(sorted(common))}"
+        )
+    for h, pkgs in unavailable.items():
+        extra = sorted(pkgs - common)
+        if extra:
+            lines.append(
+                f"Additional packages on [{h}] ({len(extra)}):\n{_format_packages(extra)}"
+            )
+    common_downgrade = next(iter(downgrades.values()))
+    if set(downgrades.values()) == {common_downgrade}:
+        lines.append(f"Downgrade command on all hosts:\n  {common_downgrade}")
+    else:
+        for h, cmd in downgrades.items():
+            lines.append(f"Downgrade command on [{h}]:\n  {cmd}")
+    logger.warning("\n".join(lines))
 
 def _check_consistency(packages: dict[Host, set[str]]) -> None:
     """Warn if not all hosts end up with the same set of packages."""
@@ -152,6 +207,7 @@ def update_pools(inventory: Inventory, reboot: bool = True, parallel: bool = Fal
     after_packages = _capture_packages(pools)
     _report_updated(before_packages, after_packages)
     _check_consistency(after_packages)
+    _check_packages_available(pools, inventory_hosts, after_packages)
 
     # Snapshot creation
     for hosting_pool, nested in nested_hosts.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "prek",
     "autopep8",
     "types-passlib",
+    "icecream",
 ]
 
 [tool.pyright]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,4 +16,5 @@ zizmor
 prek
 autopep8
 types-passlib
+icecream
 -r base.txt

--- a/uv.lock
+++ b/uv.lock
@@ -362,6 +362,21 @@ wheels = [
 ]
 
 [[package]]
+name = "icecream"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "colorama" },
+    { name = "executing" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/84/6ebc95844feae8a6a29c7fd57e9e3a7ac4817ffab384dc4f0ed53b8e3c46/icecream-2.2.0.tar.gz", hash = "sha256:9d7f244187f00a13f4ac77d176990e187e9c279d6cac4f7548e338291ad97343", size = 14267, upload-time = "2026-04-03T17:42:51.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/82/9707c7b0336bca53b75f52fc350956a93da66eb6be632b370bc933216fb4/icecream-2.2.0-py3-none-any.whl", hash = "sha256:f8df7343b3e787023eec22f42fbe4722df2f93099d394fd820b91e16b2e6cb56", size = 16707, upload-time = "2026-04-03T17:42:50.001Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1176,6 +1191,7 @@ dev = [
     { name = "bs4" },
     { name = "flake8" },
     { name = "flake8-pyproject" },
+    { name = "icecream" },
     { name = "libarchive-c" },
     { name = "mypy" },
     { name = "prek" },
@@ -1212,6 +1228,7 @@ dev = [
     { name = "bs4", specifier = ">=0.0.1" },
     { name = "flake8" },
     { name = "flake8-pyproject" },
+    { name = "icecream" },
     { name = "libarchive-c", specifier = "==5.3" },
     { name = "mypy" },
     { name = "prek" },


### PR DESCRIPTION
After updating hosts, compare installed packages against what is available\
in the selected repositories and report any that are no longer present,\
listing the common ones first then per-host extras. Include a yum downgrade\
command to align hosts with the available packages.

<!-- start jj-vine stack -->
This PR is part of a stack containing 4 PRs:

1. `master`
2. #654
3. **"gln/package-inconsistency-check-zkkx" (this PR)**
4. #656
5. #657
<!-- end jj-vine stack -->