### PR TITLE
tools: add exec subcommand to run a command on all hosts

### DIFF
--- a/lib/tools/cli.py
+++ b/lib/tools/cli.py
@@ -12,6 +12,7 @@ from lib.common import HostAddress
 from lib.tools import logger
 from lib.tools.inventory import into_inventory, load_inventory
 from lib.tools.tasks.clean import clean_pools
+from lib.tools.tasks.exec import exec_pools
 from lib.tools.tasks.update import update_pools
 
 def _command_update(args: argparse.Namespace) -> None:
@@ -30,6 +31,16 @@ def _command_clean(args: argparse.Namespace) -> None:
         inventory = into_inventory(args.hosts, [], args.hosting_pool)
 
     clean_pools(inventory, dry_run=args.dry_run)
+
+
+def _command_exec(args: argparse.Namespace) -> int:
+    if args.inventory:
+        inventory = load_inventory(args.inventory)
+    else:
+        inventory = into_inventory(args.hosts, [], None)
+
+    command = " ".join(args.command)
+    return exec_pools(inventory, command, parallel=args.parallel, dry_run=args.dry_run, reboot=args.reboot)
 
 
 def cli() -> None:
@@ -116,9 +127,55 @@ def cli() -> None:
     )
     subparser_cmd_clean.set_defaults(func=_command_clean)
 
+    # subparser - command: exec
+    subparser_cmd_exec = subparsers.add_parser(
+        name="exec",
+        description="Run the same command on all hosts of target pools",
+        help="Run the same command on all hosts of target pools",
+    )
+    cmd_exec_excl_grp = subparser_cmd_exec.add_mutually_exclusive_group(required=True)
+    cmd_exec_excl_grp.add_argument(
+        "-H",
+        "--hosts",
+        type=HostAddress,
+        metavar="HOST",
+        nargs="+",
+        help="Address (hostname|ip) of the master host in pool",
+    )
+    cmd_exec_excl_grp.add_argument("-i", "--inventory", type=Path, help="Use an hosts inventory file")
+    subparser_cmd_exec.add_argument(
+        "--parallel",
+        action="store_true",
+        default=False,
+        help="Run the command on the master and secondary hosts at the same time",
+    )
+    subparser_cmd_exec.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Only log what would be run, without running anything",
+    )
+    subparser_cmd_exec.add_argument(
+        "-r",
+        "--reboot",
+        action="store_true",
+        default=False,
+        help="Reboot each host after running the command",
+    )
+    subparser_cmd_exec.add_argument(
+        "command",
+        metavar="COMMAND",
+        nargs="+",
+        help="Command to run on every host",
+    )
+    subparser_cmd_exec.set_defaults(func=_command_exec)
+
     args = parser.parse_args()
 
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    args.func(args)
+    exit_code = args.func(args)
+    if exit_code:
+        raise SystemExit(exit_code)

--- a/lib/tools/inventory.py
+++ b/lib/tools/inventory.py
@@ -50,7 +50,7 @@ def load_inventory(inventory_path: Path) -> Inventory:
 def into_inventory(
     hosts: list[HostAddress],
     repositories: list[str],
-    hosting_pool: HostAddress,
+    hosting_pool: HostAddress | None,
     disabled_repositories: list[str] = [],
 ) -> Inventory:
     """Create an inventory object from arguments.

--- a/lib/tools/tasks/exec.py
+++ b/lib/tools/tasks/exec.py
@@ -1,0 +1,97 @@
+"""Exec tasks.
+
+This module is intended for running the same command on existing remote targets,
+on the master hosts first, then on the secondary hosts.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from lib.host import Host
+from lib.pool import NotAMasterHostError, Pool
+from lib.tools.inventory import Inventory
+
+from .. import logger
+
+def _exec_on_host(host: Host, command: str, dry_run: bool, reboot: bool) -> int:
+    """Run `command` on `host`, log its output, optionally reboot, and return its exit code."""
+    if dry_run:
+        logger.info(f"[{host}] Would run: {command}")
+        if reboot:
+            logger.info(f"[{host}] Would reboot")
+        return 0
+    result = host.ssh_with_result(command)
+    if result.returncode != 0:
+        logger.warning(
+            f"[{host}] Command exited with code {result.returncode}: {command}\n{result.stdout.strip()}"
+        )
+    else:
+        logger.info(f"[{host}] Command output:\n{result.stdout.strip()}")
+    if reboot:
+        logger.info(f"[{host}] Rebooting")
+        host.reboot(verify=True)
+    return result.returncode
+
+def _exec_on_hosts(hosts: list[Host], command: str, dry_run: bool, reboot: bool) -> int:
+    """Run `command` on every host in parallel, returning the number of failures."""
+    failures = 0
+    with ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(_exec_on_host, host, command, dry_run, reboot): host for host in hosts
+        }
+        for future in as_completed(futures):
+            try:
+                if future.result() != 0:
+                    failures += 1
+            except Exception:
+                logger.error("Running command has failed!")
+                failures += 1
+    return failures
+
+def exec_pools(
+    inventory: Inventory,
+    command: str,
+    parallel: bool = False,
+    dry_run: bool = False,
+    reboot: bool = False,
+) -> int:
+    """Run a command on all hosts of pool(s).
+
+    .. note::
+
+        Every non-master hosts in inventory will be ignored
+
+    *Run the command on each pool's master host declared in inventory first,
+    then on the other hosts of each pool.*
+
+    :param Inventory inventory:
+        Each host (key) holds its own config data.
+    :param str command:
+        The command to run on every host.
+    :param bool parallel:
+        Run the command on the master and secondary hosts at the same time (default: False).
+    :param bool dry_run:
+        Only log what would be run, without running anything (default: False).
+    :param bool reboot:
+        Reboot each host after running the command (default: False).
+    :return:
+        The number of hosts on which the command failed (exit code != 0).
+    """
+    pools: list[Pool] = []
+    for host in inventory["hosts"]:
+        try:
+            pools.append(Pool(host))
+        except NotAMasterHostError:
+            logger.warning(f"[{host}] Skipping: not a master host")
+
+    failures = 0
+    if parallel:
+        # run the command on all hosts at the same time
+        hosts = [h for p in pools for h in p.hosts]
+        failures += _exec_on_hosts(hosts, command, dry_run, reboot)
+    else:
+        # run the command on the master hosts first
+        failures += _exec_on_hosts([p.master for p in pools], command, dry_run, reboot)
+        # then on the secondary hosts
+        failures += _exec_on_hosts([h for p in pools for h in p.hosts[1:]], command, dry_run, reboot)
+    return failures


### PR DESCRIPTION
Add an 'exec' subcommand to tools.py that runs the same command on every
host of the target pools: on the master hosts first, then on the secondary
hosts (or all at once with --parallel). Support --dry-run and --reboot, and
exit non-zero if the command fails on any host.

Signed-off-by: Gaëtan Lehmann <gaetan.lehmann@vates.tech>

<!-- start jj-vine stack -->
This PR is part of a stack containing 4 PRs:

1. `master`
2. #654
3. #655
4. **"tools: add exec subcommand to run a command on all hosts" (this PR)**
5. #657
<!-- end jj-vine stack -->