### PR TITLE
Make tools.py executable

### DIFF
--- a/scripts/tools.py
+++ b/scripts/tools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Just a wrapper to run cli tools package.
 """
 import sys


### PR DESCRIPTION
So we can run it without prefixing it with `uv run`.