### PR TITLE
Configure Dependabot to scan `.github/actions/uv-setup `

### DIFF
--- a/.github/actions/uv-setup/action.yml
+++ b/.github/actions/uv-setup/action.yml
@@ -1,0 +1,35 @@
+name: Setup UV and Sync
+description: 'Install uv and sync the dependencies'
+inputs:
+  sync:
+    description: 'Whether to run `uv sync` after setting up.'
+    required: false
+    default: 'true'
+    type: boolean
+  dev:
+    description: 'Whether to use `--no-dev` with `uv sync`.'
+    required: false
+    default: 'true'
+    type: boolean
+  activate-environment:
+    description: 'Wether to activate the virtual env or not'
+    required: false
+    default: true
+    type: boolean
+runs:
+  using: 'composite'
+  steps:
+    - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+      with:
+        version: "0.7.x"
+        activate-environment: ${{ inputs.activate-environment }}
+    - if: inputs.sync == 'true' && inputs.dev == 'false'
+      run: uv sync --frozen --no-dev
+      shell: bash
+      env:
+        FORCE_COLOR: "1"
+    - if: inputs.sync == 'true' && inputs.dev == 'true'
+      run: uv sync --frozen
+      shell: bash
+      env:
+        FORCE_COLOR: "1"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/uv-setup"
     schedule:
       interval: "weekly"
       day: "sunday"

--- a/.github/workflows/code-checkers.yml
+++ b/.github/workflows/code-checkers.yml
@@ -14,13 +14,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - name: Create a dummy vm_data.py
@@ -33,13 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup/
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - name: Create a dummy vm_data.py
@@ -54,13 +42,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup/
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - run: prek -a ruff
@@ -71,13 +53,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup/
       - run: prek -a flake8
 
   autopep8:
@@ -86,11 +62,5 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup/
       - run: prek -a autopep8

--- a/.github/workflows/jobs-check.yml
+++ b/.github/workflows/jobs-check.yml
@@ -11,13 +11,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+      - uses: ./.github/actions/uv-setup/
         with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen --no-dev
-        env:
-          FORCE_COLOR: "1"
+          dev: false
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - run: ./jobs.py check

--- a/.github/workflows/requirements-check.yml
+++ b/.github/workflows/requirements-check.yml
@@ -11,12 +11,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+      - uses: ./.github/actions/uv-setup/
         with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen --no-dev
-        env:
-          FORCE_COLOR: "1"
+          dev: false
       - run: ./requirements/update_requirements.py
       - run: git diff --exit-code

--- a/.github/workflows/test-sequences.yml
+++ b/.github/workflows/test-sequences.yml
@@ -11,13 +11,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+      - uses: ./.github/actions/uv-setup/
         with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen --no-dev
-        env:
-          FORCE_COLOR: "1"
+          dev: false
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - name: jobs-check

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,13 +11,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
+      - uses: ./.github/actions/uv-setup/
         with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen --no-dev
-        env:
-          FORCE_COLOR: "1"
+          dev: false
       - name: Create a dummy data.py
         run: cp data.py-dist data.py
       - run: pytest tests/unit/

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,13 +15,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba  # v6.3.1
-        with:
-          version: "0.7.x"
-          activate-environment: true
-      - run: uv sync --frozen
-        env:
-          FORCE_COLOR: "1"
+      - uses: ./.github/actions/uv-setup
       - run: zizmor --color=always .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
I had second thoughts after validating #670. More specifically, I wasn't too comfortable with the duplication it introduced, since it gets rid of composite actions altogether. In this PR, I propose to configure dependabot to scan the composite action directories instead. 

> Dependabot only scans actions referenced directly in workflow files, not those used inside composite actions (https://github.com/dependabot/dependabot-core/issues/6704). setup-uv was only referenced from .github/actions/uv-setup/action.yml, so it stayed pinned at v6.3.1 while the project's other actions were bumped.

> Therefore, we have to explicitly tell Dependabot which directories contain composite actions. This is an alternative to the approach proposed in PR https://github.com/xcp-ng/xcp-ng-tests/pull/670, which avoids using composite actions at all.