### PR TITLE
storage: force SR scan before coalesce to ensure GC completed

### DIFF
--- a/tests/storage/storage.py
+++ b/tests/storage/storage.py
@@ -217,6 +217,9 @@ def coalesce_integrity(vm: VM, vdi: VDI, vdi_op: CoalesceOperation, defer: Defer
     spans[1].validate(vm, dev)
     spans[2].validate(vm, dev)
 
+    # FIXME: force the GC run in case it failed (it shouldn't)
+    vdi.sr.scan()
+
     # trigger the coalesce
     vdi.wait_for_coalesce(new_vdi.destroy)
     new_vdi = None


### PR DESCRIPTION
This is a workaround, for a minor problem in SM, to avoid increasing the wait for coalesce timeout.