### PR TITLE
Update Windows guest tools tests

### DIFF
--- a/lib/vif.py
+++ b/lib/vif.py
@@ -61,6 +61,6 @@ class VIF:
         logging.info("Plugging VIF %s on VM %s", self.param_get('device'), self.vm.uuid)
         self.vm.host.xe('vif-plug', {'uuid': self.uuid})
 
-    def unplug(self) -> None:
+    def unplug(self, force: bool = False) -> None:
         logging.info("Unplugging VIF %s on VM %s", self.param_get('device'), self.vm.uuid)
-        self.vm.host.xe('vif-unplug', {'uuid': self.uuid})
+        self.vm.host.xe('vif-unplug', {'uuid': self.uuid, 'force': force})

--- a/tests/guest_tools/win/test_destructive.py
+++ b/tests/guest_tools/win/test_destructive.py
@@ -1,0 +1,70 @@
+import pytest
+
+import logging
+
+from lib.commands import SSHCommandFailed
+from lib.vm import VM
+from lib.windows import (
+    PowerAction,
+    check_vm_dns,
+    set_vm_dns,
+    vm_shutdown_without_tools,
+    wait_for_vm_running_and_ssh_up_without_tools,
+)
+from lib.windows.guest_tools import ERROR_INSTALL_FAILURE, install_guest_tools, uninstall_guest_tools
+
+from typing import Any, Tuple
+
+# Requirements:
+# - Same as TestGuestToolsWindowsNondestructive.
+
+
+@pytest.mark.multi_vms
+@pytest.mark.usefixtures("windows_vm")
+class TestGuestToolsWindowsDestructive:
+    def test_uninstall_tools(self, vm_install_test_tools_no_reboot: VM) -> None:
+        vm = vm_install_test_tools_no_reboot
+        vm_shutdown_without_tools(vm)
+        vm.start()
+        wait_for_vm_running_and_ssh_up_without_tools(vm)
+
+        set_vm_dns(vm)
+        logging.info("Uninstall Windows PV drivers")
+        uninstall_guest_tools(vm, action=PowerAction.Reboot)
+        logging.info("Check tools uninstalled")
+        assert vm.are_windows_tools_uninstalled()
+        check_vm_dns(vm)
+
+    def test_uninstall_tools_early(self, vm_install_test_tools_no_reboot: VM) -> None:
+        vm = vm_install_test_tools_no_reboot
+        logging.info("Uninstall Windows PV drivers before rebooting")
+        uninstall_guest_tools(vm, action=PowerAction.Reboot)
+        assert vm.are_windows_tools_uninstalled()
+
+    def test_install_with_other_tools(
+        self, vm_install_other_drivers: Tuple[VM, dict[str, Any]], guest_tools_iso: dict[str, Any]
+    ) -> None:
+        vm, param = vm_install_other_drivers
+        if param["upgradable"]:
+            install_guest_tools(vm, guest_tools_iso, PowerAction.Reboot, check=False)
+            assert vm.are_windows_tools_working()
+        else:
+            exitcode = install_guest_tools(vm, guest_tools_iso, PowerAction.Nothing, check=False)
+            assert exitcode == ERROR_INSTALL_FAILURE
+
+    @pytest.mark.usefixtures("uefi_vm")
+    def test_uefi_vm_suspend_refused_without_tools(self, running_unsealed_windows_vm: VM) -> None:
+        vm = running_unsealed_windows_vm
+        with pytest.raises(SSHCommandFailed, match="lacks the feature"):
+            vm.suspend()
+        wait_for_vm_running_and_ssh_up_without_tools(vm)
+
+    # Test of the unplug rework, where the driver must remain activated even if the device ID changes.
+    # Also serves as a "close-enough" test of vendor device toggling.
+    def test_toggle_device_id(self, running_unsealed_windows_vm: VM, guest_tools_iso: dict[str, Any]) -> None:
+        vm = running_unsealed_windows_vm
+        assert vm.param_get("platform", "device_id") == "0002"
+        install_guest_tools(vm, guest_tools_iso, PowerAction.Shutdown, check=False)
+        vm.param_set("platform", "0001", "device_id")
+        vm.start()
+        vm.wait_for_vm_running_and_ssh_up()

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -75,13 +75,14 @@ class TestGuestToolsWindows:
     def test_drivers_detected(self, vm_install_test_tools_per_test_class: VM) -> None:
         pass
 
-    def test_vif_replug(self, vm_install_test_tools_per_test_class: VM) -> None:
+    @pytest.mark.parametrize("force", (False, True))
+    def test_vif_replug(self, vm_install_test_tools_per_test_class: VM, force: bool) -> None:
         vm = vm_install_test_tools_per_test_class
         for _iter in range(3):
             vifs = vm.vifs()
             for vif in vifs:
                 assert strtobool(vif.param_get("currently-attached"))
-                vif.unplug()
+                vif.unplug(force=force)
                 # HACK: Allow some time for the unplug to settle. If not, Windows guests have a tendency to explode.
                 # TODO reference: XCPNG-1395
                 assert not strtobool(vif.param_get("currently-attached"))

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 
 import logging
-import time
 
 from lib.commands import SSHCommandFailed
 from lib.common import strtobool, wait_for
@@ -83,10 +82,6 @@ class TestGuestToolsWindows:
             for vif in vifs:
                 assert strtobool(vif.param_get("currently-attached"))
                 vif.unplug(force=force)
