### PR TITLE
Make dependabot commit messages consistent with the project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       day: "sunday"
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "uv.lock: "
     groups:
       ci-deps:
         patterns:
@@ -23,6 +25,8 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    commit-message:
+      prefix: "uv.lock: "
     groups:
       base-deps:
         dependency-type: "production"


### PR DESCRIPTION
Dependabot defaults to conventional commits: build(deps): ...

This is not consistent with a project history where conventional commits are not used.

This commit replaces the prefix with "Deps update: ". No distinction between build deps and dev deps, because as far as I can tell the rest of the message is enough to disambiguate.

Example:

Deps update: bump the base-deps group across 1 directory with 3 updates