-                # HACK: Allow some time for the unplug to settle. If not, Windows guests have a tendency to explode.
-                # TODO reference: XCPNG-1395
-                assert not strtobool(vif.param_get("currently-attached"))
-                time.sleep(5)
                 vif.plug()
             wait_for(vm.is_ssh_up, "Wait for SSH up")
 

--- a/tests/guest_tools/win/test_guest_tools_win.py
+++ b/tests/guest_tools/win/test_guest_tools_win.py
@@ -107,11 +107,11 @@ class TestGuestToolsWindows:
             check_vm_distro(vm)
             check_vm_clipboard(vm)
 
-    def test_reporting_after_suspend(self, vm_install_test_tools_per_test_class: VM) -> None:
+    def test_reporting_after_migration(self, vm_install_test_tools_per_test_class: VM) -> None:
         vm = vm_install_test_tools_per_test_class
+        residence = vm.get_residence_host()
         for _iter in range(3):
-            vm.suspend(verify=True)
-            vm.resume()
+            vm.migrate(residence)
             wait_for_vm_running_and_ssh_up_without_tools(vm)
             check_vm_distro(vm)
             check_vm_clipboard(vm)

--- a/tests/guest_tools/win/test_nondestructive.py
+++ b/tests/guest_tools/win/test_nondestructive.py
@@ -4,26 +4,14 @@ import pytest
 
 import logging
 
-from lib.commands import SSHCommandFailed
 from lib.common import strtobool, wait_for
 from lib.vm import VM
 from lib.windows import (
-    PowerAction,
     check_vm_clipboard,
     check_vm_distro,
-    check_vm_dns,
-    set_vm_dns,
     vif_has_rss,
-    vm_shutdown_without_tools,
     wait_for_vm_running_and_ssh_up_without_tools,
 )
-from lib.windows.guest_tools import (
-    ERROR_INSTALL_FAILURE,
-    install_guest_tools,
-    uninstall_guest_tools,
-)
-
-from typing import Any, Tuple
 
 # Requirements:
 # - XCP-ng >= 8.2.
@@ -70,7 +58,7 @@ from typing import Any, Tuple
 
 @pytest.mark.multi_vms
 @pytest.mark.usefixtures("windows_vm")
-class TestGuestToolsWindows:
+class TestGuestToolsWindowsNondestructive:
     def test_drivers_detected(self, vm_install_test_tools_per_test_class: VM) -> None:
         pass
 
@@ -137,54 +125,3 @@ Select-String "Trim Supported")''')
             )
         )
         assert is_ssd
-
-
-@pytest.mark.multi_vms
-@pytest.mark.usefixtures("windows_vm")
-class TestGuestToolsWindowsDestructive:
-    def test_uninstall_tools(self, vm_install_test_tools_no_reboot: VM) -> None:
-        vm = vm_install_test_tools_no_reboot
-        vm_shutdown_without_tools(vm)
-        vm.start()
-        wait_for_vm_running_and_ssh_up_without_tools(vm)
-
-        set_vm_dns(vm)
-        logging.info("Uninstall Windows PV drivers")
-        uninstall_guest_tools(vm, action=PowerAction.Reboot)
-        logging.info("Check tools uninstalled")
-        assert vm.are_windows_tools_uninstalled()
-        check_vm_dns(vm)
-
-    def test_uninstall_tools_early(self, vm_install_test_tools_no_reboot: VM) -> None:
-        vm = vm_install_test_tools_no_reboot
-        logging.info("Uninstall Windows PV drivers before rebooting")
-        uninstall_guest_tools(vm, action=PowerAction.Reboot)
-        assert vm.are_windows_tools_uninstalled()
-
-    def test_install_with_other_tools(
-        self, vm_install_other_drivers: Tuple[VM, dict[str, Any]], guest_tools_iso: dict[str, Any]
-    ) -> None:
-        vm, param = vm_install_other_drivers
-        if param["upgradable"]:
-            install_guest_tools(vm, guest_tools_iso, PowerAction.Reboot, check=False)
-            assert vm.are_windows_tools_working()
-        else:
-            exitcode = install_guest_tools(vm, guest_tools_iso, PowerAction.Nothing, check=False)
-            assert exitcode == ERROR_INSTALL_FAILURE
-
-    @pytest.mark.usefixtures("uefi_vm")
-    def test_uefi_vm_suspend_refused_without_tools(self, running_unsealed_windows_vm: VM) -> None:
-        vm = running_unsealed_windows_vm
-        with pytest.raises(SSHCommandFailed, match="lacks the feature"):
-            vm.suspend()
-        wait_for_vm_running_and_ssh_up_without_tools(vm)
-
-    # Test of the unplug rework, where the driver must remain activated even if the device ID changes.
-    # Also serves as a "close-enough" test of vendor device toggling.
-    def test_toggle_device_id(self, running_unsealed_windows_vm: VM, guest_tools_iso: dict[str, Any]) -> None:
-        vm = running_unsealed_windows_vm
-        assert vm.param_get("platform", "device_id") == "0002"
-        install_guest_tools(vm, guest_tools_iso, PowerAction.Shutdown, check=False)
-        vm.param_set("platform", "0001", "device_id")
-        vm.start()
-        vm.wait_for_vm_running_and_ssh_up()


### PR DESCRIPTION
This series is meant for 9.2.350 and contains some small changes:
- VIF.unplug(force=?) is now tested, as the two act very differently.
- Only in the WinPV tests, localhost migration is now used to test the suspend mechanism to speed up the process. From the WinPV viewpoint, both look like the same thing.
- Some refactoring and hack removal.